### PR TITLE
Add Amazon marketplace pull factories

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/sales_channels/currencies.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sales_channels/currencies.py
@@ -1,0 +1,51 @@
+from sales_channels.factories.mixins import PullRemoteInstanceMixin
+from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
+from sales_channels.integrations.amazon.models import (
+    AmazonCurrency,
+    AmazonSalesChannelView,
+)
+
+
+class AmazonRemoteCurrencyPullFactory(GetAmazonAPIMixin, PullRemoteInstanceMixin):
+    """Pull default currencies for each Amazon marketplace."""
+
+    remote_model_class = AmazonCurrency
+    field_mapping = {
+        'remote_code': 'code',
+    }
+    update_field_mapping = field_mapping
+    get_or_create_fields = ['remote_code', 'sales_channel_view']
+
+    allow_create = True
+    allow_update = True
+    allow_delete = False
+    is_model_response = False
+
+    def fetch_remote_instances(self):
+        marketplaces = self.get_marketplaces()
+        self.remote_instances = [
+            {
+                'code': mp['marketplace']['default_currency_code'],
+                'view_remote_id': mp['marketplace']['id'],
+            }
+            for mp in marketplaces
+            if mp.get('participation', {}).get('is_participating')
+        ]
+
+    def update_get_or_create_lookup(self, lookup, remote_data):
+        view = AmazonSalesChannelView.objects.filter(
+            remote_id=remote_data['view_remote_id'],
+            sales_channel=self.sales_channel,
+        ).first()
+        lookup['sales_channel_view'] = view
+        return lookup
+
+    def create_remote_instance_mirror(self, remote_data, remote_instance_mirror):
+        remote_instance_mirror.remote_code = remote_data['code']
+        remote_instance_mirror.sales_channel = self.sales_channel
+        remote_instance_mirror.multi_tenant_company = self.sales_channel.multi_tenant_company
+        remote_instance_mirror.sales_channel_view = AmazonSalesChannelView.objects.filter(
+            remote_id=remote_data['view_remote_id'],
+            sales_channel=self.sales_channel,
+        ).first()
+        remote_instance_mirror.save()

--- a/OneSila/sales_channels/integrations/amazon/factories/sales_channels/languages.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sales_channels/languages.py
@@ -1,0 +1,51 @@
+from sales_channels.factories.mixins import PullRemoteInstanceMixin
+from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
+from sales_channels.integrations.amazon.models import (
+    AmazonRemoteLanguage,
+    AmazonSalesChannelView,
+)
+
+
+class AmazonRemoteLanguagePullFactory(GetAmazonAPIMixin, PullRemoteInstanceMixin):
+    """Pull default languages for each Amazon marketplace."""
+
+    remote_model_class = AmazonRemoteLanguage
+    field_mapping = {
+        'remote_code': 'code',
+    }
+    update_field_mapping = field_mapping
+    get_or_create_fields = ['remote_code', 'sales_channel_view']
+
+    allow_create = True
+    allow_update = True
+    allow_delete = False
+    is_model_response = False
+
+    def fetch_remote_instances(self):
+        marketplaces = self.get_marketplaces()
+        self.remote_instances = [
+            {
+                'code': mp['marketplace']['default_language_code'],
+                'view_remote_id': mp['marketplace']['id'],
+            }
+            for mp in marketplaces
+            if mp.get('participation', {}).get('is_participating')
+        ]
+
+    def update_get_or_create_lookup(self, lookup, remote_data):
+        view = AmazonSalesChannelView.objects.filter(
+            remote_id=remote_data['view_remote_id'],
+            sales_channel=self.sales_channel,
+        ).first()
+        lookup['sales_channel_view'] = view
+        return lookup
+
+    def create_remote_instance_mirror(self, remote_data, remote_instance_mirror):
+        remote_instance_mirror.remote_code = remote_data['code']
+        remote_instance_mirror.sales_channel = self.sales_channel
+        remote_instance_mirror.multi_tenant_company = self.sales_channel.multi_tenant_company
+        remote_instance_mirror.sales_channel_view = AmazonSalesChannelView.objects.filter(
+            remote_id=remote_data['view_remote_id'],
+            sales_channel=self.sales_channel,
+        ).first()
+        remote_instance_mirror.save()

--- a/OneSila/sales_channels/integrations/amazon/factories/sales_channels/views.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sales_channels/views.py
@@ -1,0 +1,42 @@
+from sales_channels.factories.mixins import PullRemoteInstanceMixin
+from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
+from sales_channels.integrations.amazon.models import AmazonSalesChannelView
+
+
+class AmazonSalesChannelViewPullFactory(GetAmazonAPIMixin, PullRemoteInstanceMixin):
+    """Pull Amazon marketplaces as sales channel views."""
+
+    remote_model_class = AmazonSalesChannelView
+    field_mapping = {
+        'remote_id': 'id',
+        'url': 'domain_name',
+    }
+    update_field_mapping = field_mapping
+    get_or_create_fields = ['remote_id']
+
+    allow_create = True
+    allow_update = True
+    allow_delete = False
+    is_model_response = False
+
+    def fetch_remote_instances(self):
+        marketplaces = self.get_marketplaces()
+        self.remote_instances = [
+            {
+                'id': mp['marketplace']['id'],
+                'name': mp['marketplace']['name'],
+                'country_code': mp['marketplace']['country_code'],
+                'domain_name': mp['marketplace']['domain_name'],
+            }
+            for mp in marketplaces
+            if mp.get('participation', {}).get('is_participating')
+        ]
+
+    def serialize_response(self, response):
+        return response
+
+    def process_remote_instance(self, remote_data, remote_instance_mirror, created):
+        name = f"{remote_data['name']} ({remote_data['country_code']})"
+        if remote_instance_mirror.name != name:
+            remote_instance_mirror.name = name
+            remote_instance_mirror.save(update_fields=['name'])

