### PR TITLE
Add WooCommerce GraphQL schema

### DIFF
--- a/OneSila/sales_channels/integrations/woocommerce/schema/__init__.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/__init__.py
@@ -1,0 +1,3 @@
+from .mutations import WoocommerceSalesChannelMutation
+from .queries import WoocommerceSalesChannelsQuery
+from .subscriptions import WoocommerceSalesChannelsSubscription

--- a/OneSila/sales_channels/integrations/woocommerce/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/mutations.py
@@ -1,0 +1,11 @@
+from sales_channels.integrations.woocommerce.schema.types.input import WoocommerceSalesChannelInput, WoocommerceSalesChannelPartialInput
+from sales_channels.integrations.woocommerce.schema.types.types import WoocommerceSalesChannelType
+from core.schema.core.mutations import create, type, List, update
+
+
+@type(name="Mutation")
+class WoocommerceSalesChannelMutation:
+    create_woocommerce_sales_channel: WoocommerceSalesChannelType = create(WoocommerceSalesChannelInput)
+    create_woocommerce_sales_channels: List[WoocommerceSalesChannelType] = create(WoocommerceSalesChannelInput)
+
+    update_woocommerce_sales_channel: WoocommerceSalesChannelType = update(WoocommerceSalesChannelPartialInput)

--- a/OneSila/sales_channels/integrations/woocommerce/schema/queries.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/queries.py
@@ -1,0 +1,8 @@
+from core.schema.core.queries import node, connection, DjangoListConnection, type
+from sales_channels.integrations.woocommerce.schema.types.types import WoocommerceSalesChannelType
+
+
+@type(name="Query")
+class WoocommerceSalesChannelsQuery:
+    woocommerce_channel: WoocommerceSalesChannelType = node()
+    woocommerce_channels: DjangoListConnection[WoocommerceSalesChannelType] = connection()

--- a/OneSila/sales_channels/integrations/woocommerce/schema/subscriptions.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/subscriptions.py
@@ -1,0 +1,12 @@
+from core.schema.core.subscriptions import type, subscription, Info, AsyncGenerator, model_subscriber
+from sales_channels.integrations.woocommerce.models import WoocommerceSalesChannel
+from sales_channels.integrations.woocommerce.schema.types.types import WoocommerceSalesChannelType
+
+
+@type(name='Subscription')
+class WoocommerceSalesChannelsSubscription:
+
+    @subscription
+    async def woocommerce_channel(self, info: Info, pk: str) -> AsyncGenerator[WoocommerceSalesChannelType, None]:
+        async for i in model_subscriber(info=info, pk=pk, model=WoocommerceSalesChannel):
+            yield i

--- a/OneSila/sales_channels/integrations/woocommerce/schema/types/__init__.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/types/__init__.py
@@ -1,0 +1,12 @@
+from .filters import WoocommerceSalesChannelFilter
+from .ordering import WoocommerceSalesChannelOrder
+from .input import WoocommerceSalesChannelInput, WoocommerceSalesChannelPartialInput
+from .types import WoocommerceSalesChannelType
+
+__all__ = [
+    "WoocommerceSalesChannelFilter",
+    "WoocommerceSalesChannelOrder",
+    "WoocommerceSalesChannelInput",
+    "WoocommerceSalesChannelPartialInput",
+    "WoocommerceSalesChannelType",
+]

--- a/OneSila/sales_channels/integrations/woocommerce/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/types/filters.py
@@ -1,0 +1,9 @@
+from core.schema.core.types.filters import filter, SearchFilterMixin
+from core.schema.core.types.types import auto
+from sales_channels.integrations.woocommerce.models import WoocommerceSalesChannel
+
+
+@filter(WoocommerceSalesChannel)
+class WoocommerceSalesChannelFilter(SearchFilterMixin):
+    active: auto
+    hostname: auto

--- a/OneSila/sales_channels/integrations/woocommerce/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/types/input.py
@@ -1,0 +1,12 @@
+from core.schema.core.types.input import NodeInput, input, partial, strawberry_input
+from sales_channels.integrations.woocommerce.models import WoocommerceSalesChannel
+
+
+@input(WoocommerceSalesChannel, exclude=['integration_ptr', 'saleschannel_ptr'])
+class WoocommerceSalesChannelInput:
+    pass
+
+
+@partial(WoocommerceSalesChannel, fields="__all__")
+class WoocommerceSalesChannelPartialInput(NodeInput):
+    pass

--- a/OneSila/sales_channels/integrations/woocommerce/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/types/ordering.py
@@ -1,0 +1,8 @@
+from core.schema.core.types.ordering import order
+from core.schema.core.types.types import auto
+from sales_channels.integrations.woocommerce.models import WoocommerceSalesChannel
+
+
+@order(WoocommerceSalesChannel)
+class WoocommerceSalesChannelOrder:
+    id: auto

--- a/OneSila/sales_channels/integrations/woocommerce/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/woocommerce/schema/types/types.py
@@ -1,0 +1,16 @@
+from core.schema.core.types.types import relay, type, GetQuerysetMultiTenantMixin, field
+from sales_channels.integrations.woocommerce.models import WoocommerceSalesChannel
+from sales_channels.integrations.woocommerce.schema.types.filters import WoocommerceSalesChannelFilter
+from sales_channels.integrations.woocommerce.schema.types.ordering import WoocommerceSalesChannelOrder
+
+
+@type(WoocommerceSalesChannel, filters=WoocommerceSalesChannelFilter, order=WoocommerceSalesChannelOrder, pagination=True, fields="__all__")
+class WoocommerceSalesChannelType(relay.Node, GetQuerysetMultiTenantMixin):
+
+    @field()
+    def integration_ptr(self, info) -> str:
+        return self.integration_ptr
+
+    @field()
+    def saleschannel_ptr(self, info) -> str:
+        return self.saleschannel_ptr


### PR DESCRIPTION
## Summary
- add WooCommerce sales channel types, queries, mutations and subscriptions
- export new classes in the schema package

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/woocommerce/schema/types/filters.py OneSila/sales_channels/integrations/woocommerce/schema/types/ordering.py OneSila/sales_channels/integrations/woocommerce/schema/types/input.py OneSila/sales_channels/integrations/woocommerce/schema/types/types.py OneSila/sales_channels/integrations/woocommerce/schema/types/__init__.py OneSila/sales_channels/integrations/woocommerce/schema/queries.py OneSila/sales_channels/integrations/woocommerce/schema/mutations.py OneSila/sales_channels/integrations/woocommerce/schema/subscriptions.py OneSila/sales_channels/integrations/woocommerce/schema/__init__.py` *(fails: RPC failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6840d9fe9ddc8322a61e3d5deb98ad0c