### PR TITLE
Add Amazon bullet points import support

### DIFF
--- a/OneSila/imports_exports/tests/tests_factories/tests_products.py
+++ b/OneSila/imports_exports/tests/tests_factories/tests_products.py
@@ -388,6 +388,24 @@ class ImportProductInstanceProcessTest(TestCase):
         translation = ProductTranslation.objects.filter(product=instance.instance).first()
         self.assertEqual(translation.short_description, "Short Desc")
 
+    def test_create_product_with_bullet_points(self):
+        data = {
+            "name": "Bullet Product",
+            "sku": "BULLET001",
+            "translations": [
+                {
+                    "bullet_points": ["Point A", "Point B"]
+                }
+            ]
+        }
+
+        instance = ImportProductInstance(data, self.import_process)
+        instance.process()
+
+        translation = ProductTranslation.objects.filter(product=instance.instance).first()
+        bullet_texts = list(translation.bullet_points.order_by('sort_order').values_list('text', flat=True))
+        self.assertEqual(bullet_texts, ["Point A", "Point B"])
+
     def test_create_product_with_images(self):
         data = {
             "name": "Image Product",

--- a/OneSila/sales_channels/integrations/amazon/helpers.py
+++ b/OneSila/sales_channels/integrations/amazon/helpers.py
@@ -1,0 +1,34 @@
+"""Utility helpers for Amazon integration."""
+
+from products.product_types import CONFIGURABLE, SIMPLE
+
+
+def infer_product_type(data: dict) -> str:
+    """Infer local product type from Amazon relationships data."""
+    relationships = data.get("relationships", [])
+
+    for relation in relationships:
+        for rel in relation.get("relationships", []):
+            if rel.get("child_skus"):
+                return CONFIGURABLE
+
+    return SIMPLE
+
+
+def extract_description_and_bullets(attributes: dict) -> tuple[str | None, list[str]]:
+    """Extract description and bullet points from attribute data."""
+    description = None
+    bullets: list[str] = []
+
+    description_data = attributes.get("product_description") or []
+    if description_data:
+        description = description_data[0].get("value")
+
+    bullet_data = attributes.get("bullet_point") or []
+    for bullet in bullet_data:
+        value = bullet.get("value")
+        if value:
+            bullets.append(value)
+
+    return description, bullets
+


### PR DESCRIPTION
## Summary
- add Amazon helper utilities to infer product type and parse bullet points
- handle bullet points in import factories
- test bullet point import logic

## Testing
- `pytest -q OneSila/imports_exports/tests/tests_factories/tests_products.py::ImportProductInstanceValidateTest::test_create_product_with_bullet_points` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685be76cfdf8832e8037587094d308ee

## Summary by Sourcery

Add support for importing product bullet points and enhance Amazon integration utilities

New Features:
- Add Amazon helper functions to infer product type and extract descriptions with bullet points

Enhancements:
- Extend product import factories and instances to handle bullet_points field by creating corresponding ProductTranslationBulletPoint records

Tests:
- Add unit test for importing bullet points in ImportProductInstance