### PR TITLE
Add AmazonProductType mutations

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -7,19 +7,15 @@ from sales_channels.integrations.amazon.schema.types.input import (
     AmazonPropertyPartialInput,
     AmazonPropertySelectValueInput,
     AmazonPropertySelectValuePartialInput,
+    AmazonProductTypeInput,
+    AmazonProductTypePartialInput,
+    AmazonValidateAuthInput,
 )
 from sales_channels.integrations.amazon.schema.types.types import (
     AmazonSalesChannelType,
     AmazonPropertyType,
     AmazonPropertySelectValueType,
-)
-from sales_channels.integrations.amazon.schema.types.input import (
-    AmazonSalesChannelInput,
-    AmazonSalesChannelPartialInput,
-    AmazonValidateAuthInput,
-)
-from sales_channels.integrations.amazon.schema.types.types import (
-    AmazonSalesChannelType,
+    AmazonProductTypeType,
     AmazonRedirectUrlType,
 )
 from core.schema.core.mutations import create, type, List, update
@@ -82,3 +78,7 @@ class AmazonSalesChannelMutation:
     create_amazon_property_select_value: AmazonPropertySelectValueType = create(AmazonPropertySelectValueInput)
     create_amazon_property_select_values: List[AmazonPropertySelectValueType] = create(AmazonPropertySelectValueInput)
     update_amazon_property_select_value: AmazonPropertySelectValueType = update(AmazonPropertySelectValuePartialInput)
+
+    create_amazon_product_type: AmazonProductTypeType = create(AmazonProductTypeInput)
+    create_amazon_product_types: List[AmazonProductTypeType] = create(AmazonProductTypeInput)
+    update_amazon_product_type: AmazonProductTypeType = update(AmazonProductTypePartialInput)

--- a/OneSila/sales_channels/integrations/amazon/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/input.py
@@ -3,6 +3,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
     AmazonProperty,
     AmazonPropertySelectValue,
+    AmazonProductType,
 )
 
 
@@ -41,3 +42,13 @@ class AmazonValidateAuthInput:
     spapi_oauth_code: str
     selling_partner_id: str
     state: str
+
+
+@input(AmazonProductType, fields="__all__")
+class AmazonProductTypeInput:
+    pass
+
+
+@partial(AmazonProductType, fields="__all__")
+class AmazonProductTypePartialInput(NodeInput):
+    pass


### PR DESCRIPTION
## Summary
- support AmazonProductType create and update mutations
- expose inputs for AmazonProductType

## Testing
- `python OneSila/manage.py test -v 0`

------
https://chatgpt.com/codex/tasks/task_e_68515bf76510832e8a0676670fab2c92

## Summary by Sourcery

Add GraphQL inputs and mutations to enable creating and updating AmazonProductType in the Amazon integration.

New Features:
- Expose AmazonProductTypeInput and AmazonProductTypePartialInput to the GraphQL schema
- Add create and bulk-create mutations for AmazonProductType
- Add update mutation for AmazonProductType