### PR TITLE
Add sales channel aware AI content

### DIFF
--- a/OneSila/llm/factories/content.py
+++ b/OneSila/llm/factories/content.py
@@ -1,4 +1,9 @@
 from .mixins import ContentLLMMixin, AskGPTMixin
+from integrations.constants import (
+    MAGENTO_INTEGRATION,
+    SHOPIFY_INTEGRATION,
+    AMAZON_INTEGRATION,
+)
 
 
 class DescriptionGenLLM(ContentLLMMixin):
@@ -75,8 +80,7 @@ class DescriptionGenLLM(ContentLLMMixin):
     @property
     def system_prompt(self):
         # FIXME: The examples in this context could come from settings in the company account.  Same goes for writing style.
-
-        return f"""
+        base_prompt = f"""
         # AI Assistant for Product Descriptions in HTML
 
         You are an AI assistant responsible for generating high-quality product descriptions in basic HTML for an eCommerce website. Your output must be structured, engaging, and optimized for readability while considering all provided product information, attributes, and images.
@@ -129,6 +133,53 @@ class DescriptionGenLLM(ContentLLMMixin):
         - **Start with an engaging sentence** that introduces the product’s benefits or unique aspects instead of its name or a title.
 
         """
+
+        channel_addition = ""
+        if self.sales_channel_type == AMAZON_INTEGRATION:
+            channel_addition = """
+            ## Amazon Style Guidelines
+
+            You are generating content for an Amazon listing. Please follow these specific rules:
+
+            - Prioritize **keywords** that improve **search visibility**.
+            - Keep sentences **short, direct, and feature-focused**.
+            - Avoid superlatives or vague statements (e.g., "best", "amazing").
+            - Do **not include HTML** unless explicitly allowed (check current context).
+            - Avoid any **subjective claims** (e.g., "perfect for everyone").
+            - Follow a tone that is **informative and conversion-focused**.
+
+            ⚠️ Ensure all claims are factual and align with Amazon's product detail page policies.
+            """
+        elif self.sales_channel_type == SHOPIFY_INTEGRATION:
+            channel_addition = """
+            ## Shopify Style Guidelines
+
+            You are creating a product description for a **Shopify-powered store**:
+
+            - Use an **engaging and branded tone**—feel free to inject personality.
+            - Emphasize **lifestyle benefits** and emotional appeal (e.g., comfort, design).
+            - Structure with **readability in mind**: use `<h3>`, `<ol>`, and short paragraphs.
+            - Focus on **visual imagination**: help the customer picture using the product.
+            - Maintain **light HTML structure** for styling and formatting.
+            - Can include brand-specific wording, seasonal messaging, and storytelling hooks.
+
+            This is **your own storefront**, so emphasize uniqueness and customer connection.
+            """
+        elif self.sales_channel_type == MAGENTO_INTEGRATION:
+            channel_addition = """
+            ## Magento Style Guidelines
+
+            The description is for a **Magento eCommerce storefront**, typically part of a multi-brand or multi-category site.
+
+            - Focus on **clear specification details** (technical, size, materials).
+            - Structure with **headings and bullet points** for fast scanning.
+            - Keep the tone **neutral and informative**, suitable for both B2B and B2C customers.
+            - Use **HTML tags** for clarity, not decoration.
+            - Emphasize **product differentiators**: what sets it apart in catalog context.
+
+            Avoid overly promotional language. Keep it professional and detail-oriented.
+            """
+        return base_prompt + channel_addition
 
     @property
     def prompt(self):
@@ -184,7 +235,7 @@ class ShortDescriptionLLM(DescriptionGenLLM):
 
     @property
     def system_prompt(self):
-        return f"""
+        base_prompt = f"""
         # **System Prompt**
         You are an AI assistant responsible for generating **high-quality product descriptions** for integration into a **Product Information Management (PIM) system**. Your output must be structured, engaging, and optimized for readability while considering **all provided product information, attributes, and images**.
 
@@ -254,3 +305,51 @@ class ShortDescriptionLLM(DescriptionGenLLM):
         ✅Start with an engaging sentence that introduces benefits rather than the product name or title.
         ✅Ensure compatibility with PIM integration** by maintaining a **clean, structured, and well-written output**
         """
+
+        channel_addition = ""
+        if self.sales_channel_type == AMAZON_INTEGRATION:
+            channel_addition = """
+            ## Amazon Style Guidelines
+
+            You are generating content for an Amazon listing. Please follow these specific rules:
+
+            - Prioritize **keywords** that improve **search visibility**.
+            - Keep sentences **short, direct, and feature-focused**.
+            - Avoid superlatives or vague statements (e.g., "best", "amazing").
+            - Do **not include HTML** unless explicitly allowed (check current context).
+            - Avoid any **subjective claims** (e.g., "perfect for everyone").
+            - Follow a tone that is **informative and conversion-focused**.
+
+            ⚠️ Ensure all claims are factual and align with Amazon's product detail page policies.
+            """
+        elif self.sales_channel_type == SHOPIFY_INTEGRATION:
+            channel_addition = """
+            ## Shopify Style Guidelines
+
+            You are creating a product description for a **Shopify-powered store**:
+
+            - Use an **engaging and branded tone**—feel free to inject personality.
+            - Emphasize **lifestyle benefits** and emotional appeal (e.g., comfort, design).
+            - Structure with **readability in mind**: use `<h3>`, `<ol>`, and short paragraphs.
+            - Focus on **visual imagination**: help the customer picture using the product.
+            - Maintain **light HTML structure** for styling and formatting.
+            - Can include brand-specific wording, seasonal messaging, and storytelling hooks.
+
+            This is **your own storefront**, so emphasize uniqueness and customer connection.
+            """
+        elif self.sales_channel_type == MAGENTO_INTEGRATION:
+            channel_addition = """
+            ## Magento Style Guidelines
+
+            The description is for a **Magento eCommerce storefront**, typically part of a multi-brand or multi-category site.
+
+            - Focus on **clear specification details** (technical, size, materials).
+            - Structure with **headings and bullet points** for fast scanning.
+            - Keep the tone **neutral and informative**, suitable for both B2B and B2C customers.
+            - Use **HTML tags** for clarity, not decoration.
+            - Emphasize **product differentiators**: what sets it apart in catalog context.
+
+            Avoid overly promotional language. Keep it professional and detail-oriented.
+            """
+
+        return base_prompt + channel_addition

