### PR TITLE
Update Amazon import progress logic

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -88,7 +88,8 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
     # Data fetching
     # ------------------------------------------------------------------
     def get_total_instances(self):
-        return 100
+        # Start with zero and update dynamically as pages are fetched.
+        return 0
 
     def get_products_data(self):
         # Delegate to the mixin helper which yields ListingItem objects

--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -111,6 +111,11 @@ class GetAmazonAPIMixin:
                     included_data=["summaries", "attributes", "issues", "offers", "relationships"]
                 )
 
+                if hasattr(self, "total_import_instances_cnt"):
+                    self.total_import_instances_cnt += len(items)
+                    if hasattr(self, "set_threshold_chunk"):
+                        self.set_threshold_chunk()
+
                 for item in items:
 
                     import pprint


### PR DESCRIPTION
## Summary
- initialize Amazon product import count at zero
- adjust total instance count as listing pages are retrieved
- remove stray saga file

## Testing
- `python OneSila/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685e59af9bbc832eb63cbda027f1a5d6

## Summary by Sourcery

Refine Amazon import progress logic by starting the instance counter at zero and updating it on each page fetch.

Enhancements:
- Initialize Amazon product import count at zero instead of a fixed value
- Dynamically increment total import instance count as listing pages are retrieved