### PR TITLE
Add Amazon GraphQL schema

### DIFF
--- a/OneSila/OneSila/schema.py
+++ b/OneSila/OneSila/schema.py
@@ -25,6 +25,8 @@ from sales_channels.integrations.magento2.schema import MagentoSalesChannelMutat
     MagentoSalesChannelsSubscription
 from sales_channels.integrations.shopify.schema import ShopifySalesChannelMutation, ShopifySalesChannelsQuery, \
     ShopifySalesChannelsSubscription
+from sales_channels.integrations.amazon.schema import AmazonSalesChannelMutation, AmazonSalesChannelsQuery, \
+    AmazonSalesChannelsSubscription
 from taxes.schema import TaxesQuery, TaxesMutation, TaxSubscription
 from translations.schema import TranslationsQuery
 from integrations.schema import IntegrationsQuery, IntegrationsMutation
@@ -38,14 +40,14 @@ from llm.schema import LlmMutation
 @strawberry.type
 class Query(CurrenciesQuery, CountryQuery, EanCodesQuery, IntegrationsQuery,
         LanguageQuery, LeadTimesQuery, MediaQuery, MultiTenantQuery, MagentoSalesChannelsQuery, ShopifySalesChannelsQuery,
-        ProductsQuery, PropertiesQuery, SalesPricesQuery, SalesChannelsQuery,
+        AmazonSalesChannelsQuery, ProductsQuery, PropertiesQuery, SalesPricesQuery, SalesChannelsQuery,
         TaxesQuery, TimeZoneQuery, TranslationsQuery):
     pass
 
 
 @strawberry.type
 class Mutation(CurrenciesMutation, EanCodesMutation, MediaMutation, MultiTenantMutation, ShopifySalesChannelMutation,
-       ProductsInspectorMutation, ProductsMutation, PropertiesMutation, IntegrationsMutation, LlmMutation,
+       AmazonSalesChannelMutation, ProductsInspectorMutation, ProductsMutation, PropertiesMutation, IntegrationsMutation, LlmMutation,
        SalesPricesMutation, SalesChannelsMutation, MagentoSalesChannelMutation, TaxesMutation):
     pass
 
@@ -53,7 +55,8 @@ class Mutation(CurrenciesMutation, EanCodesMutation, MediaMutation, MultiTenantM
 @strawberry.type
 class Subscription(CurrenciesSubscription, EanCodesSubscription, MediaSubscription, MultiTenantSubscription,
         ProductsInspectorSubscription, ProductsSubscription, PropertiesSubscription, SalesPriceSubscription,
-        MagentoSalesChannelsSubscription, SalesChannelsSubscription, TaxSubscription, ShopifySalesChannelsSubscription):
+        MagentoSalesChannelsSubscription, SalesChannelsSubscription, TaxSubscription, ShopifySalesChannelsSubscription,
+        AmazonSalesChannelsSubscription):
     pass
 
 #

--- a/OneSila/integrations/constants.py
+++ b/OneSila/integrations/constants.py
@@ -1,16 +1,20 @@
 from django.utils.translation import gettext_lazy as _
 from sales_channels.integrations.magento2.models import MagentoSalesChannel
 from sales_channels.integrations.shopify.models import ShopifySalesChannel
+from sales_channels.integrations.amazon.models import AmazonSalesChannel
 
 MAGENTO_INTEGRATION = 'magento'
 SHOPIFY_INTEGRATION = 'shopify'
+AMAZON_INTEGRATION = 'amazon'
 
 INTEGRATIONS_TYPES = (
     (MAGENTO_INTEGRATION, _('Magento')),
     (SHOPIFY_INTEGRATION, _('Shopify')),
+    (AMAZON_INTEGRATION, _('Amazon')),
 )
 
 INTEGRATIONS_TYPES_MAP = {
     MagentoSalesChannel: MAGENTO_INTEGRATION,
     ShopifySalesChannel: SHOPIFY_INTEGRATION,
+    AmazonSalesChannel: AMAZON_INTEGRATION,
 }

--- a/OneSila/integrations/schema/types/types.py
+++ b/OneSila/integrations/schema/types/types.py
@@ -8,6 +8,8 @@ from sales_channels.integrations.magento2.models import MagentoSalesChannel
 from sales_channels.integrations.magento2.schema.types.types import MagentoSalesChannelType
 from sales_channels.integrations.shopify.models import ShopifySalesChannel
 from sales_channels.integrations.shopify.schema.types.types import ShopifySalesChannelType
+from sales_channels.integrations.amazon.models import AmazonSalesChannel
+from sales_channels.integrations.amazon.schema.types.types import AmazonSalesChannelType
 from sales_channels.schema.types.types import SalesChannelType
 
 
@@ -27,6 +29,9 @@ class IntegrationType(relay.Node, GetQuerysetMultiTenantMixin):
         elif isinstance(self, ShopifySalesChannel):
             return self.access_token is not None
 
+        elif isinstance(self, AmazonSalesChannel):
+            return self.access_token is not None
+
         return False
 
     @field()
@@ -35,6 +40,8 @@ class IntegrationType(relay.Node, GetQuerysetMultiTenantMixin):
             graphql_type = MagentoSalesChannelType
         elif isinstance(self, ShopifySalesChannel):
             graphql_type = ShopifySalesChannelType
+        elif isinstance(self, AmazonSalesChannel):
+            graphql_type = AmazonSalesChannelType
         else:
             graphql_type = SalesChannelType
 

