### PR TITLE
Add Amazon integration models

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/models.py
+++ b/OneSila/sales_channels/integrations/amazon/models.py
@@ -1,4 +1,0 @@
-from core import models
-
-# class MyModel(models.Model):
-#     pass

--- a/OneSila/sales_channels/integrations/amazon/models/__init__.py
+++ b/OneSila/sales_channels/integrations/amazon/models/__init__.py
@@ -1,0 +1,14 @@
+from .orders import AmazonOrder, AmazonOrderItem
+from .products import (
+    AmazonProduct, AmazonInventory, AmazonPrice,
+    AmazonProductContent, AmazonImageProductAssociation,
+    AmazonCategory, AmazonEanCode
+)
+from .properties import (
+    AmazonProperty, AmazonPropertySelectValue, AmazonProductProperty
+)
+from .sales_channels import (
+    AmazonSalesChannel, AmazonSalesChannelView, AmazonRemoteLanguage
+)
+from .taxes import AmazonCurrency, AmazonVat
+from .imports import *

--- a/OneSila/sales_channels/integrations/amazon/models/orders.py
+++ b/OneSila/sales_channels/integrations/amazon/models/orders.py
@@ -1,0 +1,11 @@
+from sales_channels.models.orders import RemoteOrder, RemoteOrderItem
+
+
+class AmazonOrder(RemoteOrder):
+    """Amazon specific remote order."""
+    pass
+
+
+class AmazonOrderItem(RemoteOrderItem):
+    """Amazon specific remote order item."""
+    pass

--- a/OneSila/sales_channels/integrations/amazon/models/products.py
+++ b/OneSila/sales_channels/integrations/amazon/models/products.py
@@ -1,0 +1,48 @@
+from core import models
+from sales_channels.models.products import (
+    RemoteProduct,
+    RemoteInventory,
+    RemotePrice,
+    RemoteProductContent,
+    RemoteImageProductAssociation,
+    RemoteCategory,
+    RemoteEanCode,
+)
+
+
+class AmazonProduct(RemoteProduct):
+    """Amazon specific remote product."""
+    pass
+
+
+class AmazonInventory(RemoteInventory):
+    """Amazon specific remote inventory."""
+    pass
+
+
+class AmazonPrice(RemotePrice):
+    """Amazon specific remote price."""
+    pass
+
+
+class AmazonProductContent(RemoteProductContent):
+    """Amazon specific remote product content."""
+    pass
+
+
+class AmazonImageProductAssociation(RemoteImageProductAssociation):
+    """Association between images and Amazon products."""
+    pass
+
+
+class AmazonCategory(RemoteCategory):
+    """Amazon remote category."""
+    pass
+
+
+class AmazonEanCode(RemoteEanCode):
+    """Amazon remote EAN codes."""
+
+    class Meta:
+        verbose_name = 'Amazon EAN Code'
+        verbose_name_plural = 'Amazon EAN Codes'

--- a/OneSila/sales_channels/integrations/amazon/models/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/models/properties.py
@@ -1,0 +1,33 @@
+from sales_channels.models.properties import (
+    RemoteProperty,
+    RemotePropertySelectValue,
+    RemoteProductProperty,
+)
+from core import models
+from django.utils.translation import gettext_lazy as _
+
+
+class AmazonProperty(RemoteProperty):
+    """Amazon specific remote property."""
+
+    attribute_code = models.CharField(
+        max_length=255,
+        help_text="The attribute code used in Amazon for this property.",
+        verbose_name="Attribute Code",
+    )
+
+    class Meta:
+        verbose_name = 'Amazon Property'
+        verbose_name_plural = 'Amazon Properties'
+
+
+class AmazonPropertySelectValue(RemotePropertySelectValue):
+    """Amazon specific remote property select value."""
+    pass
+
+
+class AmazonProductProperty(RemoteProductProperty):
+    """Amazon specific remote product property."""
+
+    class Meta:
+        verbose_name_plural = _('Amazon Product Properties')

--- a/OneSila/sales_channels/integrations/amazon/models/sales_channels.py
+++ b/OneSila/sales_channels/integrations/amazon/models/sales_channels.py
@@ -1,0 +1,59 @@
+from django.utils.translation import gettext_lazy as _
+from core import models
+from sales_channels.models.sales_channels import SalesChannel, SalesChannelView, RemoteLanguage
+
+
+class AmazonSalesChannel(SalesChannel):
+    """Amazon specific Sales Channel."""
+
+    NORTH_AMERICA = "NA"
+    EUROPE = "EU"
+    FAR_EAST = "FE"
+
+    REGION_CHOICES = (
+        (NORTH_AMERICA, _("North America")),
+        (EUROPE, _("Europe")),
+        (FAR_EAST, _("Far East")),
+    )
+
+    refresh_token = models.CharField(
+        max_length=512,
+        help_text="Refresh token used to generate new access tokens."
+    )
+    access_token = models.CharField(
+        max_length=512,
+        null=True, blank=True,
+        help_text="Access token for API requests."
+    )
+    expiration_date = models.DateTimeField(
+        null=True, blank=True,
+        help_text="Expiration datetime of the access token."
+    )
+    region = models.CharField(
+        max_length=2,
+        choices=REGION_CHOICES,
+        null=True,
+        blank=True,
+        help_text="Amazon region of this store."
+    )
+
+    class Meta:
+        verbose_name = 'Amazon Sales Channel'
+        verbose_name_plural = 'Amazon Sales Channels'
+
+    def __str__(self):
+        return f"Amazon Store: {self.hostname}"
+
+    def connect(self):
+        pass
+
+
+class AmazonSalesChannelView(SalesChannelView):
+    """Amazon marketplace representation."""
+
+
+
+class AmazonRemoteLanguage(RemoteLanguage):
+    """Amazon remote language placeholder."""
+
+    pass

--- a/OneSila/sales_channels/integrations/amazon/models/taxes.py
+++ b/OneSila/sales_channels/integrations/amazon/models/taxes.py
@@ -1,0 +1,15 @@
+from sales_channels.models import RemoteCurrency, RemoteVat
+from core import models
+
+
+class AmazonCurrency(RemoteCurrency):
+    """Amazon remote currency."""
+    is_default = models.BooleanField(
+        default=False,
+        help_text="Marks the primary currency for this Amazon store."
+    )
+
+
+class AmazonVat(RemoteVat):
+    """Amazon remote VAT."""
+    pass


### PR DESCRIPTION
## Summary
- structure Amazon models package
- implement Amazon sales channel models
- stub product, property, order, tax, and import models
- refine Amazon region field choices and remove unused marketplace field

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/models/sales_channels.py OneSila/sales_channels/integrations/amazon/models/imports.py` *(fails: command not found)*
- `pytest -q` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68402c03ae84832eab6f2520bf9829bb

## Summary by Sourcery

Introduce a new Amazon integration package by adding sales channel, view, and language models along with stubs for all remote entities and refine channel configuration options.

New Features:
- Add AmazonSalesChannel model with authentication fields and region support
- Add placeholder AmazonSalesChannelView and AmazonRemoteLanguage classes
- Scaffold Amazon-specific remote model stubs for products, inventory, pricing, content, images, categories, EAN codes, properties, orders, currencies, and taxes

Enhancements:
- Refine AmazonSalesChannel region choices to North America, Europe, and Far East
- Remove unused marketplace field from Amazon integration