### PR TITLE
Add mapping manager and filters for Amazon models

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/managers.py
+++ b/OneSila/sales_channels/integrations/amazon/managers.py
@@ -1,0 +1,66 @@
+from core.managers import MultiTenantManager, MultiTenantQuerySet
+from django.db.models import BooleanField, Case, Value, When
+from polymorphic.managers import PolymorphicManager, PolymorphicQuerySet
+
+
+class _MappingQuerySetMixin:
+    mapped_field: str
+
+    def annotate_mapping(self):
+        return self.annotate(
+            mapped_locally=Case(
+                When(local_instance__isnull=False, then=Value(True)),
+                default=Value(False),
+                output_field=BooleanField(),
+            ),
+            mapped_remotely=Case(
+                When(**{f"{self.mapped_field}__isnull": False}, then=Value(True)),
+                When(**{f"{self.mapped_field}__exact": ""}, then=Value(False)),
+                default=Value(False),
+                output_field=BooleanField(),
+            ),
+        )
+
+    def filter_mapped_locally(self, value: bool = True):
+        return self.annotate_mapping().filter(mapped_locally=value)
+
+    def filter_mapped_remotely(self, value: bool = True):
+        return self.annotate_mapping().filter(mapped_remotely=value)
+
+
+class AmazonPropertyQuerySet(_MappingQuerySetMixin, PolymorphicQuerySet, MultiTenantQuerySet):
+    mapped_field = "code"
+
+
+class AmazonPropertySelectValueQuerySet(_MappingQuerySetMixin, MultiTenantQuerySet):
+    mapped_field = "remote_value"
+
+
+class AmazonProductTypeQuerySet(_MappingQuerySetMixin, MultiTenantQuerySet):
+    mapped_field = "product_type_code"
+
+
+class _MappingManagerMixin:
+    queryset_class = None
+
+    def get_queryset(self):
+        return self.queryset_class(self.model, using=self._db).annotate_mapping()
+
+    def filter_mapped_locally(self, value: bool = True):
+        return self.get_queryset().filter_mapped_locally(value)
+
+    def filter_mapped_remotely(self, value: bool = True):
+        return self.get_queryset().filter_mapped_remotely(value)
+
+
+class AmazonPropertyManager(_MappingManagerMixin, PolymorphicManager, MultiTenantManager):
+    queryset_class = AmazonPropertyQuerySet
+
+
+class AmazonPropertySelectValueManager(_MappingManagerMixin, MultiTenantManager):
+    queryset_class = AmazonPropertySelectValueQuerySet
+
+
+class AmazonProductTypeManager(_MappingManagerMixin, MultiTenantManager):
+    queryset_class = AmazonProductTypeQuerySet
+

--- a/OneSila/sales_channels/integrations/amazon/models/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/models/properties.py
@@ -7,6 +7,11 @@ from sales_channels.models.properties import (
     RemotePropertySelectValue,
     RemoteProductProperty,
 )
+from sales_channels.integrations.amazon.managers import (
+    AmazonPropertyManager,
+    AmazonPropertySelectValueManager,
+    AmazonProductTypeManager,
+)
 from core import models
 from django.utils.translation import gettext_lazy as _
 from datetime import timedelta
@@ -89,6 +94,8 @@ class AmazonProperty(RemoteProperty):
     allows_unmapped_values = models.BooleanField(default=False)
     type  = models.CharField(max_length=16, choices=Property.TYPES.ALL, default=Property.TYPES.TEXT)
 
+    objects = AmazonPropertyManager()
+
     class Meta:
         verbose_name = 'Amazon Property'
         verbose_name_plural = 'Amazon Properties'
@@ -125,6 +132,8 @@ class AmazonPropertySelectValue(RemoteObjectMixin, models.Model):
         on_delete=models.SET_NULL,
         help_text="Optional link to local PropertySelectValue."
     )
+
+    objects = AmazonPropertySelectValueManager()
 
     class Meta:
         unique_together = ('amazon_property', 'marketplace', 'remote_value')
@@ -165,6 +174,8 @@ class AmazonProductType(RemoteObjectMixin, models.Model):
         help_text="Display name for the Amazon product type (e.g., 'Toys & Games').",
         verbose_name="Remote Name"
     )
+
+    objects = AmazonProductTypeManager()
 
     class Meta:
         unique_together = ('local_instance', 'sales_channel')

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -1,4 +1,8 @@
 from core.schema.core.types.filters import filter, SearchFilterMixin
