### PR TITLE
#320 fix demo data bug

### DIFF
--- a/OneSila/currencies/demo_data.py
+++ b/OneSila/currencies/demo_data.py
@@ -36,6 +36,7 @@ class CurrencyDefaultDataGenerator(PrivateStructuredDataGenerator):
 @registry.register_private_app
 class CurrencyNonDefaultDataGenerator(PrivateStructuredDataGenerator):
     model = Currency
+    skip_existing = True
 
     def get_structure(self):
         return [

--- a/OneSila/products/schema/types/filters.py
+++ b/OneSila/products/schema/types/filters.py
@@ -68,6 +68,7 @@ class ProductTranslationFilter:
 class ConfigurableVariationFilter:
     id: auto
     parent: Optional[ProductFilter]
+    variation: Optional[ProductFilter]
 
 
 @filter(BundleVariation)

--- a/OneSila/products/schema/types/types.py
+++ b/OneSila/products/schema/types/types.py
@@ -63,6 +63,10 @@ class ProductType(relay.Node, GetQuerysetMultiTenantMixin):
         else:
             return 1  # Green
 
+    @field()
+    def has_parents(self, info) -> bool:
+        return ConfigurableVariation.objects.filter(variation_id=self.id).exists()
+
 
 @type(ProductTranslation, filters=ProductTranslationFilter, order=ProductTranslationOrder, pagination=True, fields="__all__")
 class ProductTranslationType(relay.Node, GetQuerysetMultiTenantMixin):


### PR DESCRIPTION
## Summary by Sourcery

Improves demo data generation by skipping existing data and adds a `has_parents` field to the `Product` GraphQL type.

New Features:
- Adds a `has_parents` field to the `Product` GraphQL type, indicating whether a configurable variation has parents.

Bug Fixes:
- Fixes a bug where demo data generation would fail when encountering existing data, by adding a `skip_existing` flag to the `PrivateStructuredDataGenerator` class and handling `IntegrityError` exceptions during instance creation.