### PR TITLE
Add create-only mode for imports

### DIFF
--- a/OneSila/imports_exports/migrations/0008_typedimport_create_only.py
+++ b/OneSila/imports_exports/migrations/0008_typedimport_create_only.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('imports_exports', '0007_typedimport_type'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='typedimport',
+            name='create_only',
+            field=models.BooleanField(default=False, help_text='If True, existing objects fetched during the import will not be updated.'),
+        ),
+    ]

--- a/OneSila/imports_exports/models.py
+++ b/OneSila/imports_exports/models.py
@@ -144,6 +144,10 @@ class TypedImport(Import):
         blank=True,
         help_text="Language context for imported records (e.g., en, de, fr)."
     )
+    create_only = models.BooleanField(
+        default=False,
+        help_text="If True, existing objects fetched during the import will not be updated.",
+    )
 
     def should_run(self) -> bool:
         if not self.is_periodic or not self.interval_hours:


### PR DESCRIPTION
## Summary
- add `create_only` flag to TypedImport model
- propagate flag through import instances
- skip updates and post-processing when `create_only` is active
- create migration for new field

## Testing
- `coverage run --source='.' manage.py test` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68471c3cdc68832e95d7bf06db90c7c2

## Summary by Sourcery

Add a create-only import mode that prevents updates and post-processing on existing records by introducing and propagating a `create_only` flag through TypedImport and factory mixins.

New Features:
- Add `create_only` BooleanField to TypedImport to disable updates of existing objects
- Create a migration to add the `create_only` field to the database

Enhancements:
- Propagate `create_only` flag through import instances and factory mixins
- Skip post-processing, update operations, translation updates, and mirror data creation when `create_only` is active