### PR TITLE
Add Amazon OAuth flow

### DIFF
--- a/OneSila/OneSila/urls.py
+++ b/OneSila/OneSila/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     path('units/', include('units.urls')),
     path('sales_channels/', include('sales_channels.urls')),
     path('direct/integrations/shopify/', include('sales_channels.integrations.shopify.urls')),
+    path('direct/integrations/amazon/', include('sales_channels.integrations.amazon.urls')),
     path('integrations/', include('integrations.urls')),
     path('graphql/',
         AsyncGraphQLView.as_view(

--- a/OneSila/integrations/urls.py
+++ b/OneSila/integrations/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path, include
 
 from sales_channels.integrations.shopify.views import ShopifyInstalledView, ShopifyEntryView
+from sales_channels.integrations.amazon.views import AmazonInstalledView, AmazonEntryView
 from . import views
-from .views import IntegrationListView, ShopifyIntegrationDetailView
+from .views import IntegrationListView, ShopifyIntegrationDetailView, AmazonIntegrationDetailView
 
 app_name = 'integrations'
 
@@ -11,5 +12,8 @@ urlpatterns = [
     path("shopify/<str:id>/", ShopifyIntegrationDetailView.as_view(), name="shopify_integration_detail"),
     path("shopify/installed", ShopifyInstalledView.as_view(), name="shopify_oauth_callback"),
     path("shopify/entry", ShopifyEntryView.as_view(), name="shopify_oauth_entry"),
+    path("amazon/<str:id>/", AmazonIntegrationDetailView.as_view(), name="amazon_integration_detail"),
+    path("amazon/installed", AmazonInstalledView.as_view(), name="amazon_oauth_callback"),
+    path("amazon/entry", AmazonEntryView.as_view(), name="amazon_oauth_entry"),
 
 ]

--- a/OneSila/integrations/views.py
+++ b/OneSila/integrations/views.py
@@ -26,3 +26,7 @@ class IntegrationListView(EmptyTemplateView):
 
 class ShopifyIntegrationDetailView(EmptyTemplateView):
     pass
+
+
+class AmazonIntegrationDetailView(EmptyTemplateView):
+    pass

--- a/OneSila/sales_channels/integrations/amazon/constants.py
+++ b/OneSila/sales_channels/integrations/amazon/constants.py
@@ -1,0 +1,27 @@
+SELLER_CENTRAL_URLS = {
+    "CA": "https://sellercentral.amazon.ca",
+    "US": "https://sellercentral.amazon.com",
+    "MX": "https://sellercentral.amazon.com.mx",
+    "BR": "https://sellercentral.amazon.com.br",
+    "IE": "https://sellercentral.amazon.ie",
+    "ES": "https://sellercentral-europe.amazon.com",
+    "GB": "https://sellercentral-europe.amazon.com",
+    "FR": "https://sellercentral-europe.amazon.com",
+    "BE": "https://sellercentral.amazon.com.be",
+    "NL": "https://sellercentral.amazon.nl",
+    "DE": "https://sellercentral-europe.amazon.com",
+    "IT": "https://sellercentral-europe.amazon.com",
+    "SE": "https://sellercentral.amazon.se",
+    "ZA": "https://sellercentral.amazon.co.za",
+    "PL": "https://sellercentral.amazon.pl",
+    "EG": "https://sellercentral.amazon.eg",
+    "TR": "https://sellercentral.amazon.com.tr",
+    "SA": "https://sellercentral.amazon.sa",
+    "AE": "https://sellercentral.amazon.ae",
+    "IN": "https://sellercentral.amazon.in",
+    "SG": "https://sellercentral.amazon.sg",
+    "AU": "https://sellercentral.amazon.com.au",
+    "JP": "https://sellercentral.amazon.co.jp",
+}
+
+AMAZON_OAUTH_TOKEN_URL = "https://api.amazon.com/auth/o2/token"

--- a/OneSila/sales_channels/integrations/amazon/factories/sales_channels/oauth.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sales_channels/oauth.py
@@ -1,0 +1,76 @@
+from urllib.parse import urlencode
+import json
+from datetime import timedelta
+from urllib import request, parse
+
+from django.conf import settings
+from django.urls import reverse
+from django.utils.timezone import now
+from django.utils.translation import gettext_lazy as _
+
+from get_absolute_url.helpers import generate_absolute_url
+from sales_channels.integrations.amazon.models import AmazonSalesChannel
+from sales_channels.integrations.amazon.constants import SELLER_CENTRAL_URLS, AMAZON_OAUTH_TOKEN_URL
+from sales_channels.signals import refresh_website_pull_models
+
+
+class GetAmazonRedirectUrlFactory:
+    def __init__(self, sales_channel: AmazonSalesChannel):
+        self.sales_channel = sales_channel
+        self.redirect_url = None
+
+    def get_base_url(self) -> str:
+        base = SELLER_CENTRAL_URLS.get(self.sales_channel.country)
+        if not base:
+            raise ValueError(_("Unknown Amazon country."))
+        return base
+
+    def run(self):
+        params = {
+            "application_id": settings.AMAZON_APP_ID,
+            "state": self.sales_channel.state,
+        }
+        if settings.DEBUG:
+            params["version"] = "beta"
+        base_url = self.get_base_url()
+        self.redirect_url = f"{base_url}/apps/authorize/consent?{urlencode(params)}"
+
+
+class ValidateAmazonAuthFactory:
+    def __init__(self, sales_channel: AmazonSalesChannel, code: str, selling_partner_id: str):
+        self.sales_channel = sales_channel
+        self.code = code
+        self.selling_partner_id = selling_partner_id
+
+    def exchange_token(self):
+        redirect_uri = f"{generate_absolute_url(trailing_slash=False)}{reverse('integrations:amazon_oauth_callback')}"
+        data = parse.urlencode({
+            "grant_type": "authorization_code",
+            "code": self.code,
+            "client_id": settings.AMAZON_CLIENT_ID,
+            "client_secret": settings.AMAZON_CLIENT_SECRET,
+            "redirect_uri": redirect_uri,
+        }).encode()
+        req = request.Request(AMAZON_OAUTH_TOKEN_URL, data=data)
+        try:
+            with request.urlopen(req) as resp:
+                payload = json.loads(resp.read())
+        except Exception:
+            raise ValueError(_("Token exchange failed. Please try again or contact support."))
+
+        self.sales_channel.refresh_token = payload.get("refresh_token")
+        self.sales_channel.access_token = payload.get("access_token")
+        expires_in = payload.get("expires_in")
+        if expires_in:
+            self.sales_channel.expiration_date = now() + timedelta(seconds=int(expires_in))
+        self.sales_channel.save()
+
+    def dispatch_refresh(self):
+        refresh_website_pull_models.send(
+            sender=self.sales_channel.__class__,
+            instance=self.sales_channel
+        )
+
+    def run(self):
+        self.exchange_token()
+        self.dispatch_refresh()

--- a/OneSila/sales_channels/integrations/amazon/models/sales_channels.py
+++ b/OneSila/sales_channels/integrations/amazon/models/sales_channels.py
@@ -1,6 +1,7 @@
 from django.utils.translation import gettext_lazy as _
 from core import models
 from sales_channels.models.sales_channels import SalesChannel, SalesChannelView, RemoteLanguage
+import uuid
 
 
 class AmazonSalesChannel(SalesChannel):
@@ -29,6 +30,19 @@ class AmazonSalesChannel(SalesChannel):
         null=True, blank=True,
         help_text="Expiration datetime of the access token."
     )
+    state = models.CharField(
+        max_length=64,
+        unique=True,
+        null=True,
+        blank=True,
+        help_text="Unique state used for OAuth verification",
+    )
+    country = models.CharField(
+        max_length=2,
+        null=True,
+        blank=True,
+        help_text="Country code for Seller Central domain.",
+    )
     region = models.CharField(
         max_length=2,
         choices=REGION_CHOICES,
@@ -46,6 +60,11 @@ class AmazonSalesChannel(SalesChannel):
 
     def connect(self):
         pass
+
+    def save(self, *args, **kwargs):
+        if not self.access_token and not self.state:
+            self.state = uuid.uuid4().hex
+        super().save(*args, **kwargs)
 
 
 class AmazonSalesChannelView(SalesChannelView):

--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -1,6 +1,17 @@
-from sales_channels.integrations.amazon.schema.types.input import AmazonSalesChannelInput, AmazonSalesChannelPartialInput
-from sales_channels.integrations.amazon.schema.types.types import AmazonSalesChannelType
+from sales_channels.integrations.amazon.schema.types.input import (
+    AmazonSalesChannelInput,
+    AmazonSalesChannelPartialInput,
+    AmazonValidateAuthInput,
+)
+from sales_channels.integrations.amazon.schema.types.types import (
+    AmazonSalesChannelType,
+    AmazonRedirectUrlType,
+)
 from core.schema.core.mutations import create, type, List, update
+from strawberry import Info
+import strawberry_django
+from core.schema.core.extensions import default_extensions
+from core.schema.core.helpers import get_multi_tenant_company
 
 
 @type(name="Mutation")
@@ -9,3 +20,39 @@ class AmazonSalesChannelMutation:
     create_amazon_sales_channels: List[AmazonSalesChannelType] = create(AmazonSalesChannelInput)
 
     update_amazon_sales_channel: AmazonSalesChannelType = update(AmazonSalesChannelPartialInput)
+
+    @strawberry_django.mutation(handle_django_errors=True, extensions=default_extensions)
+    def get_amazon_redirect_url(self, instance: AmazonSalesChannelPartialInput, info: Info) -> AmazonRedirectUrlType:
+        from sales_channels.integrations.amazon.models import AmazonSalesChannel
+        from sales_channels.integrations.amazon.factories.sales_channels.oauth import GetAmazonRedirectUrlFactory
+
+        multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
+        sales_channel = AmazonSalesChannel.objects.get(
+            id=instance.id.node_id,
+            multi_tenant_company=multi_tenant_company
+        )
+
+        factory = GetAmazonRedirectUrlFactory(sales_channel=sales_channel)
+        factory.run()
+
+        return AmazonRedirectUrlType(redirect_url=factory.redirect_url)
+
+    @strawberry_django.mutation(handle_django_errors=True, extensions=default_extensions)
+    def validate_amazon_auth(self, instance: AmazonValidateAuthInput, info: Info) -> AmazonSalesChannelType:
+        from sales_channels.integrations.amazon.models import AmazonSalesChannel
+        from sales_channels.integrations.amazon.factories.sales_channels.oauth import ValidateAmazonAuthFactory
+
+        multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
+        sales_channel = AmazonSalesChannel.objects.get(
+            state=instance.state,
+            multi_tenant_company=multi_tenant_company
+        )
+
+        factory = ValidateAmazonAuthFactory(
+            sales_channel=sales_channel,
+            code=instance.spapi_oauth_code,
+            selling_partner_id=instance.selling_partner_id,
+        )
+        factory.run()
+
+        return sales_channel

--- a/OneSila/sales_channels/integrations/amazon/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/input.py
@@ -1,4 +1,4 @@
-from core.schema.core.types.input import NodeInput, input, partial
+from core.schema.core.types.input import NodeInput, input, partial, strawberry_input
 from sales_channels.integrations.amazon.models import AmazonSalesChannel
 
 
@@ -10,3 +10,10 @@ class AmazonSalesChannelInput:
 @partial(AmazonSalesChannel, fields="__all__")
 class AmazonSalesChannelPartialInput(NodeInput):
     pass
+
+
+@strawberry_input
+class AmazonValidateAuthInput:
+    spapi_oauth_code: str
+    selling_partner_id: str
+    state: str

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -1,7 +1,12 @@
-from core.schema.core.types.types import relay, type, GetQuerysetMultiTenantMixin, field
+from core.schema.core.types.types import relay, type, GetQuerysetMultiTenantMixin, field, strawberry_type
 from sales_channels.integrations.amazon.models import AmazonSalesChannel
 from sales_channels.integrations.amazon.schema.types.filters import AmazonSalesChannelFilter
 from sales_channels.integrations.amazon.schema.types.ordering import AmazonSalesChannelOrder
+
+
+@strawberry_type
+class AmazonRedirectUrlType:
+    redirect_url: str
 
 
 @type(AmazonSalesChannel, filters=AmazonSalesChannelFilter, order=AmazonSalesChannelOrder, pagination=True, fields="__all__")

--- a/OneSila/sales_channels/integrations/amazon/urls.py
+++ b/OneSila/sales_channels/integrations/amazon/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+app_name = "amazon"
+
+urlpatterns = [
+    # Placeholder for future Amazon webhooks
+]

--- a/OneSila/sales_channels/integrations/amazon/views.py
+++ b/OneSila/sales_channels/integrations/amazon/views.py
@@ -1,4 +1,9 @@
 from core.views import EmptyTemplateView
 
-# class SomeModelView(EmptyTemplateView):
-#    pass
+
+class AmazonInstalledView(EmptyTemplateView):
+    pass
+
+
+class AmazonEntryView(EmptyTemplateView):
+    pass


### PR DESCRIPTION
## Summary
- implement Amazon OAuth flow with new factories and GraphQL mutations
- extend Amazon sales channel model with state and country fields
- add seller central URL mapping and token endpoint constants
- expose Amazon OAuth entry/callback views
- wire URLs for Amazon integration

## Testing
- `python OneSila/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684056f67ffc832eac701476df590f4d

## Summary by Sourcery

Add full Amazon OAuth integration including GraphQL mutations, model extensions, factories for redirect and token exchange, and URL/view routing for entry and callback flows.

New Features:
- Introduce GraphQL mutations to generate Amazon OAuth consent URLs and validate OAuth responses.
- Implement factories to build redirect URLs and exchange OAuth codes for tokens with Amazon's endpoints.
- Add entry and callback views along with integration detail views for Amazon OAuth

Enhancements:
- Extend AmazonSalesChannel model with unique state and country fields and auto-generate state values.
- Add constants for country-specific Seller Central URLs and define the OAuth token endpoint URL.