### PR TITLE
Add WooCommerce GraphQL schema placeholders

### DIFF
--- a/OneSila/OneSila/schema.py
+++ b/OneSila/OneSila/schema.py
@@ -25,6 +25,8 @@ from sales_channels.integrations.magento2.schema import MagentoSalesChannelMutat
     MagentoSalesChannelsSubscription
 from sales_channels.integrations.shopify.schema import ShopifySalesChannelMutation, ShopifySalesChannelsQuery, \
     ShopifySalesChannelsSubscription
+from sales_channels.integrations.woocommerce.schema import WoocommerceSalesChannelMutation, WoocommerceSalesChannelsQuery, \
+    WoocommerceSalesChannelsSubscription
 from taxes.schema import TaxesQuery, TaxesMutation, TaxSubscription
 from translations.schema import TranslationsQuery
 from integrations.schema import IntegrationsQuery, IntegrationsMutation
@@ -36,24 +38,66 @@ from llm.schema import LlmMutation
 #
 
 @strawberry.type
-class Query(CurrenciesQuery, CountryQuery, EanCodesQuery, IntegrationsQuery,
-        LanguageQuery, LeadTimesQuery, MediaQuery, MultiTenantQuery, MagentoSalesChannelsQuery, ShopifySalesChannelsQuery,
-        ProductsQuery, PropertiesQuery, SalesPricesQuery, SalesChannelsQuery,
-        TaxesQuery, TimeZoneQuery, TranslationsQuery):
+class Query(
+        CurrenciesQuery,
+        CountryQuery,
+        EanCodesQuery,
+        IntegrationsQuery,
+        LanguageQuery,
+        LeadTimesQuery,
+        MediaQuery,
+        MultiTenantQuery,
+        MagentoSalesChannelsQuery,
+        ShopifySalesChannelsQuery,
+        WoocommerceSalesChannelsQuery,
+        ProductsQuery,
+        PropertiesQuery,
+        SalesPricesQuery,
+        SalesChannelsQuery,
+        TaxesQuery,
+        TimeZoneQuery,
+        TranslationsQuery,
+):
     pass
 
 
 @strawberry.type
-class Mutation(CurrenciesMutation, EanCodesMutation, MediaMutation, MultiTenantMutation, ShopifySalesChannelMutation,
-       ProductsInspectorMutation, ProductsMutation, PropertiesMutation, IntegrationsMutation, LlmMutation,
-       SalesPricesMutation, SalesChannelsMutation, MagentoSalesChannelMutation, TaxesMutation):
+class Mutation(
+        CurrenciesMutation,
+        EanCodesMutation,
+        MediaMutation,
+        MultiTenantMutation,
+        ShopifySalesChannelMutation,
+        WoocommerceSalesChannelMutation,
+        ProductsInspectorMutation,
+        ProductsMutation,
+        PropertiesMutation,
+        IntegrationsMutation,
+        LlmMutation,
+        SalesPricesMutation,
+        SalesChannelsMutation,
+        MagentoSalesChannelMutation,
+        TaxesMutation,
+):
     pass
 
 
 @strawberry.type
-class Subscription(CurrenciesSubscription, EanCodesSubscription, MediaSubscription, MultiTenantSubscription,
-        ProductsInspectorSubscription, ProductsSubscription, PropertiesSubscription, SalesPriceSubscription,
-        MagentoSalesChannelsSubscription, SalesChannelsSubscription, TaxSubscription, ShopifySalesChannelsSubscription):
+class Subscription(
+        CurrenciesSubscription,
+        EanCodesSubscription,
+        MediaSubscription,
+        MultiTenantSubscription,
+        ProductsInspectorSubscription,
+        ProductsSubscription,
+        PropertiesSubscription,
+        SalesPriceSubscription,
+        MagentoSalesChannelsSubscription,
+        SalesChannelsSubscription,
+        TaxSubscription,
+        ShopifySalesChannelsSubscription,
+        WoocommerceSalesChannelsSubscription,
+):
     pass
 
 #

--- a/OneSila/sales_channels/integrations/woocommerce/schema/__init__.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/__init__.py
@@ -1,0 +1,3 @@
+from .mutations import WoocommerceSalesChannelMutation
+from .queries import WoocommerceSalesChannelsQuery
+from .subscriptions import WoocommerceSalesChannelsSubscription

--- a/OneSila/sales_channels/integrations/woocommerce/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/mutations.py
@@ -1,0 +1,7 @@
+from core.schema.core.mutations import type
+
+
+@type(name="Mutation")
+class WoocommerceSalesChannelMutation:
+    """Placeholder mutations for WooCommerce sales channels."""
+    pass

--- a/OneSila/sales_channels/integrations/woocommerce/schema/queries.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/queries.py
@@ -1,0 +1,7 @@
+from core.schema.core.queries import type
+
+
+@type(name="Query")
+class WoocommerceSalesChannelsQuery:
+    """Placeholder queries for WooCommerce sales channels."""
+    pass

--- a/OneSila/sales_channels/integrations/woocommerce/schema/subscriptions.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/subscriptions.py
@@ -1,0 +1,7 @@
+from core.schema.core.subscriptions import type
+
+
+@type(name="Subscription")
+class WoocommerceSalesChannelsSubscription:
+    """Placeholder subscriptions for WooCommerce sales channels."""
+    pass


### PR DESCRIPTION
## Summary
- import WooCommerce GraphQL classes in main schema
- expose placeholder WooCommerce query/mutation/subscription classes
- register WooCommerce support in Query, Mutation and Subscription

## Testing
- `pycodestyle OneSila/OneSila/schema.py OneSila/sales_channels/integrations/woocommerce/schema/*.py`
- `python manage.py test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6840da02ddf083229024fb924bbd0ddb

## Summary by Sourcery

Introduce WooCommerce GraphQL schema placeholders and integrate them into the main schema to enable future sales channel support.

New Features:
- Add placeholder GraphQL Query, Mutation, and Subscription classes for WooCommerce sales channels.

Enhancements:
- Import and register WooCommerce placeholder schema classes in the main GraphQL root types (Query, Mutation, Subscription).