### PR TITLE
Upgrade/strawberry 0 59

### DIFF
--- a/OneSila/contacts/schema/queries.py
+++ b/OneSila/contacts/schema/queries.py
@@ -1,4 +1,4 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type, field, anonymous_field
+from core.schema.core.queries import node, connection, DjangoListConnection, type, field, anonymous_field
 from contacts.models import Company
 
 from typing import List
@@ -17,33 +17,33 @@ def get_customer_languages(info) -> List[CustomerLanguageType]:
 @type(name="Query")
 class ContactsQuery:
     company: CompanyType = node()
-    companies: ListConnectionWithTotalCount[CompanyType] = connection()
+    companies: DjangoListConnection[CompanyType] = connection()
 
     supplier: SupplierType = node()
-    suppliers: ListConnectionWithTotalCount[SupplierType] = connection()
+    suppliers: DjangoListConnection[SupplierType] = connection()
 
     customer: CustomerType = node()
-    customers: ListConnectionWithTotalCount[CustomerType] = connection()
+    customers: DjangoListConnection[CustomerType] = connection()
 
     influencer: InfluencerType = node()
-    influencers: ListConnectionWithTotalCount[InfluencerType] = connection()
+    influencers: DjangoListConnection[InfluencerType] = connection()
 
     internal_company: InternalCompanyType = node()
-    internal_companies: ListConnectionWithTotalCount[InternalCompanyType] = connection()
+    internal_companies: DjangoListConnection[InternalCompanyType] = connection()
 
     person: PersonType = node()
-    people: ListConnectionWithTotalCount[PersonType] = connection()
+    people: DjangoListConnection[PersonType] = connection()
 
     address: AddressType = node()
-    addresses: ListConnectionWithTotalCount[AddressType] = connection()
+    addresses: DjangoListConnection[AddressType] = connection()
 
     shipping_address: ShippingAddressType = node()
-    shipping_addresses: ListConnectionWithTotalCount[ShippingAddressType] = connection()
+    shipping_addresses: DjangoListConnection[ShippingAddressType] = connection()
 
     invoice_address: InvoiceAddressType = node()
-    invoice_addresses: ListConnectionWithTotalCount[InvoiceAddressType] = connection()
+    invoice_addresses: DjangoListConnection[InvoiceAddressType] = connection()
 
     inventory_shipping_address: InventoryShippingAddressType = node()
-    inventory_shipping_addresses: ListConnectionWithTotalCount[InventoryShippingAddressType] = connection()
+    inventory_shipping_addresses: DjangoListConnection[InventoryShippingAddressType] = connection()
 
     customer_languages: List[CustomerLanguageType] = anonymous_field(resolver=get_customer_languages)

--- a/OneSila/core/management/commands/generate_schema.py
+++ b/OneSila/core/management/commands/generate_schema.py
@@ -1,9 +1,7 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.conf import settings
 from django.db.models import Model as BaseModel
 import os
-import shutil
-import importlib
 
 from .generate_views import generate_view, VIEW_TYPES, \
     generate_views_list, import_app, get_model_app, \
