### PR TITLE
Add AI bullet point generation

### DIFF
--- a/OneSila/llm/factories/content.py
+++ b/OneSila/llm/factories/content.py
@@ -254,3 +254,52 @@ class ShortDescriptionLLM(DescriptionGenLLM):
         ✅Start with an engaging sentence that introduces benefits rather than the product name or title.
         ✅Ensure compatibility with PIM integration** by maintaining a **clean, structured, and well-written output**
         """
+
+
+class BulletPointsLLM(ContentLLMMixin):
+    """Generate bullet points for a product."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.bullet_points: list[str] = []
+
+    @property
+    def system_prompt(self):
+        return (
+            "Generate a short list (max 5 items) of concise bullet points in the "
+            "given language describing the product. Respond ONLY with a JSON array "
+            "of strings."
+        )
+
+    @property
+    def prompt(self):
+        prompt = f"""
+        ##Language Code##
+        {self.language_code}
+
+        ##Product name##
+        {self.product_name}
+
+        ##Product attributes##
+        {self.property_values}
+        """
+
+        if self.short_description:
+            prompt += f"""
+            ##Product Short Description##
+            {self.short_description}
+            """
+        return prompt
+
+    def parse_response(self):
+        import json
+
+        try:
+            self.bullet_points = json.loads(self.text_response)
+        except Exception:
+            self.bullet_points = [
+                line.strip("- •\t ")
+                for line in self.text_response.splitlines()
+                if line.strip()
+            ]
+

--- a/OneSila/llm/flows/generate_bullet_points.py
+++ b/OneSila/llm/flows/generate_bullet_points.py
@@ -1,0 +1,21 @@
+from llm.factories.content import BulletPointsLLM
+
+
+class AIGenerateBulletPointsFlow:
+    def __init__(self, product, language):
+        self.product = product
+        self.language = language
+        self.factory = BulletPointsLLM(product=product, language_code=language)
+        self.generated_points = []
+        self.used_points = 0
+
+    def generate_points(self):
+        self.factory.generate_response()
+        process = self.factory.ai_process
+        self.generated_points = self.factory.bullet_points
+        self.used_points = process.transaction.points
+
+    def flow(self):
+        self.generate_points()
+        return self.generated_points
+

--- a/OneSila/llm/schema/mutations.py
+++ b/OneSila/llm/schema/mutations.py
@@ -4,8 +4,13 @@ import strawberry_django
 from strawberry import Info
 from core.schema.core.extensions import default_extensions
 from sales_channels.schema.types.input import SalesChannelPartialInput
-from .types.types import AiContent, AiTaskResponse
-from .types.input import ProductAiContentInput, AITranslationInput, AIBulkTranslationInput
+from .types.types import AiContent, AiTaskResponse, AiBulletPoints, BulletPoint
+from .types.input import (
+    ProductAiContentInput,
+    AITranslationInput,
+    AIBulkTranslationInput,
+    ProductAiBulletPointsInput,
+)
 from core.schema.core.mutations import type
 from core.schema.core.helpers import get_multi_tenant_company
 from products.models import Product
@@ -27,6 +32,21 @@ class LlmMutation:
         content_generator.flow()
 
         return AiContent(content=content_generator.generated_content, points=content_generator.used_points)
+
+    @strawberry_django.mutation(handle_django_errors=True, extensions=default_extensions)
+    def generate_product_bullet_points_ai(self, instance: ProductAiBulletPointsInput, info: Info) -> AiBulletPoints:
+        from llm.flows.generate_bullet_points import AIGenerateBulletPointsFlow
+
+        multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
+
+        product = Product.objects.get(id=instance.id.node_id, multi_tenant_company=multi_tenant_company)
+
+        flow = AIGenerateBulletPointsFlow(product=product, language=instance.language_code)
+        flow.flow()
+
+        bullets = [BulletPoint(text=bp) for bp in flow.generated_points]
+
+        return AiBulletPoints(bullet_points=bullets, points=str(flow.used_points))
 
     @strawberry_django.mutation(handle_django_errors=True, extensions=default_extensions)
     def generate_ai_translation(self, instance: AITranslationInput, info: Info) -> AiContent:

--- a/OneSila/llm/schema/types/input.py
+++ b/OneSila/llm/schema/types/input.py
@@ -37,3 +37,8 @@ class AIBulkTranslationInput:
     products: Optional[List[ProductPartialInput]] = None
     properties: Optional[List[PropertyPartialInput]] = None
     values: Optional[List[PropertySelectValuePartialInput]] = None
+
+
+@partial(Product, fields="__all__")
+class ProductAiBulletPointsInput(NodeInput):
+    language_code: str

--- a/OneSila/llm/schema/types/types.py
+++ b/OneSila/llm/schema/types/types.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from core.schema.core.types.types import strawberry_type
 
 
@@ -10,3 +12,14 @@ class AiContent:
 @strawberry_type
 class AiTaskResponse:
     success: bool
+
+
+@strawberry_type
+class BulletPoint:
+    text: str
+
+
+@strawberry_type
+class AiBulletPoints:
+    bullet_points: List[BulletPoint]
+    points: str


### PR DESCRIPTION
## Summary
- implement BulletPointsLLM for generating bullet point text
- add AIGenerateBulletPointsFlow
- support new ProductAiBulletPointsInput and GraphQL bullet point types
- expose `generate_product_bullet_points_ai` mutation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_6862de1f99e0832e9d44a9fdf5162a61

## Summary by Sourcery

Implement AI-powered bullet point generation for products

New Features:
- Add BulletPointsLLM factory to generate concise bullet points via LLM
- Introduce AIGenerateBulletPointsFlow to orchestrate bullet point generation
- Expose generate_product_bullet_points_ai mutation with ProductAiBulletPointsInput
- Define BulletPoint and AiBulletPoints GraphQL types for bullet point outputs