### PR TITLE
Fix helper for directory creation

### DIFF
--- a/OneSila/core/helpers.py
+++ b/OneSila/core/helpers.py
@@ -13,8 +13,8 @@ def get_languages():
 
 
 def is_or_create_folder(path):
-    if not os.path.isdir(path):
-        os.mkdir(path)
+    """Ensure that the directory at ``path`` exists."""
+    os.makedirs(path, exist_ok=True)
 
 
 def save_test_file(filename, file_contents):


### PR DESCRIPTION
## Summary
- ensure `is_or_create_folder` handles nested directories

## Testing
- `pre-commit run --files OneSila/core/helpers.py` *(fails: error 403 fetching pre-commit hooks)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684047b834448322bb35991d2d150954