@@ -175,7 +173,7 @@ def generate_schema_init(app_name, models):
 
 def generate_queries(app_name, models):
     content = [
-        "from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type, field",
+        "from core.schema.core.queries import node, connection, DjangoListConnection, type, field",
         get_model_import(app_name, models),
         get_type_import(app_name, models),
         "",
@@ -187,7 +185,7 @@ def generate_queries(app_name, models):
     for model in models:
         content.extend([
             f"    {to_snake_case(model)}: {model}Type = node()",
-            f"    {to_snake_case(model)}s: ListConnectionWithTotalCount[{model}Type] = connection()",
+            f"    {to_snake_case(model)}s: DjangoListConnection[{model}Type] = connection()",
             "",
         ])
     return '\n'.join(content)

--- a/OneSila/core/schema/core/queries.py
+++ b/OneSila/core/schema/core/queries.py
@@ -1,7 +1,7 @@
 import strawberry_django
 from strawberry.relay import from_base64
 from strawberry_django.fields.field import StrawberryDjangoField, filter_with_perms, optimizer
-from strawberry_django.relay import ListConnectionWithTotalCount
+from strawberry_django.relay import DjangoListConnection
 from strawberry.types import Info
 from strawberry import type, field
 from typing import Any, List

--- a/OneSila/core/schema/core/types/filters.py
+++ b/OneSila/core/schema/core/types/filters.py
@@ -3,11 +3,12 @@ from typing import Optional
 from asgiref.sync import sync_to_async
 from channels.db import database_sync_to_async
 from django.db.models import Q
-from strawberry_django.filters import filter as strawberry_filter
+from strawberry_django.filters import filter_type as strawberry_filter
 from strawberry_django import filter_field as custom_filter
 from strawberry import UNSET
 from strawberry import LazyType as lazy
 from core.managers import QuerySet
+
 
 class AnnotationMergerMixin:
 
@@ -20,6 +21,7 @@ class AnnotationMergerMixin:
             annotations.update(getattr(base, '__annotations__', {}))
         annotations.update(cls.__annotations__)
         cls.__annotations__ = annotations
+
 
 class SearchFilterMixin(AnnotationMergerMixin):
     search: Optional[str]

--- a/OneSila/core/schema/countries/queries.py
+++ b/OneSila/core/schema/countries/queries.py
@@ -1,9 +1,4 @@
-from strawberry_django import auth
-
-from core.schema.core.helpers import get_multi_tenant_company
-from core.schema.multi_tenant.types.types import MultiTenantUserType, MultiTenantCompanyType
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, \
-    type, field, anonymous_field, default_extensions, Info
+from core.schema.core.queries import type, anonymous_field
 
 from typing import List
 

--- a/OneSila/core/schema/languages/queries.py
+++ b/OneSila/core/schema/languages/queries.py
@@ -3,13 +3,10 @@ from strawberry_django import auth, field
 from django.contrib.auth.models import AnonymousUser
 
 from core.schema.core.helpers import get_multi_tenant_company
-from core.schema.multi_tenant.types.types import MultiTenantUserType, MultiTenantCompanyType
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, \
-    type, field, default_extensions, Info, anonymous_field
+from core.schema.core.queries import type, field, anonymous_field
 
 from typing import List
 
-from core.countries import COUNTRY_CHOICES
 from core.schema.languages.types.types import LanguageType
 from core.schema.core.helpers import get_current_user
 from django.conf import settings
@@ -29,6 +26,7 @@ def get_languages(info) -> List[LanguageType]:
 
     return languages
 
+
 def get_interface_languages(info) -> List[LanguageType]:
     user = get_current_user(info)
 
@@ -41,6 +39,7 @@ def get_interface_languages(info) -> List[LanguageType]:
         deactivate()
 
     return languages
+
 
 def get_default_language() -> LanguageType:
     return LanguageType(**get_language_info(settings.LANGUAGE_CODE))
@@ -69,6 +68,7 @@ def get_company_languages(info) -> List[LanguageType]:
 
     deactivate()
     return languages
+
 
 @type(name="Query")
 class LanguageQuery:

--- a/OneSila/core/schema/multi_tenant/queries.py
+++ b/OneSila/core/schema/multi_tenant/queries.py
@@ -1,10 +1,9 @@
 from strawberry_django import auth, field
 
 from core.schema.core.helpers import get_multi_tenant_company
-from core.schema.multi_tenant.types.filters import MultiTenantUserFilter
 from core.schema.multi_tenant.types.types import MultiTenantUserType, MultiTenantCompanyType, HasDemoDataType, MinimalMultiTenantUserType
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, \
-    type, field, default_extensions, Info, List, anonymous_field
+from core.schema.core.queries import connection, DjangoListConnection, \
+    type, field, Info, List, anonymous_field
 
 
 def my_multi_tenant_company_resolver(info: Info) -> MultiTenantCompanyType:
@@ -27,5 +26,5 @@ def has_demo_data(info: Info) -> HasDemoDataType:
 class MultiTenantQuery:
     me: MultiTenantUserType = auth.current_user()
     my_multi_tenant_company: MultiTenantCompanyType = field(resolver=my_multi_tenant_company_resolver)
-    users: ListConnectionWithTotalCount[MinimalMultiTenantUserType] = connection()
+    users: DjangoListConnection[MinimalMultiTenantUserType] = connection()
     has_demo_data: HasDemoDataType = anonymous_field(resolver=has_demo_data)

--- a/OneSila/core/schema/timezones/queries.py
+++ b/OneSila/core/schema/timezones/queries.py
@@ -1,13 +1,8 @@
 from strawberry_django import auth, field
 
-from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
-from django.conf import settings
 
-from core.schema.core.helpers import get_multi_tenant_company
-from core.schema.multi_tenant.types.types import MultiTenantUserType, MultiTenantCompanyType
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, \
-    type, field, default_extensions, Info, anonymous_field
+from core.schema.core.queries import type, field, anonymous_field
 
 from typing import List
 

--- a/OneSila/currencies/schema/queries.py
+++ b/OneSila/currencies/schema/queries.py
@@ -1,4 +1,4 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type
+from core.schema.core.queries import node, connection, DjangoListConnection, type
 from typing import List
 
 from .types.types import CurrencyType, PublicCurrencyType
@@ -7,6 +7,6 @@ from .types.types import CurrencyType, PublicCurrencyType
 @type(name="Query")
 class CurrenciesQuery:
     currency: CurrencyType = node()
-    currencies: ListConnectionWithTotalCount[CurrencyType] = connection()
+    currencies: DjangoListConnection[CurrencyType] = connection()
 
-    public_currencies: ListConnectionWithTotalCount[PublicCurrencyType] = connection()
+    public_currencies: DjangoListConnection[PublicCurrencyType] = connection()

--- a/OneSila/customs/schema/queries.py
+++ b/OneSila/customs/schema/queries.py
@@ -1,6 +1,4 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type, field
-from customs.models import HsCode
-
+from core.schema.core.queries import node, connection, DjangoListConnection, type
 
 from .types.types import HsCodeType
 
@@ -8,4 +6,4 @@ from .types.types import HsCodeType
 @type(name="Query")
 class CustomsQuery:
     hs_code: HsCodeType = node()
-    hs_codes: ListConnectionWithTotalCount[HsCodeType] = connection()
+    hs_codes: DjangoListConnection[HsCodeType] = connection()

--- a/OneSila/eancodes/schema/queries.py
+++ b/OneSila/eancodes/schema/queries.py
@@ -1,4 +1,4 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type
+from core.schema.core.queries import node, connection, DjangoListConnection, type
 from typing import List
 
 from .types.types import EanCodeType
@@ -7,4 +7,4 @@ from .types.types import EanCodeType
 @type(name="Query")
 class EanCodesQuery:
     ean_code: EanCodeType = node()
-    ean_codes: ListConnectionWithTotalCount[EanCodeType] = connection()
+    ean_codes: DjangoListConnection[EanCodeType] = connection()

--- a/OneSila/integrations/schema/queries.py
+++ b/OneSila/integrations/schema/queries.py
@@ -1,8 +1,8 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type
+from core.schema.core.queries import node, connection, DjangoListConnection, type
 from integrations.schema.types.types import IntegrationType
 
 
 @type(name="Query")
 class IntegrationsQuery:
     integration: IntegrationType = node()
-    integrations: ListConnectionWithTotalCount[IntegrationType] = connection()
+    integrations: DjangoListConnection[IntegrationType] = connection()

--- a/OneSila/inventory/schema/queries.py
+++ b/OneSila/inventory/schema/queries.py
@@ -1,21 +1,16 @@
-import strawberry
-from asgiref.sync import sync_to_async
-from strawberry.relay import from_base64
-
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type
+from core.schema.core.queries import node, connection, DjangoListConnection, type
 from typing import List
 
-from .types.types import InventoryType, InventoryLocationType, InventoryMovementType, PickingLocationType
-
+from .types.types import InventoryType, InventoryLocationType, InventoryMovementType
 
 
 @type(name="Query")
 class InventoryQuery:
     inventory: InventoryType = node()
-    inventories: ListConnectionWithTotalCount[InventoryType] = connection()
+    inventories: DjangoListConnection[InventoryType] = connection()
 
     inventory_location: InventoryLocationType = node()
-    inventory_locations: ListConnectionWithTotalCount[InventoryLocationType] = connection()
+    inventory_locations: DjangoListConnection[InventoryLocationType] = connection()
 
     inventory_movement: InventoryMovementType = node()
-    inventory_movements: ListConnectionWithTotalCount[InventoryMovementType] = connection()
+    inventory_movements: DjangoListConnection[InventoryMovementType] = connection()

--- a/OneSila/lead_times/schema/queries.py
+++ b/OneSila/lead_times/schema/queries.py
@@ -1,4 +1,4 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type, \
+from core.schema.core.queries import node, connection, DjangoListConnection, type, \
     anonymous_field
 from typing import List
 
@@ -13,9 +13,9 @@ def get_lead_time_units() -> List[LeadTimeUnitType]:
 @type(name="Query")
 class LeadTimesQuery:
     lead_time: LeadTimeType = node()
-    lead_times: ListConnectionWithTotalCount[LeadTimeType] = connection()
+    lead_times: DjangoListConnection[LeadTimeType] = connection()
 
     lead_time_units: List[LeadTimeUnitType] = anonymous_field(resolver=get_lead_time_units)
 
     lead_time_for_shippingaddress: LeadTimeForShippingAddressType = node()
-    lead_time_for_shippingaddresses: ListConnectionWithTotalCount[LeadTimeForShippingAddressType] = connection()
+    lead_time_for_shippingaddresses: DjangoListConnection[LeadTimeForShippingAddressType] = connection()

--- a/OneSila/media/schema/queries.py
+++ b/OneSila/media/schema/queries.py
@@ -1,4 +1,4 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type
+from core.schema.core.queries import node, connection, DjangoListConnection, type
 from typing import List
 
 from .types.types import MediaType, ImageType, VideoType, MediaProductThroughType, FileType
@@ -7,16 +7,16 @@ from .types.types import MediaType, ImageType, VideoType, MediaProductThroughTyp
 @type(name="Query")
 class MediaQuery:
     media: MediaType = node()
-    medias: ListConnectionWithTotalCount[MediaType] = connection()
+    medias: DjangoListConnection[MediaType] = connection()
 
     image: ImageType = node()
-    images: ListConnectionWithTotalCount[ImageType] = connection()
+    images: DjangoListConnection[ImageType] = connection()
 
     file: FileType = node()
-    files: ListConnectionWithTotalCount[FileType] = connection()
+    files: DjangoListConnection[FileType] = connection()
 
     video: VideoType = node()
-    videos: ListConnectionWithTotalCount[VideoType] = connection()
+    videos: DjangoListConnection[VideoType] = connection()
 
     media_product_through: MediaProductThroughType = node()
-    media_product_throughs: ListConnectionWithTotalCount[MediaProductThroughType] = connection()
+    media_product_throughs: DjangoListConnection[MediaProductThroughType] = connection()

--- a/OneSila/orders/schema/queries.py
+++ b/OneSila/orders/schema/queries.py
@@ -1,4 +1,4 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type
+from core.schema.core.queries import node, connection, DjangoListConnection, type
 from typing import List
 
 from .types.types import OrderType, OrderItemType, OrderNoteType
@@ -7,10 +7,10 @@ from .types.types import OrderType, OrderItemType, OrderNoteType
 @type(name="Query")
 class OrdersQuery:
     order: OrderType = node()
-    orders: ListConnectionWithTotalCount[OrderType] = connection()
+    orders: DjangoListConnection[OrderType] = connection()
 
     order_item: OrderItemType = node()
-    order_items: ListConnectionWithTotalCount[OrderItemType] = connection()
+    order_items: DjangoListConnection[OrderItemType] = connection()
 
     order_note: OrderNoteType = node()
-    order_notes: ListConnectionWithTotalCount[OrderNoteType] = connection()
+    order_notes: DjangoListConnection[OrderNoteType] = connection()

--- a/OneSila/products/schema/queries.py
+++ b/OneSila/products/schema/queries.py
@@ -1,4 +1,4 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type
+from core.schema.core.queries import node, connection, DjangoListConnection, type
 from typing import List
 
 from .types.types import ProductType, BundleProductType, ConfigurableProductType, \
@@ -9,22 +9,22 @@ from .types.types import ProductType, BundleProductType, ConfigurableProductType
 @type(name="Query")
 class ProductsQuery:
     product: ProductType = node()
-    products: ListConnectionWithTotalCount[ProductType] = connection()
+    products: DjangoListConnection[ProductType] = connection()
 
     bundle_product: BundleProductType = node()
-    bundle_products: ListConnectionWithTotalCount[BundleProductType] = connection()
+    bundle_products: DjangoListConnection[BundleProductType] = connection()
 
     configurable_product: ConfigurableProductType = node()
-    configurable_products: ListConnectionWithTotalCount[ConfigurableProductType] = connection()
+    configurable_products: DjangoListConnection[ConfigurableProductType] = connection()
 
     simple_product: SimpleProductType = node()
-    simple_products: ListConnectionWithTotalCount[SimpleProductType] = connection()
+    simple_products: DjangoListConnection[SimpleProductType] = connection()
 
     product_translation: ProductTranslationType = node()
-    product_translations: ListConnectionWithTotalCount[ProductTranslationType] = connection()
+    product_translations: DjangoListConnection[ProductTranslationType] = connection()
 
     configurable_variation: ConfigurableVariationType = node()
-    configurable_variations: ListConnectionWithTotalCount[ConfigurableVariationType] = connection()
+    configurable_variations: DjangoListConnection[ConfigurableVariationType] = connection()
 
     bundle_variation: BundleVariationType = node()
-    bundle_variations: ListConnectionWithTotalCount[BundleVariationType] = connection()
+    bundle_variations: DjangoListConnection[BundleVariationType] = connection()

--- a/OneSila/properties/schema/queries.py
+++ b/OneSila/properties/schema/queries.py
@@ -1,4 +1,4 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type
+from core.schema.core.queries import node, connection, DjangoListConnection, type
 from typing import List
 
 
@@ -10,25 +10,25 @@ from .types.types import PropertyType, PropertyTranslationType, \
 @type(name="Query")
 class PropertiesQuery:
     property: PropertyType = node()
-    properties: ListConnectionWithTotalCount[PropertyType] = connection()
+    properties: DjangoListConnection[PropertyType] = connection()
 
     property_translation: PropertyTranslationType = node()
-    property_translations: ListConnectionWithTotalCount[PropertyTranslationType] = connection()
+    property_translations: DjangoListConnection[PropertyTranslationType] = connection()
 
     property_select_value: PropertySelectValueType = node()
-    property_select_values: ListConnectionWithTotalCount[PropertySelectValueType] = connection()
+    property_select_values: DjangoListConnection[PropertySelectValueType] = connection()
 
     product_property: ProductPropertyType = node()
-    product_properties: ListConnectionWithTotalCount[ProductPropertyType] = connection()
+    product_properties: DjangoListConnection[ProductPropertyType] = connection()
 
     product_property_text_translation: ProductPropertyTextTranslationType = node()
-    product_property_text_translations: ListConnectionWithTotalCount[ProductPropertyTextTranslationType] = connection()
+    product_property_text_translations: DjangoListConnection[ProductPropertyTextTranslationType] = connection()
 
     property_select_value_translation: PropertySelectValueTranslationType = node()
-    property_select_value_translations: ListConnectionWithTotalCount[PropertySelectValueTranslationType] = connection()
+    property_select_value_translations: DjangoListConnection[PropertySelectValueTranslationType] = connection()
 
     product_properties_rule: ProductPropertiesRuleType = node()
-    product_properties_rules: ListConnectionWithTotalCount[ProductPropertiesRuleType] = connection()
+    product_properties_rules: DjangoListConnection[ProductPropertiesRuleType] = connection()
 
     product_properties_rule_item: ProductPropertiesRuleItemType = node()
-    product_properties_rule_items: ListConnectionWithTotalCount[ProductPropertiesRuleItemType] = connection()
+    product_properties_rule_items: DjangoListConnection[ProductPropertiesRuleItemType] = connection()

--- a/OneSila/sales_channels/integrations/magento2/schema/queries.py
+++ b/OneSila/sales_channels/integrations/magento2/schema/queries.py
@@ -2,7 +2,7 @@ import json
 from typing import List
 from strawberry import Info, ID
 from core.schema.core.helpers import get_multi_tenant_company
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type, field
+from core.schema.core.queries import node, connection, DjangoListConnection, type, field
 from sales_channels.integrations.magento2.constants import EXCLUDED_ATTRIBUTE_CODES
 from sales_channels.integrations.magento2.factories.sales_channels.sales_channel import TryConnection
 from sales_channels.integrations.magento2.models import MagentoSalesChannel
@@ -36,7 +36,7 @@ def get_magento_attributes(info: Info, sales_channel_id: ID) -> List[MagentoRemo
         )
         for attr in attributes
         if hasattr(attr, 'default_frontend_label')
-           and attr.attribute_code not in EXCLUDED_ATTRIBUTE_CODES
+        and attr.attribute_code not in EXCLUDED_ATTRIBUTE_CODES
     ]
 
 
