### PR TITLE
Add GraphQL resources for AmazonSalesChannelImport

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -9,6 +9,8 @@ from sales_channels.integrations.amazon.schema.types.input import (
     AmazonPropertySelectValuePartialInput,
     AmazonProductTypeInput,
     AmazonProductTypePartialInput,
+    AmazonSalesChannelImportInput,
+    AmazonSalesChannelImportPartialInput,
     AmazonValidateAuthInput,
 )
 from sales_channels.integrations.amazon.schema.types.types import (
@@ -17,13 +19,15 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonPropertySelectValueType,
     AmazonProductTypeType,
     AmazonRedirectUrlType,
+    AmazonSalesChannelImportType,
 )
-from core.schema.core.mutations import create, type, List, update
+from core.schema.core.mutations import create, type, List, update, delete
 from strawberry import Info
 import strawberry_django
 from core.schema.core.extensions import default_extensions
 from core.schema.core.helpers import get_multi_tenant_company
 from django.utils.translation import gettext_lazy as _
+
 
 @type(name="Mutation")
 class AmazonSalesChannelMutation:
@@ -74,3 +78,9 @@ class AmazonSalesChannelMutation:
     update_amazon_property: AmazonPropertyType = update(AmazonPropertyPartialInput)
     update_amazon_property_select_value: AmazonPropertySelectValueType = update(AmazonPropertySelectValuePartialInput)
     update_amazon_product_type: AmazonProductTypeType = update(AmazonProductTypePartialInput)
+
+    create_amazon_import_process: AmazonSalesChannelImportType = create(AmazonSalesChannelImportInput)
+    create_amazon_import_processes: List[AmazonSalesChannelImportType] = create(AmazonSalesChannelImportInput)
+    update_amazon_import_process: AmazonSalesChannelImportType = update(AmazonSalesChannelImportPartialInput)
+    delete_amazon_import_process: AmazonSalesChannelImportType = delete()
+    delete_amazon_import_processes: List[AmazonSalesChannelImportType] = delete()

--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -4,6 +4,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonPropertyType,
     AmazonPropertySelectValueType,
     AmazonProductTypeType,
+    AmazonSalesChannelImportType,
 )
 
 
@@ -20,3 +21,6 @@ class AmazonSalesChannelsQuery:
 
     amazon_product_type: AmazonProductTypeType = node()
     amazon_product_types: DjangoListConnection[AmazonProductTypeType] = connection()
+
+    amazon_import_process: AmazonSalesChannelImportType = node()
+    amazon_import_processes: DjangoListConnection[AmazonSalesChannelImportType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/subscriptions.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/subscriptions.py
@@ -3,11 +3,13 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
     AmazonProperty,
     AmazonPropertySelectValue,
+    AmazonSalesChannelImport,
 )
 from sales_channels.integrations.amazon.schema.types.types import (
     AmazonSalesChannelType,
     AmazonPropertyType,
     AmazonPropertySelectValueType,
+    AmazonSalesChannelImportType,
 )
 
 
@@ -27,4 +29,9 @@ class AmazonSalesChannelsSubscription:
     @subscription
     async def amazon_property_select_value(self, info: Info, pk: str) -> AsyncGenerator[AmazonPropertySelectValueType, None]:
         async for i in model_subscriber(info=info, pk=pk, model=AmazonPropertySelectValue):
+            yield i
+
+    @subscription
+    async def amazon_import_process(self, info: Info, pk: str) -> AsyncGenerator[AmazonSalesChannelImportType, None]:
+        async for i in model_subscriber(info=info, pk=pk, model=AmazonSalesChannelImport):
             yield i

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -12,6 +12,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProperty,
     AmazonPropertySelectValue,
     AmazonProductType,
+    AmazonSalesChannelImport,
 )
 from properties.schema.types.filters import (
     PropertyFilter,
@@ -97,3 +98,9 @@ class AmazonProductTypeFilter(SearchFilterMixin):
         if value not in (None, UNSET):
             queryset = queryset.filter_mapped_remotely(value)
         return queryset, Q()
+
+
+@filter(AmazonSalesChannelImport)
+class AmazonSalesChannelImportFilter(SearchFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]

--- a/OneSila/sales_channels/integrations/amazon/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/input.py
@@ -4,6 +4,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProperty,
     AmazonPropertySelectValue,
     AmazonProductType,
+    AmazonSalesChannelImport,
 )
 
 
@@ -51,4 +52,14 @@ class AmazonProductTypeInput:
 
 @partial(AmazonProductType, fields="__all__")
 class AmazonProductTypePartialInput(NodeInput):
