### PR TITLE
Fix missing zipfile import

### DIFF
--- a/OneSila/core/helpers.py
+++ b/OneSila/core/helpers.py
@@ -5,6 +5,7 @@ from django.http import HttpResponse
 import os
 from get_absolute_url.helpers import reverse_lazy
 from io import BytesIO
+import zipfile
 
 
 def get_languages():


### PR DESCRIPTION
## Summary
- import Python zipfile module to fix `multiple_files_to_zip_httpresponse`

## Testing
- `python manage.py test core --verbosity 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683ff7c8978c832e966360c11267300b