### PR TITLE
Add Amazon schema filters and search terms

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/models/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/models/properties.py
@@ -17,6 +17,7 @@ from django.utils.translation import gettext_lazy as _
 from datetime import timedelta
 from django.utils import timezone
 
+
 class AmazonPublicDefinition(models.SharedModel):
     """
     Canonical, tenant-agnostic description of *one attribute key* of ONE
@@ -31,23 +32,23 @@ class AmazonPublicDefinition(models.SharedModel):
     """
 
     # ------------- identity -------------
-    api_region_code   = models.CharField(max_length=8)          # "EU_DE"
+    api_region_code = models.CharField(max_length=8)          # "EU_DE"
     product_type_code = models.CharField(max_length=64)         # "AIR_PURIFIER"
-    code              = models.CharField(max_length=128)        # "color"  or "battery__cell_composition"
+    code = models.CharField(max_length=128)        # "color"  or "battery__cell_composition"
 
     # ------------- display -------------
-    name  = models.CharField(max_length=255)
+    name = models.CharField(max_length=255)
     raw_schema = models.JSONField(blank=True, null=True)        # the slice of Amazon schema for this property
 
     # ------------- rendering / encoding -------------
-    usage_definition   = models.TextField(
+    usage_definition = models.TextField(
         help_text=(
             "Template for rendering this attribute into SP-API payload.\n"
             "Tokens: %value%, %unit:weight%, %key:battery__cell_composition%, "
             "%marketplace_id%, %language_tag%"
         )
     )
-    export_definition  = models.JSONField(blank=True, null=True)
+    export_definition = models.JSONField(blank=True, null=True)
 
     last_fetched = models.DateTimeField(null=True, blank=True)
 
@@ -92,13 +93,14 @@ class AmazonProperty(RemoteProperty):
     )
 
     allows_unmapped_values = models.BooleanField(default=False)
-    type  = models.CharField(max_length=16, choices=Property.TYPES.ALL, default=Property.TYPES.TEXT)
+    type = models.CharField(max_length=16, choices=Property.TYPES.ALL, default=Property.TYPES.TEXT)
 
     objects = AmazonPropertyManager()
 
     class Meta:
         verbose_name = 'Amazon Property'
         verbose_name_plural = 'Amazon Properties'
+        search_terms = ['name', 'code']
 
 
 class AmazonPropertySelectValue(RemoteObjectMixin, models.Model):
@@ -137,10 +139,15 @@ class AmazonPropertySelectValue(RemoteObjectMixin, models.Model):
 
     class Meta:
         unique_together = ('amazon_property', 'marketplace', 'remote_value')
+        search_terms = [
+            'remote_name',
+            'remote_value',
+            'amazon_property__name',
+            'amazon_property__code',
+        ]
 
     def __str__(self):
         return f"{self.remote_name or self.remote_value} ({self.marketplace})"
-
 
 
 class AmazonProductProperty(RemoteProductProperty):
@@ -181,6 +188,7 @@ class AmazonProductType(RemoteObjectMixin, models.Model):
         unique_together = ('local_instance', 'sales_channel')
         verbose_name = 'Amazon Product Type'
         verbose_name_plural = 'Amazon Product Types'
+        search_terms = ['name', 'product_type_code']
 
     def __str__(self):
         try:

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from core.schema.core.types.filters import filter, SearchFilterMixin
 from strawberry_django import filter_field as custom_filter
 from django.db.models import Q
@@ -10,6 +12,15 @@ from sales_channels.integrations.amazon.models import (
     AmazonPropertySelectValue,
     AmazonProductType,
 )
+from properties.schema.types.filters import (
+    PropertyFilter,
+    PropertySelectValueFilter,
+    ProductPropertiesRuleFilter,
+)
+from sales_channels.schema.types.filters import (
+    SalesChannelFilter,
+    SalesChannelViewFilter,
+)
 
 
 @filter(AmazonSalesChannel)
@@ -20,6 +31,11 @@ class AmazonSalesChannelFilter(SearchFilterMixin):
 
 @filter(AmazonProperty)
 class AmazonPropertyFilter(SearchFilterMixin):
+    sales_channel: Optional[SalesChannelFilter]
+    local_instance: Optional[PropertyFilter]
+    allows_unmapped_values: auto
+    type: auto
+
     @custom_filter
     def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
         if value not in (None, UNSET):
@@ -35,6 +51,11 @@ class AmazonPropertyFilter(SearchFilterMixin):
 
 @filter(AmazonPropertySelectValue)
 class AmazonPropertySelectValueFilter(SearchFilterMixin):
+    sales_channel: Optional[SalesChannelFilter]
+    amazon_property: Optional[AmazonPropertyFilter]
+    local_instance: Optional[PropertySelectValueFilter]
+    marketplace: Optional[SalesChannelViewFilter]
+
     @custom_filter
     def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
         if value not in (None, UNSET):
@@ -50,6 +71,9 @@ class AmazonPropertySelectValueFilter(SearchFilterMixin):
 
 @filter(AmazonProductType)
 class AmazonProductTypeFilter(SearchFilterMixin):
+    sales_channel: Optional[SalesChannelFilter]
+    local_instance: Optional[ProductPropertiesRuleFilter]
+
     @custom_filter
     def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
         if value not in (None, UNSET):
@@ -61,4 +85,3 @@ class AmazonProductTypeFilter(SearchFilterMixin):
         if value not in (None, UNSET):
             queryset = queryset.filter_mapped_remotely(value)
         return queryset, Q()
-


### PR DESCRIPTION
## Summary
- extend `AmazonPropertyFilter`, `AmazonPropertySelectValueFilter` and `AmazonProductTypeFilter` to allow filtering by sales channel and related objects
- enable searching on Amazon property, select value and product type models

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/schema/types/filters.py OneSila/sales_channels/integrations/amazon/models/properties.py`
- `python OneSila/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6851912b3254832e8626ac15bd3c9d0e

## Summary by Sourcery

Add sales channel and related-object filters to Amazon schema filters and enable search functionality on Amazon property and product type models

New Features:
- Extend AmazonPropertyFilter with sales_channel, local_instance, allows_unmapped_values, and type filters
- Extend AmazonPropertySelectValueFilter with sales_channel, amazon_property, local_instance, and marketplace filters
- Extend AmazonProductTypeFilter with sales_channel and local_instance filters
- Add search_terms to AmazonProperty, AmazonPropertySelectValue, and AmazonProductType models to enable model search