+from strawberry_django import filter_field as custom_filter
+from django.db.models import Q
+from strawberry import UNSET
+from core.managers import QuerySet
 from core.schema.core.types.types import auto
 from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
@@ -16,14 +20,45 @@ class AmazonSalesChannelFilter(SearchFilterMixin):
 
 @filter(AmazonProperty)
 class AmazonPropertyFilter(SearchFilterMixin):
-    pass
+    @custom_filter
+    def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
+        if value not in (None, UNSET):
+            queryset = queryset.filter_mapped_locally(value)
+        return queryset, Q()
+
+    @custom_filter
+    def mapped_remotely(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
+        if value not in (None, UNSET):
+            queryset = queryset.filter_mapped_remotely(value)
+        return queryset, Q()
 
 
 @filter(AmazonPropertySelectValue)
 class AmazonPropertySelectValueFilter(SearchFilterMixin):
-    pass
+    @custom_filter
+    def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
+        if value not in (None, UNSET):
+            queryset = queryset.filter_mapped_locally(value)
+        return queryset, Q()
+
+    @custom_filter
+    def mapped_remotely(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
+        if value not in (None, UNSET):
+            queryset = queryset.filter_mapped_remotely(value)
+        return queryset, Q()
 
 
 @filter(AmazonProductType)
 class AmazonProductTypeFilter(SearchFilterMixin):
-    pass
+    @custom_filter
+    def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
+        if value not in (None, UNSET):
+            queryset = queryset.filter_mapped_locally(value)
+        return queryset, Q()
+
+    @custom_filter
+    def mapped_remotely(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
+        if value not in (None, UNSET):
+            queryset = queryset.filter_mapped_remotely(value)
+        return queryset, Q()
+

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -44,7 +44,13 @@ class AmazonSalesChannelType(relay.Node, GetQuerysetMultiTenantMixin):
     fields="__all__",
 )
 class AmazonPropertyType(relay.Node, GetQuerysetMultiTenantMixin):
-    pass
+    @field()
+    def mapped_locally(self, info) -> bool:
+        return self.mapped_locally
+
+    @field()
+    def mapped_remotely(self, info) -> bool:
+        return self.mapped_remotely
 
 
 @type(
@@ -55,7 +61,13 @@ class AmazonPropertyType(relay.Node, GetQuerysetMultiTenantMixin):
     fields="__all__",
 )
 class AmazonPropertySelectValueType(relay.Node, GetQuerysetMultiTenantMixin):
-    pass
+    @field()
+    def mapped_locally(self, info) -> bool:
+        return self.mapped_locally
+
+    @field()
+    def mapped_remotely(self, info) -> bool:
+        return self.mapped_remotely
 
 
 @type(
@@ -66,4 +78,11 @@ class AmazonPropertySelectValueType(relay.Node, GetQuerysetMultiTenantMixin):
     fields="__all__",
 )
 class AmazonProductTypeType(relay.Node, GetQuerysetMultiTenantMixin):
-    pass
+    @field()
+    def mapped_locally(self, info) -> bool:
+        return self.mapped_locally
+
+    @field()
+    def mapped_remotely(self, info) -> bool:
+        return self.mapped_remotely
+


### PR DESCRIPTION
## Summary
- add custom queryset and manager for Amazon mapping info
- expose mapping status via GraphQL fields
- add custom GraphQL filters for mapping flags

## Testing
- `pip install -q -r ../requirements.txt`
- `python manage.py test` *(fails: connection to postgres refused)*

------
https://chatgpt.com/codex/tasks/task_e_68514af0caf8832ea2a664601edd13e3

## Summary by Sourcery

Introduce mapping status management for Amazon integration by adding specialized managers to annotate and filter mapping flags on Amazon models and exposing these mapping flags as GraphQL fields and filters.

New Features:
- Add custom querysets and managers to annotate and filter AmazonProperty, AmazonPropertySelectValue, and AmazonProductType by mapped_locally and mapped_remotely.
- Expose mapped_locally and mapped_remotely fields in the GraphQL schema for Amazon property, select value, and product type types.
- Add custom GraphQL filters for mapped_locally and mapped_remotely on AmazonPropertyFilter, AmazonPropertySelectValueFilter, and AmazonProductTypeFilter.