### PR TITLE
Enable WooCommerce sales channel imports

### DIFF
--- a/OneSila/sales_channels/integrations/woocommerce/tasks.py
+++ b/OneSila/sales_channels/integrations/woocommerce/tasks.py
@@ -388,8 +388,15 @@ def delete_woocommerce_product_db_task(task_queue_item_id, sales_channel_id, rem
 
 @remote_task(priority=LOW_PRIORITY)
 @db_task()
-def woocommerce_import_db_task(import_process, sales_channel_id):
-    pass
+def woocommerce_import_db_task(import_process, sales_channel):
+    """Run the WooCommerce import process for the given sales channel."""
+    from .factories.imports import WoocommerceProductImportProcessor
+
+    fac = WoocommerceProductImportProcessor(
+        import_process=import_process,
+        sales_channel=sales_channel,
+    )
+    fac.run()
 
 
 @periodic_task(crontab(minute=0, hour=2))

--- a/OneSila/sales_channels/receivers.py
+++ b/OneSila/sales_channels/receivers.py
@@ -2,7 +2,7 @@ from django.db.models.signals import post_delete, pre_delete, pre_save
 
 from core.decorators import trigger_signal_for_dirty_fields
 from core.schema.core.subscriptions import refresh_subscription_receiver
-from core.signals import post_create, post_update, mutation_update
+from core.signals import post_create, post_update, mutation_update, post_save
 from eancodes.signals import ean_code_released_for_product
 from inventory.models import Inventory
 from media.models import Media
@@ -31,6 +31,10 @@ from properties.models import Property, PropertyTranslation, PropertySelectValue
     ProductPropertyTextTranslation
 
 
+import logging
+logger = logging.getLogger(__name__)
+
+
 @receiver(post_update, sender=SalesChannelImport)
 def import_process_post_update_fist_import_complete_receiver(sender, instance: SalesChannelImport, **kwargs):
 
@@ -57,11 +61,22 @@ def import_process_avoid_duplicate_pre_create_receiver(sender, instance: SalesCh
 
 @receiver(post_create, sender=SalesChannelImport)
 def import_process_ashopify_post_create_receiver(sender, instance: SalesChannelImport, **kwargs):
+    """
+    This receiver is used to handle the post_create signal for the SalesChannelImport model.
+    It is used to trigger the import process for the sales channel upon creation.
+
+    A few things you need to know:
+    - new integrations need to be added here.
+    - also add the declaration on post_update: import_process_post_update_receiver
+    """
     from sales_channels.integrations.shopify.models.sales_channels import ShopifySalesChannel
     from sales_channels.integrations.shopify.tasks import shopify_import_db_task
     from sales_channels.integrations.woocommerce.models import WoocommerceSalesChannel
     from sales_channels.integrations.woocommerce.tasks import woocommerce_import_db_task
 
+    # NOTE: Magento does not trigger after creation.  The import flow will first set
+    # some settings (possibly property stuff) and manually triggger the import via the status.
+    # all other import integrations need to be declared here.
     sales_channel = instance.sales_channel.get_real_instance()
     if isinstance(sales_channel, ShopifySalesChannel):
         refresh_subscription_receiver(sales_channel)
@@ -69,11 +84,22 @@ def import_process_ashopify_post_create_receiver(sender, instance: SalesChannelI
     elif isinstance(sales_channel, WoocommerceSalesChannel):
         refresh_subscription_receiver(sales_channel)
         woocommerce_import_db_task(import_process=instance, sales_channel=sales_channel)
+    else:
+        logger.warning(f"Sales channel {type(sales_channel)} is not supported in post_create.")
 
 
 @receiver(post_update, sender=SalesChannelImport)
 @trigger_signal_for_dirty_fields('status')
 def import_process_post_update_receiver(sender, instance: SalesChannelImport, **kwargs):
+    """
+    This receiver is used to handle the post_update signal for the SalesChannelImport model.
+    It is used to trigger the import process for the sales channel.
+
+    A few things you need to know:
+    - new integrations need to be added here.
+    - these models have dirty-save. So just re-saving in the backend when someting doesnt trigger wont work.
+    - also add the declaration on post-create import_process_ashopify_post_create_receiver()
+    """
     from sales_channels.integrations.magento2.models import MagentoSalesChannel
     from sales_channels.integrations.magento2.tasks import magento_import_db_task
     from sales_channels.integrations.shopify.models.sales_channels import ShopifySalesChannel
@@ -83,7 +109,6 @@ def import_process_post_update_receiver(sender, instance: SalesChannelImport, **
 
     sales_channel = instance.sales_channel.get_real_instance()
     if instance.status == SalesChannelImport.STATUS_PENDING:
-
         if isinstance(sales_channel, MagentoSalesChannel):
             magento_import_db_task(import_process=instance, sales_channel=sales_channel)
         elif isinstance(sales_channel, ShopifySalesChannel):
@@ -91,7 +116,7 @@ def import_process_post_update_receiver(sender, instance: SalesChannelImport, **
         elif isinstance(sales_channel, WoocommerceSalesChannel):
             woocommerce_import_db_task(import_process=instance, sales_channel=sales_channel)
         else:
-            raise NotImplementedError(f"Sales channel {type(sales_channel)} is not supported")
+            logger.warning(f"Sales channel {type(sales_channel)} is not supported in post_update.")
 
 
 @receiver(post_update, sender=SalesChannelImport)

--- a/OneSila/sales_channels/receivers.py
+++ b/OneSila/sales_channels/receivers.py
@@ -59,12 +59,16 @@ def import_process_avoid_duplicate_pre_create_receiver(sender, instance: SalesCh
 def import_process_ashopify_post_create_receiver(sender, instance: SalesChannelImport, **kwargs):
     from sales_channels.integrations.shopify.models.sales_channels import ShopifySalesChannel
     from sales_channels.integrations.shopify.tasks import shopify_import_db_task
+    from sales_channels.integrations.woocommerce.models import WoocommerceSalesChannel
+    from sales_channels.integrations.woocommerce.tasks import woocommerce_import_db_task
 
     sales_channel = instance.sales_channel.get_real_instance()
     if isinstance(sales_channel, ShopifySalesChannel):
         refresh_subscription_receiver(sales_channel)
-
         shopify_import_db_task(import_process=instance, sales_channel=sales_channel)
+    elif isinstance(sales_channel, WoocommerceSalesChannel):
+        refresh_subscription_receiver(sales_channel)
+        woocommerce_import_db_task(import_process=instance, sales_channel=sales_channel)
 
 
 @receiver(post_update, sender=SalesChannelImport)
@@ -74,6 +78,8 @@ def import_process_post_update_receiver(sender, instance: SalesChannelImport, **
     from sales_channels.integrations.magento2.tasks import magento_import_db_task
     from sales_channels.integrations.shopify.models.sales_channels import ShopifySalesChannel
     from sales_channels.integrations.shopify.tasks import shopify_import_db_task
+    from sales_channels.integrations.woocommerce.models import WoocommerceSalesChannel
+    from sales_channels.integrations.woocommerce.tasks import woocommerce_import_db_task
 
     sales_channel = instance.sales_channel.get_real_instance()
     if instance.status == SalesChannelImport.STATUS_PENDING:
@@ -82,6 +88,8 @@ def import_process_post_update_receiver(sender, instance: SalesChannelImport, **
             magento_import_db_task(import_process=instance, sales_channel=sales_channel)
         elif isinstance(sales_channel, ShopifySalesChannel):
             shopify_import_db_task(import_process=instance, sales_channel=sales_channel)
+        elif isinstance(sales_channel, WoocommerceSalesChannel):
+            woocommerce_import_db_task(import_process=instance, sales_channel=sales_channel)
         else:
             raise NotImplementedError(f"Sales channel {type(sales_channel)} is not supported")
 


### PR DESCRIPTION
## Summary
- implement `woocommerce_import_db_task`
- trigger WooCommerce imports on SalesChannelImport events

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/woocommerce/tasks.py OneSila/sales_channels/receivers.py` *(fails: HTTP 403 fetching pre-commit hooks)*
- `./run_tests_locally.sh sales_channels.integrations.woocommerce.tests.tests_factories.tests_imports.TestWoocommerceProductImportProcessor.test_woocommerce_import_product` *(fails: OperationalError connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6841efad9b008322bb1a177328907a18

## Summary by Sourcery

Enable WooCommerce sales channel imports by implementing the import database task and wiring it into SalesChannelImport event receivers.

New Features:
- Add woocommerce_import_db_task to execute the WooCommerce product import processor.

Enhancements:
- Invoke woocommerce_import_db_task in post-create and post-update receivers for WooCommerce sales channels.