### PR TITLE
Add AmazonProductType GraphQL queries

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -3,6 +3,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonSalesChannelType,
     AmazonPropertyType,
     AmazonPropertySelectValueType,
+    AmazonProductTypeType,
 )
 
 
@@ -16,3 +17,6 @@ class AmazonSalesChannelsQuery:
 
     amazon_property_select_value: AmazonPropertySelectValueType = node()
     amazon_property_select_values: DjangoListConnection[AmazonPropertySelectValueType] = connection()
+
+    amazon_product_type: AmazonProductTypeType = node()
+    amazon_product_types: DjangoListConnection[AmazonProductTypeType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -4,6 +4,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
     AmazonProperty,
     AmazonPropertySelectValue,
+    AmazonProductType,
 )
 
 
@@ -20,4 +21,9 @@ class AmazonPropertyFilter(SearchFilterMixin):
 
 @filter(AmazonPropertySelectValue)
 class AmazonPropertySelectValueFilter(SearchFilterMixin):
+    pass
+
+
+@filter(AmazonProductType)
+class AmazonProductTypeFilter(SearchFilterMixin):
     pass

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -4,6 +4,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
     AmazonProperty,
     AmazonPropertySelectValue,
+    AmazonProductType,
 )
 
 
@@ -19,4 +20,9 @@ class AmazonPropertyOrder:
 
 @order(AmazonPropertySelectValue)
 class AmazonPropertySelectValueOrder:
+    id: auto
+
+
+@order(AmazonProductType)
+class AmazonProductTypeOrder:
     id: auto

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -3,16 +3,19 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
     AmazonProperty,
     AmazonPropertySelectValue,
+    AmazonProductType,
 )
 from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonSalesChannelFilter,
     AmazonPropertyFilter,
     AmazonPropertySelectValueFilter,
+    AmazonProductTypeFilter,
 )
 from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonSalesChannelOrder,
     AmazonPropertyOrder,
     AmazonPropertySelectValueOrder,
+    AmazonProductTypeOrder,
 )
 
 
@@ -52,4 +55,15 @@ class AmazonPropertyType(relay.Node, GetQuerysetMultiTenantMixin):
     fields="__all__",
 )
 class AmazonPropertySelectValueType(relay.Node, GetQuerysetMultiTenantMixin):
+    pass
+
+
+@type(
+    AmazonProductType,
+    filters=AmazonProductTypeFilter,
+    order=AmazonProductTypeOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonProductTypeType(relay.Node, GetQuerysetMultiTenantMixin):
     pass


### PR DESCRIPTION
## Summary
- add `AmazonProductType` support to the Amazon integration
- expose filtering and ordering helpers for this model
- allow querying single and list of product types

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/schema/queries.py OneSila/sales_channels/integrations/amazon/schema/types/filters.py OneSila/sales_channels/integrations/amazon/schema/types/ordering.py OneSila/sales_channels/integrations/amazon/schema/types/types.py`
- `python OneSila/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6851450d0d18832e83d42e52c3ec6d3a

## Summary by Sourcery

Add AmazonProductType to the Amazon GraphQL integration, including type definition, filter and order helpers, and query fields for both single and list operations.

New Features:
- Define AmazonProductType GraphQL node with full field support, pagination, filtering, and ordering
- Expose amazon_product_type and amazon_product_types GraphQL queries for single and list retrieval