@@ -64,6 +64,7 @@ def get_magento_attribute_sets(info: Info, sales_channel_id: ID) -> list[Magento
         for attr in attribute_sets
     ]
 
+
 @type(name="Query")
 class MagentoSalesChannelsQuery:
     magento_remote_attributes: List[MagentoRemoteAttributeType] = field(
@@ -73,4 +74,4 @@ class MagentoSalesChannelsQuery:
     )
 
     magento_channel: MagentoSalesChannelType = node()
-    magento_channels: ListConnectionWithTotalCount[MagentoSalesChannelType] = connection()
+    magento_channels: DjangoListConnection[MagentoSalesChannelType] = connection()

--- a/OneSila/sales_channels/schema/queries.py
+++ b/OneSila/sales_channels/schema/queries.py
@@ -1,36 +1,37 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type, field
+from core.schema.core.queries import node, connection, DjangoListConnection, type, field
 from integrations.schema.types.types import IntegrationType
 from .types.types import RemoteLogType, RemoteProductType, SalesChannelType, \
     SalesChannelIntegrationPricelistType, SalesChannelViewType, SalesChannelViewAssignType, RemoteLanguageType, \
     RemoteCurrencyType, SalesChannelImportType
 
+
 @type(name='Query')
 class SalesChannelsQuery:
     sales_channel_import: SalesChannelImportType = node()
