### PR TITLE
Implement group cleanup in subscriptions

### DIFF
--- a/OneSila/core/schema/core/subscriptions/publishers.py
+++ b/OneSila/core/schema/core/subscriptions/publishers.py
@@ -1,6 +1,7 @@
 from strawberry_django.auth.utils import get_current_user
 from strawberry.relay.utils import from_base64
 from asgiref.sync import sync_to_async
+import contextlib
 
 from .typing import Info, GlobalID, Model
 
@@ -123,7 +124,11 @@ class ModelInstanceSubscribePublisher:
         await self.subscribe()
         await self.send_initial_message()
 
-        async with self.ws.listen_to_channel(type=self.msg_type, groups=[self.group]) as messages:
-            async for msg in messages:
-                logger.info(f"Found wake-up: {msg}")
-                yield await self.refresh_instance()
+        try:
+            async with self.ws.listen_to_channel(type=self.msg_type, groups=[self.group]) as messages:
+                async for msg in messages:
+                    logger.info(f"Found wake-up: {msg}")
+                    yield await self.refresh_instance()
+        finally:
+            with contextlib.suppress(Exception):
+                await self.channel_layer.group_discard(self.group, self.ws.channel_name)

--- a/OneSila/core/tests/tests_schemas/tests_subscriptions.py
+++ b/OneSila/core/tests/tests_schemas/tests_subscriptions.py
@@ -1,0 +1,71 @@
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+from asgiref.sync import async_to_sync
+from channels.layers import InMemoryChannelLayer
+from model_bakery import baker
+
+from core.tests import TestCase
+from core.models import MultiTenantCompany, MultiTenantUser
+from core.schema.core.subscriptions.publishers import ModelInstanceSubscribePublisher
+from core.schema.core.subscriptions.helpers import create_global_id
+
+
+class FakeWS:
+    def __init__(self, channel_layer=None):
+        self.channel_layer = channel_layer or InMemoryChannelLayer()
+        self.channel_name = "test-channel"
+
+    @asynccontextmanager
+    async def listen_to_channel(self, type, *, timeout=None, groups=()):
+        for group in groups:
+            await self.channel_layer.group_add(group, self.channel_name)
+
+        async def generator():
+            while True:
+                msg = await self.channel_layer.receive(self.channel_name)
+                yield msg
+
+        try:
+            yield generator()
+        finally:
+            for group in groups:
+                await self.channel_layer.group_discard(group, self.channel_name)
+
+
+class ModelInstanceSubscribePublisherTests(TestCase):
+    def test_group_removed_after_disconnect(self):
+        channel_layer = InMemoryChannelLayer()
+        ws = FakeWS(channel_layer=channel_layer)
+
+        company = baker.make(MultiTenantCompany)
+        user = baker.make(MultiTenantUser, multi_tenant_company=company)
+
+        info = SimpleNamespace(
+            context={
+                "ws": ws,
+                "request": SimpleNamespace(user=user),
+            },
+            return_type=SimpleNamespace(__name__="MultiTenantCompanyType"),
+        )
+
+        pk = create_global_id(company)
+        publisher = ModelInstanceSubscribePublisher(
+            info=info,
+            pk=pk,
+            model=MultiTenantCompany,
+        )
+
+        async def run_pub():
+            gen = publisher.await_messages()
+            await gen.__anext__()
+            self.assertIn(
+                ws.channel_name,
+                channel_layer.groups.get("MultiTenantCompany", {}),
+            )
+            await gen.aclose()
+
+        async_to_sync(run_pub)()
+
+        self.assertNotIn("MultiTenantCompany", channel_layer.groups)
+


### PR DESCRIPTION
## Summary
- discard websocket group when subscription closes
- test that groups are discarded on disconnect

## Testing
- `python OneSila/manage.py test -v 0` *(fails: connection to PostgreSQL refused)*
- `python OneSila/manage.py test core.tests.tests_schemas.tests_subscriptions.ModelInstanceSubscribePublisherTests.test_group_removed_after_disconnect -v 2` *(fails: connection to PostgreSQL refused)*

------
https://chatgpt.com/codex/tasks/task_e_6853d62c86c483228f81efa77b27896b