### PR TITLE
Update ProductTranslation schema and add bullet point graphql

### DIFF
--- a/OneSila/products/schema/mutations/mutation_type.py
+++ b/OneSila/products/schema/mutations/mutation_type.py
@@ -1,13 +1,32 @@
 from .fields import create_product
-from ..types.types import ProductType, BundleProductType, ConfigurableProductType, \
-    SimpleProductType, ProductTranslationType, ConfigurableVariationType, \
-    BundleVariationType
-from ..types.input import ProductInput, BundleProductInput, ConfigurableProductInput, \
-    SimpleProductInput, ProductTranslationInput, ConfigurableVariationInput, \
-    BundleVariationInput, ProductPartialInput, ConfigurableProductPartialInput, \
-    BundleProductPartialInput, SimpleProductPartialInput, \
-    ProductTranslationPartialInput, ConfigurableVariationPartialInput, \
-    BundleVariationPartialInput
+from ..types.types import (
+    ProductType,
+    BundleProductType,
+    ConfigurableProductType,
+    SimpleProductType,
+    ProductTranslationType,
+    ConfigurableVariationType,
+    BundleVariationType,
+    ProductTranslationBulletPointType,
+)
+from ..types.input import (
+    ProductInput,
+    BundleProductInput,
+    ConfigurableProductInput,
+    SimpleProductInput,
+    ProductTranslationInput,
+    ConfigurableVariationInput,
+    BundleVariationInput,
+    ProductPartialInput,
+    ConfigurableProductPartialInput,
+    BundleProductPartialInput,
+    SimpleProductPartialInput,
+    ProductTranslationPartialInput,
+    ConfigurableVariationPartialInput,
+    BundleVariationPartialInput,
+    ProductTranslationBulletPointInput,
+    ProductTranslationBulletPointPartialInput,
+)
 from core.schema.core.mutations import create, update, delete, type, List
 
 
@@ -54,3 +73,9 @@ class ProductsMutation:
     update_bundle_variation: BundleVariationType = update(BundleVariationPartialInput)
     delete_bundle_variation: BundleVariationType = delete()
     delete_bundle_variations: List[BundleVariationType] = delete()
+
+    create_product_translation_bullet_point: ProductTranslationBulletPointType = create(ProductTranslationBulletPointInput)
+    create_product_translation_bullet_points: List[ProductTranslationBulletPointType] = create(ProductTranslationBulletPointInput)
+    update_product_translation_bullet_point: ProductTranslationBulletPointType = update(ProductTranslationBulletPointPartialInput)
+    delete_product_translation_bullet_point: ProductTranslationBulletPointType = delete()
+    delete_product_translation_bullet_points: List[ProductTranslationBulletPointType] = delete()

--- a/OneSila/products/schema/queries.py
+++ b/OneSila/products/schema/queries.py
@@ -1,9 +1,16 @@
 from core.schema.core.queries import node, connection, DjangoListConnection, type
 from typing import List
 
-from .types.types import ProductType, BundleProductType, ConfigurableProductType, \
-    SimpleProductType, ProductTranslationType, ConfigurableVariationType, \
-    BundleVariationType
+from .types.types import (
+    ProductType,
+    BundleProductType,
+    ConfigurableProductType,
+    SimpleProductType,
+    ProductTranslationType,
+    ConfigurableVariationType,
+    BundleVariationType,
+    ProductTranslationBulletPointType,
+)
 
 
 @type(name="Query")
@@ -28,3 +35,6 @@ class ProductsQuery:
 
     bundle_variation: BundleVariationType = node()
     bundle_variations: DjangoListConnection[BundleVariationType] = connection()
+
+    product_translation_bullet_point: ProductTranslationBulletPointType = node()
+    product_translation_bullet_points: DjangoListConnection[ProductTranslationBulletPointType] = connection()

--- a/OneSila/products/schema/subscriptions.py
+++ b/OneSila/products/schema/subscriptions.py
@@ -1,9 +1,25 @@
 from core.schema.core.subscriptions import type, subscription, Info, AsyncGenerator, model_subscriber
 
-from products.models import Product, BundleProduct, ConfigurableProduct, SimpleProduct, ProductTranslation, \
-    ConfigurableVariation, BundleVariation
-from products.schema.types.types import ProductType, BundleProductType, ConfigurableProductType, \
-    SimpleProductType, ProductTranslationType, ConfigurableVariationType, BundleVariationType
+from products.models import (
+    Product,
+    BundleProduct,
+    ConfigurableProduct,
+    SimpleProduct,
+    ProductTranslation,
+    ConfigurableVariation,
+    BundleVariation,
+    ProductTranslationBulletPoint,
+)
+from products.schema.types.types import (
+    ProductType,
+    BundleProductType,
+    ConfigurableProductType,
+    SimpleProductType,
+    ProductTranslationType,
+    ConfigurableVariationType,
+    BundleVariationType,
+    ProductTranslationBulletPointType,
+)
 
 
 @type(name="Subscription")