+    pass
+
+
+@input(AmazonSalesChannelImport, exclude=['saleschannelimport_ptr', 'import_ptr'])
+class AmazonSalesChannelImportInput:
+    pass
+
+
+@partial(AmazonSalesChannelImport, fields="__all__")
+class AmazonSalesChannelImportPartialInput(NodeInput):
     pass

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -5,6 +5,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProperty,
     AmazonPropertySelectValue,
     AmazonProductType,
+    AmazonSalesChannelImport,
 )
 
 
@@ -25,4 +26,9 @@ class AmazonPropertySelectValueOrder:
 
 @order(AmazonProductType)
 class AmazonProductTypeOrder:
+    id: auto
+
+
+@order(AmazonSalesChannelImport)
+class AmazonSalesChannelImportOrder:
     id: auto

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -8,23 +8,28 @@ from core.schema.core.types.types import (
     lazy,
 )
 from typing import Optional, List
+from strawberry.relay import to_base64
+from imports_exports.schema.queries import ImportType
 from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
     AmazonProperty,
     AmazonPropertySelectValue,
     AmazonProductType,
+    AmazonSalesChannelImport,
 )
 from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonSalesChannelFilter,
     AmazonPropertyFilter,
     AmazonPropertySelectValueFilter,
     AmazonProductTypeFilter,
+    AmazonSalesChannelImportFilter,
 )
 from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonSalesChannelOrder,
     AmazonPropertyOrder,
     AmazonPropertySelectValueOrder,
     AmazonProductTypeOrder,
+    AmazonSalesChannelImportOrder,
 )
 
 
@@ -65,6 +70,7 @@ class AmazonPropertyType(relay.Node, GetQuerysetMultiTenantMixin):
         'AmazonPropertySelectValueType',
         lazy("sales_channels.integrations.amazon.schema.types.types")
     ]]
+
     @field()
     def mapped_locally(self, info) -> bool:
         return self.mapped_locally
@@ -95,6 +101,7 @@ class AmazonPropertySelectValueType(relay.Node, GetQuerysetMultiTenantMixin):
         'PropertySelectValueType',
         lazy("properties.schema.types.types")
     ]]
+
     @field()
     def mapped_locally(self, info) -> bool:
         return self.mapped_locally
@@ -120,6 +127,7 @@ class AmazonProductTypeType(relay.Node, GetQuerysetMultiTenantMixin):
         'ProductPropertiesRuleType',
         lazy("properties.schema.types.types")
     ]]
+
     @field()
     def mapped_locally(self, info) -> bool:
         return self.mapped_locally
@@ -127,3 +135,21 @@ class AmazonProductTypeType(relay.Node, GetQuerysetMultiTenantMixin):
     @field()
     def mapped_remotely(self, info) -> bool:
         return self.mapped_remotely
+
+
+@type(
+    AmazonSalesChannelImport,
+    filters=AmazonSalesChannelImportFilter,
+    order=AmazonSalesChannelImportOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonSalesChannelImportType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'AmazonSalesChannelType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]
+
+    @field()
+    def import_id(self, info) -> str:
+        return to_base64(ImportType, self.pk)


### PR DESCRIPTION
## Summary
- implement GraphQL type, input, filter and order for `AmazonSalesChannelImport`
- expose Amazon import process queries, mutations and subscriptions

## Testing
- `pycodestyle OneSila/sales_channels/integrations/amazon/schema/mutations.py OneSila/sales_channels/integrations/amazon/schema/queries.py OneSila/sales_channels/integrations/amazon/schema/subscriptions.py OneSila/sales_channels/integrations/amazon/schema/types/filters.py OneSila/sales_channels/integrations/amazon/schema/types/input.py OneSila/sales_channels/integrations/amazon/schema/types/ordering.py OneSila/sales_channels/integrations/amazon/schema/types/types.py`
- `python -m compileall -q OneSila/sales_channels/integrations/amazon/schema`

------
https://chatgpt.com/codex/tasks/task_e_685444a76730832e89669b5f6cb7e692

## Summary by Sourcery

Add comprehensive GraphQL support for AmazonSalesChannelImport by introducing new types, inputs, filters, ordering, queries, mutations, and subscriptions.

New Features:
- Define AmazonSalesChannelImportType with full field exposure, filters, ordering, and pagination.
- Add GraphQL input classes (AmazonSalesChannelImportInput and AmazonSalesChannelImportPartialInput).
- Implement create, bulk create, update, delete, and bulk delete mutations for import processes.
- Expose amazon_import_process and amazon_import_processes via node and connection queries.
- Add subscription support for real-time amazon_import_process updates.