### PR TITLE
Fix throttle decorator to retry safely

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/decorators.py
+++ b/OneSila/sales_channels/integrations/amazon/decorators.py
@@ -1,6 +1,8 @@
 import time
 from functools import wraps
 from sp_api.base import SellingApiRequestThrottledException
+import requests
+
 
 def throttle_safe(max_retries=5, base_delay=1.0):
     """
@@ -13,13 +15,12 @@ def throttle_safe(max_retries=5, base_delay=1.0):
             for attempt in range(max_retries + 1):
                 try:
                     return func(*args, **kwargs)
-                except SellingApiRequestThrottledException as e:
-                    if attempt >= max_retries:
+                except (SellingApiRequestThrottledException, requests.exceptions.RequestException):
+                    if attempt == max_retries:
                         raise
                     delay = base_delay * (2 ** attempt)
                     time.sleep(delay)
-                    return None
-            return None
+                    continue
 
         return wrapper
     return decorator


### PR DESCRIPTION
## Summary
- handle `requests` connection issues in `throttle_safe`
- avoid prematurely exiting retry loop

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/decorators.py`
- `python OneSila/manage.py test` *(0 tests discovered)*
- `pytest` *(failed: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_685d32b0eeb4832ebc7a31e85d844f63