@@ -41,4 +57,15 @@ class ProductsSubscription:
     @subscription
     async def bundle_variation(self, info: Info, pk: str) -> AsyncGenerator[BundleVariationType, None]:
         async for i in model_subscriber(info=info, pk=pk, model=BundleVariation):
+            yield i
+
+    @subscription
+    async def product_translation_bullet_point(
+        self, info: Info, pk: str
+    ) -> AsyncGenerator[ProductTranslationBulletPointType, None]:
+        async for i in model_subscriber(
+            info=info,
+            pk=pk,
+            model=ProductTranslationBulletPoint,
+        ):
             yield i

--- a/OneSila/products/schema/types/filters.py
+++ b/OneSila/products/schema/types/filters.py
@@ -7,8 +7,17 @@ from core.managers import QuerySet
 from core.schema.core.types.types import auto
 from core.schema.core.types.filters import filter, SearchFilterMixin, ExcluideDemoDataFilterMixin, lazy
 from strawberry_django import filter_field as custom_filter
-from products.models import Product, BundleProduct, ConfigurableProduct, \
-    SimpleProduct, ProductTranslation, ConfigurableVariation, BundleVariation, AliasProduct
+from products.models import (
+    Product,
+    BundleProduct,
+    ConfigurableProduct,
+    SimpleProduct,
+    ProductTranslation,
+    ConfigurableVariation,
+    BundleVariation,
+    AliasProduct,
+    ProductTranslationBulletPoint,
+)
 from products_inspector.models import InspectorBlock
 from taxes.schema.types.filters import VatRateFilter
 from strawberry.relay import from_base64
@@ -81,6 +90,7 @@ class ProductTranslationFilter:
     id: auto
     product: Optional[ProductFilter]
     language: auto
+    sales_channel: Optional[lazy['SalesChannelFilter', "sales_channels.schema.types.filters"]]
 
 
 @filter(ConfigurableVariation)
@@ -95,3 +105,9 @@ class BundleVariationFilter:
     id: auto
     parent: Optional[ProductFilter]
     variation: Optional[ProductFilter]
+
+
+@filter(ProductTranslationBulletPoint)
+class ProductTranslationBulletPointFilter(SearchFilterMixin):
+    id: auto
+    product_translation: Optional[ProductTranslationFilter]

--- a/OneSila/products/schema/types/input.py
+++ b/OneSila/products/schema/types/input.py
@@ -1,6 +1,14 @@
 from core.schema.core.types.input import NodeInput, input, partial
-from products.models import Product, BundleProduct, ConfigurableProduct, SimpleProduct, \
-    ProductTranslation, ConfigurableVariation, BundleVariation
+from products.models import (
+    Product,
+    BundleProduct,
+    ConfigurableProduct,
+    SimpleProduct,
+    ProductTranslation,
+    ConfigurableVariation,
+    BundleVariation,
+    ProductTranslationBulletPoint,
+)
 
 
 @input(Product, fields="__all__")
@@ -72,4 +80,14 @@ class BundleVariationInput:
 
 @partial(BundleVariation, fields="__all__")
 class BundleVariationPartialInput(NodeInput):
+    pass
+
+
+@input(ProductTranslationBulletPoint, fields="__all__")
+class ProductTranslationBulletPointInput:
+    pass
+
+
+@partial(ProductTranslationBulletPoint, fields="__all__")
+class ProductTranslationBulletPointPartialInput(NodeInput):
     pass

--- a/OneSila/products/schema/types/ordering.py
+++ b/OneSila/products/schema/types/ordering.py
@@ -1,9 +1,17 @@
 from core.schema.core.types.ordering import order
 from core.schema.core.types.types import auto
 
-from products.models import Product, BundleProduct, ConfigurableProduct, \
-    SimpleProduct, ProductTranslation, ConfigurableVariation, \
-    BundleVariation, AliasProduct
+from products.models import (
+    Product,
+    BundleProduct,
+    ConfigurableProduct,
+    SimpleProduct,
+    ProductTranslation,
+    ConfigurableVariation,
+    BundleVariation,
+    AliasProduct,
+    ProductTranslationBulletPoint,
+)
 
 
 @order(Product)
@@ -50,4 +58,9 @@ class ConfigurableVariationOrder:
 
 @order(BundleVariation)
 class BundleVariationOrder:
+    id: auto
+
+
+@order(ProductTranslationBulletPoint)
+class ProductTranslationBulletPointOrder:
     id: auto

--- a/OneSila/products/schema/types/types.py
+++ b/OneSila/products/schema/types/types.py
@@ -7,16 +7,42 @@ from core.schema.core.types.types import relay, type, GetQuerysetMultiTenantMixi
 from typing import List, Optional
 
 from media.models import Media
-from products.models import Product, BundleProduct, ConfigurableProduct, SimpleProduct, \
-    ProductTranslation, ConfigurableVariation, BundleVariation, AliasProduct
+from products.models import (
+    Product,
+    BundleProduct,
+    ConfigurableProduct,
+    SimpleProduct,
+    ProductTranslation,
+    ConfigurableVariation,
+    BundleVariation,
+    AliasProduct,
+    ProductTranslationBulletPoint,
+)
 from properties.models import ProductProperty
 from properties.schema.types.types import ProductPropertyType
 from taxes.schema.types.types import VatRateType
-from .filters import ProductFilter, BundleProductFilter, ConfigurableProductFilter, \
-    SimpleProductFilter, ProductTranslationFilter, ConfigurableVariationFilter, BundleVariationFilter, \
-    AliasProductFilter
-from .ordering import ProductOrder, BundleProductOrder, ConfigurableProductOrder, \
-    SimpleProductOrder, ProductTranslationOrder, ConfigurableVariationOrder, BundleVariationOrder, AliasProductOrder
+from .filters import (
+    ProductFilter,
+    BundleProductFilter,
+    ConfigurableProductFilter,
+    SimpleProductFilter,
+    ProductTranslationFilter,
+    ConfigurableVariationFilter,
+    BundleVariationFilter,
+    AliasProductFilter,
+    ProductTranslationBulletPointFilter,
+)
+from .ordering import (
+    ProductOrder,
+    BundleProductOrder,
+    ConfigurableProductOrder,
+    SimpleProductOrder,
+    ProductTranslationOrder,
+    ConfigurableVariationOrder,
+    BundleVariationOrder,
+    AliasProductOrder,
+    ProductTranslationBulletPointOrder,
+)
 
 
 @type(Product, filters=ProductFilter, order=ProductOrder, pagination=True, fields="__all__")
@@ -78,7 +104,7 @@ class ProductType(relay.Node, GetQuerysetMultiTenantMixin):
 
 @type(ProductTranslation, filters=ProductTranslationFilter, order=ProductTranslationOrder, pagination=True, fields="__all__")
 class ProductTranslationType(relay.Node, GetQuerysetMultiTenantMixin):
-    pass
+    sales_channel: Optional[Annotated['SalesChannelType', lazy('sales_channels.schema.types.types')]]
 
 
 @type(BundleProduct, filters=BundleProductFilter, order=BundleProductOrder, pagination=True, fields="__all__")
@@ -116,3 +142,14 @@ class AliasProductType(relay.Node, GetQuerysetMultiTenantMixin):
     @field()
     def name(self, info) -> str | None:
         return self.name
+
+
+@type(
+    ProductTranslationBulletPoint,
+    filters=ProductTranslationBulletPointFilter,
+    order=ProductTranslationBulletPointOrder,
+    pagination=True,
+    fields="__all__",
+)
+class ProductTranslationBulletPointType(relay.Node, GetQuerysetMultiTenantMixin):
+    product_translation: Optional[ProductTranslationType]


### PR DESCRIPTION
## Summary
- add GraphQL input definitions for ProductTranslationBulletPoint
- expose bullet point filtering and ordering capabilities
- include sales channel field on ProductTranslation GraphQL type
- create bullet point type plus related queries, mutations and subscriptions

## Testing
- `python -m py_compile products/schema/types/input.py products/schema/types/filters.py products/schema/types/ordering.py products/schema/types/types.py products/schema/queries.py products/schema/mutations/mutation_type.py products/schema/subscriptions.py`
- `./OneSila/run_tests_locally.sh` *(fails: coverage not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685979b224fc832e8c0bbd081bcef877

## Summary by Sourcery

Add full GraphQL support for ProductTranslationBulletPoint, including type definitions, inputs, filters, ordering, queries, mutations, and subscriptions, and extend ProductTranslation with a sales_channel field and filtering.

New Features:
- Introduce ProductTranslationBulletPoint GraphQL type with filters, ordering, pagination, and sales channel filtering
- Add GraphQL input definitions for creating and updating ProductTranslationBulletPoint
- Expose ProductTranslationBulletPoint queries (single and list), CRUD mutations, and subscription
- Extend ProductTranslation GraphQL type to include sales_channel field and enable sales_channel filtering