--- a/OneSila/sales_channels/integrations/amazon/schema/__init__.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/__init__.py
@@ -1,0 +1,3 @@
+from .mutations import AmazonSalesChannelMutation
+from .queries import AmazonSalesChannelsQuery
+from .subscriptions import AmazonSalesChannelsSubscription

--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -1,0 +1,11 @@
+from sales_channels.integrations.amazon.schema.types.input import AmazonSalesChannelInput, AmazonSalesChannelPartialInput
+from sales_channels.integrations.amazon.schema.types.types import AmazonSalesChannelType
+from core.schema.core.mutations import create, type, List, update
+
+
+@type(name="Mutation")
+class AmazonSalesChannelMutation:
+    create_amazon_sales_channel: AmazonSalesChannelType = create(AmazonSalesChannelInput)
+    create_amazon_sales_channels: List[AmazonSalesChannelType] = create(AmazonSalesChannelInput)
+
+    update_amazon_sales_channel: AmazonSalesChannelType = update(AmazonSalesChannelPartialInput)

--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -1,0 +1,8 @@
+from core.schema.core.queries import node, connection, DjangoListConnection, type
+from sales_channels.integrations.amazon.schema.types.types import AmazonSalesChannelType
+
+
+@type(name="Query")
+class AmazonSalesChannelsQuery:
+    amazon_channel: AmazonSalesChannelType = node()
+    amazon_channels: DjangoListConnection[AmazonSalesChannelType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/subscriptions.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/subscriptions.py
@@ -1,0 +1,12 @@
+from core.schema.core.subscriptions import type, subscription, Info, AsyncGenerator, model_subscriber
+from sales_channels.integrations.amazon.models import AmazonSalesChannel
+from sales_channels.integrations.amazon.schema.types.types import AmazonSalesChannelType
+
+
+@type(name='Subscription')
+class AmazonSalesChannelsSubscription:
+
+    @subscription
+    async def amazon_channel(self, info: Info, pk: str) -> AsyncGenerator[AmazonSalesChannelType, None]:
+        async for i in model_subscriber(info=info, pk=pk, model=AmazonSalesChannel):
+            yield i

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -1,0 +1,9 @@
+from core.schema.core.types.filters import filter, SearchFilterMixin
+from core.schema.core.types.types import auto
+from sales_channels.integrations.amazon.models import AmazonSalesChannel
+
+
+@filter(AmazonSalesChannel)
+class AmazonSalesChannelFilter(SearchFilterMixin):
+    active: auto
+    hostname: auto

--- a/OneSila/sales_channels/integrations/amazon/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/input.py
@@ -1,0 +1,12 @@
+from core.schema.core.types.input import NodeInput, input, partial
+from sales_channels.integrations.amazon.models import AmazonSalesChannel
+
+
+@input(AmazonSalesChannel, exclude=['integration_ptr', 'saleschannel_ptr'])
+class AmazonSalesChannelInput:
+    pass
+
+
+@partial(AmazonSalesChannel, fields="__all__")
+class AmazonSalesChannelPartialInput(NodeInput):
+    pass

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -1,0 +1,8 @@
+from core.schema.core.types.ordering import order
+from core.schema.core.types.types import auto
+from sales_channels.integrations.amazon.models import AmazonSalesChannel
+
+
+@order(AmazonSalesChannel)
+class AmazonSalesChannelOrder:
+    id: auto

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -1,0 +1,16 @@
+from core.schema.core.types.types import relay, type, GetQuerysetMultiTenantMixin, field
+from sales_channels.integrations.amazon.models import AmazonSalesChannel
+from sales_channels.integrations.amazon.schema.types.filters import AmazonSalesChannelFilter
+from sales_channels.integrations.amazon.schema.types.ordering import AmazonSalesChannelOrder
+
+
+@type(AmazonSalesChannel, filters=AmazonSalesChannelFilter, order=AmazonSalesChannelOrder, pagination=True, fields="__all__")
+class AmazonSalesChannelType(relay.Node, GetQuerysetMultiTenantMixin):
+
+    @field()
+    def integration_ptr(self, info) -> str:
+        return self.integration_ptr
+
+    @field()
+    def saleschannel_ptr(self, info) -> str:
+        return self.saleschannel_ptr


### PR DESCRIPTION
## Summary
- support amazon integration in constants and integration types
- wire amazon types into the main schema
- implement amazon GraphQL schema (queries, mutations, subscriptions, types)

## Testing
- `pre-commit run --files OneSila/OneSila/schema.py OneSila/integrations/constants.py OneSila/integrations/schema/types/types.py OneSila/sales_channels/integrations/amazon/schema/__init__.py OneSila/sales_channels/integrations/amazon/schema/mutations.py OneSila/sales_channels/integrations/amazon/schema/queries.py OneSila/sales_channels/integrations/amazon/schema/subscriptions.py OneSila/sales_channels/integrations/amazon/schema/types/filters.py OneSila/sales_channels/integrations/amazon/schema/types/input.py OneSila/sales_channels/integrations/amazon/schema/types/ordering.py OneSila/sales_channels/integrations/amazon/schema/types/types.py` *(fails: command not found)*
- `coverage run --source='.' manage.py test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403285cd20832e8fc6aa627820dcf8

## Summary by Sourcery

Implement Amazon sales channel integration by adding GraphQL schema support and wiring it into the main schema

New Features:
- Add GraphQL types, filters, ordering, inputs, queries, mutations, and subscriptions for AmazonSalesChannel
- Wire AmazonSalesChannelQuery, Mutation, and Subscription into the root schema definitions

Enhancements:
- Add Amazon integration constant and map AmazonSalesChannel in integration types
- Extend existing integration resolvers to support AmazonSalesChannel in connected and proxy_id fields