--- a/OneSila/llm/factories/mixins.py
+++ b/OneSila/llm/factories/mixins.py
@@ -199,11 +199,12 @@ class ContentLLMMixin(AskGPTMixin, CalculateCostMixin, CreateTransactionMixin):
 
         return True
 
-    def __init__(self, product, language_code):
+    def __init__(self, product, language_code, sales_channel_type=None):
         super().__init__()
         self.product = product
         self.multi_tenant_company = product.multi_tenant_company
         self.language_code = language_code
+        self.sales_channel_type = sales_channel_type
 
     def _set_translation(self):
         self.translation = ProductTranslation.objects.filter(

--- a/OneSila/llm/flows/generate_ai_content.py
+++ b/OneSila/llm/flows/generate_ai_content.py
@@ -3,7 +3,7 @@ from llm.schema.types.input import ContentAiGenerateType
 
 
 class AIGenerateContentFlow:
-    def __init__(self, product, language, content_type):
+    def __init__(self, product, language, content_type, sales_channel_type=None):
         factory_map = {
             ContentAiGenerateType.DESCRIPTION: DescriptionGenLLM,
             ContentAiGenerateType.SHORT_DESCRIPTION: ShortDescriptionLLM,
@@ -12,7 +12,11 @@ class AIGenerateContentFlow:
 
         self.product = product
         self.language = language
-        self.factory = factory_class(product=product, language_code=language)
+        self.factory = factory_class(
+            product=product,
+            language_code=language,
+            sales_channel_type=sales_channel_type,
+        )
         self.generated_content = ''
         self.used_points = 0
 

--- a/OneSila/llm/schema/mutations.py
+++ b/OneSila/llm/schema/mutations.py
@@ -23,7 +23,12 @@ class LlmMutation:
         content_type = instance.content_ai_generate_type
         product = Product.objects.get(id=instance.id.node_id, multi_tenant_company=multi_tenant_company)
 
-        content_generator = AIGenerateContentFlow(product=product, language=language, content_type=content_type)
+        content_generator = AIGenerateContentFlow(
+            product=product,
+            language=language,
+            content_type=content_type,
+            sales_channel_type=instance.sales_channel_type,
+        )
         content_generator.flow()
 
         return AiContent(content=content_generator.generated_content, points=content_generator.used_points)

--- a/OneSila/llm/schema/types/input.py
+++ b/OneSila/llm/schema/types/input.py
@@ -3,6 +3,11 @@ from typing import Optional, List
 from core.schema.core.types.input import NodeInput, partial, strawberry_input
 from products.models import Product
 from enum import Enum
+from integrations.constants import (
+    MAGENTO_INTEGRATION,
+    SHOPIFY_INTEGRATION,
+    AMAZON_INTEGRATION,
+)
 
 from products.schema.types.input import ProductPartialInput
 from properties.schema.types.input import PropertyPartialInput, PropertySelectValuePartialInput
@@ -14,10 +19,17 @@ class ContentAiGenerateType(Enum):
     NAME = "name"
 
 
+class SalesChannelType(Enum):
+    MAGENTO = MAGENTO_INTEGRATION
+    SHOPIFY = SHOPIFY_INTEGRATION
+    AMAZON = AMAZON_INTEGRATION
+
+
 @partial(Product, fields="__all__")
 class ProductAiContentInput(NodeInput):
     language_code: str
     content_ai_generate_type: ContentAiGenerateType
+    sales_channel_type: Optional[SalesChannelType] = None
 
 
 @strawberry_input


### PR DESCRIPTION
## Summary
- support optional sales channel argument when requesting AI content
- pass sales channel type through GraphQL mutation and flow
- store sales channel in content LLMs
- tweak description prompts for Amazon channel
- expand style guidelines for Shopify and Magento

## Testing
- `pre-commit run --files OneSila/llm/factories/content.py`
- `python OneSila/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6862dd98b6a4832ebcf9070a380fac6b

## Summary by Sourcery

Enable sales channel-aware AI content generation by extending the GraphQL API, flow logic, and LLM factory to accept an optional sales_channel_type and injecting channel-specific style guidelines into system prompts.

New Features:
- Accept an optional sales_channel_type in the GraphQL generate_product_ai_content mutation input
- Expose sales_channel_type through AIGenerateContentFlow and LLM factory constructors

Enhancements:
- Inject distinct style guidelines for Amazon, Shopify, and Magento into AI content prompts
- Refactor LLM mixins and prompt methods to combine base prompts with channel-specific additions