### PR TITLE
Fix SP API log noise

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -16,6 +16,17 @@ logging.getLogger("spapi").setLevel(logging.WARNING)
 logging.getLogger("sp_api").propagate = False
 logging.getLogger("spapi").propagate = False
 
+
+class _SpAPILogFilter(logging.Filter):
+    """Filter out noisy logs from the Amazon SP API libraries."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - pure configuration
+        return "sp_api" not in record.pathname and "spapi" not in record.pathname
+
+
+for handler in logging.getLogger().handlers:
+    handler.addFilter(_SpAPILogFilter())
+
 from sales_channels.integrations.amazon.models import AmazonSalesChannelView
 
 class PullAmazonMixin:


### PR DESCRIPTION
## Summary
- filter out SP API library logs

## Testing
- `pytest -q` *(fails: ImproperlyConfigured: settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_685c666e1c60832eb8283b0030c17d84

## Summary by Sourcery

Suppress noisy logs from Amazon SP API libraries by filtering out log records originating from `sp_api` and `spapi` paths

Enhancements:
- Introduce `_SpAPILogFilter` to exclude SP API library log records based on pathname
- Attach the SP API log filter to all existing root logger handlers to stop propagating those logs