### PR TITLE
Add validation for AmazonProperty type

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/models/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/models/properties.py
@@ -12,6 +12,7 @@ from sales_channels.integrations.amazon.managers import (
     AmazonPropertySelectValueManager,
     AmazonProductTypeManager,
 )
+from django.core.exceptions import ValidationError
 from core import models
 from django.utils.translation import gettext_lazy as _
 from datetime import timedelta
@@ -96,6 +97,20 @@ class AmazonProperty(RemoteProperty):
     type = models.CharField(max_length=16, choices=Property.TYPES.ALL, default=Property.TYPES.TEXT)
 
     objects = AmazonPropertyManager()
+
+    def save(self, *args, **kwargs):
+        if self.local_instance and self.local_instance.type != self.type:
+            raise ValidationError(
+                _(
+                    "Amazon property type %(remote)s must match local property type %(local)s."
+                )
+                % {
+                    "remote": self.get_type_display(),
+                    "local": self.local_instance.get_type_display(),
+                }
+            )
+
+        super().save(*args, **kwargs)
 
     class Meta:
         verbose_name = 'Amazon Property'

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_models.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_models.py
@@ -1,0 +1,30 @@
+from core.tests import TestCase
+from django.core.exceptions import ValidationError
+from model_bakery import baker
+
+from sales_channels.integrations.amazon.models.properties import AmazonProperty
+from properties.models import Property
+
+
+class AmazonPropertyModelTest(TestCase):
+    def test_save_raises_error_for_type_mismatch(self):
+        local_property = baker.make(Property, type=Property.TYPES.SELECT)
+        amazon_property = baker.prepare(
+            AmazonProperty,
+            sales_channel=baker.make("amazon.AmazonSalesChannel"),
+            type=Property.TYPES.TEXT,
+            local_instance=local_property,
+        )
+        with self.assertRaises(ValidationError):
+            amazon_property.save()
+
+    def test_save_allowed_when_types_match(self):
+        local_property = baker.make(Property, type=Property.TYPES.SELECT)
+        amazon_property = baker.make(
+            AmazonProperty,
+            sales_channel=baker.make("amazon.AmazonSalesChannel"),
+            type=Property.TYPES.SELECT,
+            local_instance=local_property,
+        )
+        self.assertIsNotNone(amazon_property.pk)
+


### PR DESCRIPTION
## Summary
- ensure AmazonProperty only saves if type matches local property
- test mismatch scenarios for AmazonProperty

## Testing
- `coverage run --source='.' OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_models -v 2` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6851c5eeaf40832ea51b7f58d7885c84

## Summary by Sourcery

Add validation to ensure AmazonProperty's type matches its linked local Property and raise ValidationError on mismatch, and add unit tests for these scenarios.

Enhancements:
- Override AmazonProperty.save to enforce matching property types before saving.

Tests:
- Add unit tests verifying that saving an AmazonProperty raises a ValidationError on type mismatch and succeeds when types match.