-    sales_channel_imports: ListConnectionWithTotalCount[SalesChannelImportType] = connection()
+    sales_channel_imports: DjangoListConnection[SalesChannelImportType] = connection()
 
     remote_log: RemoteLogType = node()
-    remote_logs: ListConnectionWithTotalCount[RemoteLogType] = connection()
+    remote_logs: DjangoListConnection[RemoteLogType] = connection()
 
     remote_product: RemoteProductType = node()
-    remote_products: ListConnectionWithTotalCount[RemoteProductType] = connection()
+    remote_products: DjangoListConnection[RemoteProductType] = connection()
 
     sales_channel: SalesChannelType = node()
-    sales_channels: ListConnectionWithTotalCount[SalesChannelType] = connection()
+    sales_channels: DjangoListConnection[SalesChannelType] = connection()
 
     sales_channel_integration_pricelist: SalesChannelIntegrationPricelistType = node()
-    sales_channel_integration_pricelists: ListConnectionWithTotalCount[SalesChannelIntegrationPricelistType] = connection()
+    sales_channel_integration_pricelists: DjangoListConnection[SalesChannelIntegrationPricelistType] = connection()
 
     sales_channel_view: SalesChannelViewType = node()
-    sales_channel_views: ListConnectionWithTotalCount[SalesChannelViewType] = connection()
+    sales_channel_views: DjangoListConnection[SalesChannelViewType] = connection()
 
     remote_language: RemoteLanguageType = node()
