### PR TITLE
Reduce verbose urllib3 logging

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -12,16 +12,27 @@ from sales_channels.integrations.amazon.decorators import throttle_safe
 logging.getLogger("sp_api").setLevel(logging.WARNING)
 logging.getLogger("spapi").setLevel(logging.WARNING)
 
+# Quiet urllib3/requests connection debug spam
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+logging.getLogger("requests").setLevel(logging.WARNING)
+
 # Optional: If they're flooding stdout handlers
 logging.getLogger("sp_api").propagate = False
 logging.getLogger("spapi").propagate = False
+logging.getLogger("urllib3").propagate = False
+logging.getLogger("requests").propagate = False
 
 
 class _SpAPILogFilter(logging.Filter):
-    """Filter out noisy logs from the Amazon SP API libraries."""
+    """Filter out noisy logs from the Amazon SP API and HTTP libraries."""
 
     def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - pure configuration
-        return "sp_api" not in record.pathname and "spapi" not in record.pathname
+        noisy_sources = ("sp_api", "spapi", "urllib3", "requests")
+        name = record.name or ""
+        path = record.pathname or ""
+        return not any(
+            name.startswith(src) or src in path for src in noisy_sources
+        )
 
 
 for handler in logging.getLogger().handlers:


### PR DESCRIPTION
## Summary
- suppress noisy HTTP connection logs in Amazon SP API mixins
- extend log filter to ignore urllib3/requests output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685c6b26e694832eae07374f2f135745

## Summary by Sourcery

Suppress verbose HTTP logging by silencing urllib3 and requests logs and extending the existing SP API log filter to ignore HTTP library output

Enhancements:
- Silence urllib3 and requests loggers by setting their level to WARNING and disabling propagation
- Extend the SP API logging filter to ignore records originating from urllib3 and requests