--- a/OneSila/sales_channels/integrations/amazon/migrations/0006_amazon_language_currency_view_fk.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0006_amazon_language_currency_view_fk.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0005_remove_amazoncurrency_is_default'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='amazonremotelanguage',
+            name='sales_channel_view',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='remote_languages',
+                help_text='The marketplace associated with this remote language.',
+                to='amazon.amazonsaleschannelview',
+            ),
+        ),
+        migrations.AddField(
+            model_name='amazoncurrency',
+            name='sales_channel_view',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='remote_currencies',
+                help_text='The marketplace associated with this remote currency.',
+                to='amazon.amazonsaleschannelview',
+            ),
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/sales_channels.py
+++ b/OneSila/sales_channels/integrations/amazon/models/sales_channels.py
@@ -109,5 +109,13 @@ class AmazonSalesChannelView(SalesChannelView):
 
 
 class AmazonRemoteLanguage(RemoteLanguage):
-    """Amazon remote language placeholder."""
-    pass
+    """Amazon remote language linked to a marketplace."""
+
+    sales_channel_view = models.ForeignKey(
+        AmazonSalesChannelView,
+        on_delete=models.CASCADE,
+        related_name='remote_languages',
+        null=True,
+        blank=True,
+        help_text="The marketplace associated with this remote language.",
+    )

--- a/OneSila/sales_channels/integrations/amazon/models/taxes.py
+++ b/OneSila/sales_channels/integrations/amazon/models/taxes.py
@@ -3,8 +3,16 @@ from core import models
 
 
 class AmazonCurrency(RemoteCurrency):
-    """Amazon remote currency."""
-    pass
+    """Amazon remote currency linked to a marketplace."""
+
+    sales_channel_view = models.ForeignKey(
+        'amazon.AmazonSalesChannelView',
+        on_delete=models.CASCADE,
+        related_name='remote_currencies',
+        null=True,
+        blank=True,
+        help_text="The marketplace associated with this remote currency.",
+    )
 
 class AmazonVat(RemoteVat):
     """Amazon remote VAT."""

--- a/OneSila/sales_channels/integrations/amazon/receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/receivers.py
@@ -1,6 +1,39 @@
 from core.receivers import receiver
 from core.signals import post_create, post_update
+from sales_channels.signals import refresh_website_pull_models, sales_channel_created
+from sales_channels.integrations.amazon.models import AmazonSalesChannel
 
+
+@receiver(refresh_website_pull_models, sender='sales_channels.SalesChannel')
+@receiver(sales_channel_created, sender='sales_channels.SalesChannel')
+@receiver(refresh_website_pull_models, sender='amazon.AmazonSalesChannel')
+@receiver(sales_channel_created, sender='amazon.AmazonSalesChannel')
+def sales_channels__amazon__handle_pull_views(sender, instance, **kwargs):
+    from sales_channels.integrations.amazon.factories.sales_channels.views import (
+        AmazonSalesChannelViewPullFactory,
+    )
+    from sales_channels.integrations.amazon.factories.sales_channels.languages import (
+        AmazonRemoteLanguagePullFactory,
+    )
+    from sales_channels.integrations.amazon.factories.sales_channels.currencies import (
+        AmazonRemoteCurrencyPullFactory,
+    )
+
+    if not isinstance(instance.get_real_instance(), AmazonSalesChannel):
+        return
+    if not instance.refresh_token:
+        return
+
+    views_factory = AmazonSalesChannelViewPullFactory(sales_channel=instance)
+    views_factory.run()
+
+    languages_factory = AmazonRemoteLanguagePullFactory(sales_channel=instance)
+    languages_factory.run()
+
+    currencies_factory = AmazonRemoteCurrencyPullFactory(sales_channel=instance)
+    currencies_factory.run()
+
+# Example placeholder for future signal handlers
 # @receiver(post_update, sender='app_name.Model')
 # def app_name__model__action__example(sender, instance, **kwargs):
 #     do_something()


### PR DESCRIPTION
## Summary
- implement marketplace sync via `AmazonSalesChannelViewPullFactory`
- pull languages and currencies for each Amazon marketplace
- link Amazon languages and currencies to sales channel views
- add migration for new foreign keys
- trigger pull on channel refresh via receiver

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6841bc4f08fc832e87bd92507a7c10fd

## Summary by Sourcery

Add end-to-end support for syncing Amazon marketplaces by introducing pull factories for views, languages, and currencies, linking pulled data to sales channel views, and running the sync automatically on channel creation or refresh.

New Features:
- Add factories to pull Amazon marketplace views, languages, and currencies
- Trigger Amazon marketplace data sync on sales channel creation and refresh via a new signal handler

Enhancements:
- Link AmazonRemoteLanguage and AmazonCurrency models to their respective AmazonSalesChannelView via new foreign keys
- Add a migration to add sales_channel_view foreign keys on AmazonRemoteLanguage and AmazonCurrency models