-    remote_languages: ListConnectionWithTotalCount[RemoteLanguageType] = connection()
+    remote_languages: DjangoListConnection[RemoteLanguageType] = connection()
 
     remote_currency: RemoteCurrencyType = node()
-    remote_currencies: ListConnectionWithTotalCount[RemoteCurrencyType] = connection()
+    remote_currencies: DjangoListConnection[RemoteCurrencyType] = connection()
 
     sales_channel_view_assign: SalesChannelViewAssignType = node()
-    sales_channel_view_assigns: ListConnectionWithTotalCount[SalesChannelViewAssignType] = connection()
+    sales_channel_view_assigns: DjangoListConnection[SalesChannelViewAssignType] = connection()
 
     integration: IntegrationType = node()

--- a/OneSila/sales_prices/schema/queries.py
+++ b/OneSila/sales_prices/schema/queries.py
@@ -1,4 +1,4 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, \
+from core.schema.core.queries import node, connection, DjangoListConnection, \
     type
 
 from .types.types import SalesPriceType, SalesPriceListType, SalesPriceListItemType
@@ -7,10 +7,10 @@ from .types.types import SalesPriceType, SalesPriceListType, SalesPriceListItemT
 @type(name="Query")
 class SalesPricesQuery:
     sales_price: SalesPriceType = node()
-    sales_prices: ListConnectionWithTotalCount[SalesPriceType] = connection()
+    sales_prices: DjangoListConnection[SalesPriceType] = connection()
 
     sales_price_list: SalesPriceListType = node()
-    sales_price_lists: ListConnectionWithTotalCount[SalesPriceListType] = connection()
+    sales_price_lists: DjangoListConnection[SalesPriceListType] = connection()
 
     sales_price_list_item: SalesPriceListItemType = node()
-    sales_price_list_items: ListConnectionWithTotalCount[SalesPriceListItemType] = connection()
+    sales_price_list_items: DjangoListConnection[SalesPriceListItemType] = connection()

--- a/OneSila/taxes/schema/queries.py
+++ b/OneSila/taxes/schema/queries.py
@@ -1,4 +1,4 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type
+from core.schema.core.queries import node, connection, DjangoListConnection, type
 from typing import List
 
 from .types.types import VatRateType
@@ -7,4 +7,4 @@ from .types.types import VatRateType
 @type(name="Query")
 class TaxesQuery:
     vat_rate: VatRateType = node()
-    vat_rates: ListConnectionWithTotalCount[VatRateType] = connection()
+    vat_rates: DjangoListConnection[VatRateType] = connection()

--- a/OneSila/units/schema/queries.py
+++ b/OneSila/units/schema/queries.py
@@ -1,4 +1,4 @@
-from core.schema.core.queries import node, connection, ListConnectionWithTotalCount, type
+from core.schema.core.queries import node, connection, DjangoListConnection, type
 from typing import List
 
 from .types.types import UnitType
@@ -7,4 +7,4 @@ from .types.types import UnitType
 @type(name="Query")
 class UnitsQuery:
     unit: UnitType = node()
-    units: ListConnectionWithTotalCount[UnitType] = connection()
+    units: DjangoListConnection[UnitType] = connection()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=5
+Django>=5,<5.3
 django-imagekit>=4.1.0
 Pillow>=10.0.0
 CurrencyConverter

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,8 +34,8 @@ openai~=1.66.3
 replicate
 pydantic<2.0
 
-strawberry-graphql==0.261.0
-strawberry-graphql-django==0.56.0
+strawberry-graphql==0.266.0
+strawberry-graphql-django==0.59.0
 
 django_get_absolute_url @ git+https://git@github.com/TweaveTech/django_get_absolute_url.git@master
 


### PR DESCRIPTION
I’m pushing an upgrade to strawberry and fixed the version of Django to 5.2.

- our deployments were installing latest django version without supervision
- strawberry had 5.2 compaibiltity issues up until 0.57
- Sorting was imrpoved >0.56
- some imports needed renmaing. 

Test are running fine.  
Frontend local testing:
- Create
- Delete
- Update
- List filter
- Ordering

All seem to be OK with first tests
New release requires decent testing - however I’m merging this update into development.