### PR TITLE
Add Amazon product type item GraphQL support

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -9,6 +9,8 @@ from sales_channels.integrations.amazon.schema.types.input import (
     AmazonPropertySelectValuePartialInput,
     AmazonProductTypeInput,
     AmazonProductTypePartialInput,
+    AmazonProductTypeItemInput,
+    AmazonProductTypeItemPartialInput,
     AmazonSalesChannelImportInput,
     AmazonSalesChannelImportPartialInput,
     AmazonValidateAuthInput,
@@ -18,6 +20,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonPropertyType,
     AmazonPropertySelectValueType,
     AmazonProductTypeType,
+    AmazonProductTypeItemType,
     AmazonRedirectUrlType,
     AmazonSalesChannelImportType,
 )
@@ -78,6 +81,7 @@ class AmazonSalesChannelMutation:
     update_amazon_property: AmazonPropertyType = update(AmazonPropertyPartialInput)
     update_amazon_property_select_value: AmazonPropertySelectValueType = update(AmazonPropertySelectValuePartialInput)
     update_amazon_product_type: AmazonProductTypeType = update(AmazonProductTypePartialInput)
+    update_amazon_product_type_item: AmazonProductTypeItemType = update(AmazonProductTypeItemPartialInput)
 
     create_amazon_import_process: AmazonSalesChannelImportType = create(AmazonSalesChannelImportInput)
     update_amazon_import_process: AmazonSalesChannelImportType = update(AmazonSalesChannelImportPartialInput)

--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -4,6 +4,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonPropertyType,
     AmazonPropertySelectValueType,
     AmazonProductTypeType,
+    AmazonProductTypeItemType,
     AmazonSalesChannelImportType,
 )
 
@@ -21,6 +22,9 @@ class AmazonSalesChannelsQuery:
 
     amazon_product_type: AmazonProductTypeType = node()
     amazon_product_types: DjangoListConnection[AmazonProductTypeType] = connection()
+
+    amazon_product_type_item: AmazonProductTypeItemType = node()
+    amazon_product_type_items: DjangoListConnection[AmazonProductTypeItemType] = connection()
 
     amazon_import_process: AmazonSalesChannelImportType = node()
     amazon_import_processes: DjangoListConnection[AmazonSalesChannelImportType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -18,6 +18,7 @@ from properties.schema.types.filters import (
     PropertyFilter,
     PropertySelectValueFilter,
     ProductPropertiesRuleFilter,
+    ProductPropertiesRuleItemFilter,
 )
 from sales_channels.schema.types.filters import (
     SalesChannelFilter,
@@ -98,6 +99,15 @@ class AmazonProductTypeFilter(SearchFilterMixin):
         if value not in (None, UNSET):
             queryset = queryset.filter_mapped_remotely(value)
         return queryset, Q()
+
+
+@filter(AmazonProductTypeItem)
+class AmazonProductTypeItemFilter(SearchFilterMixin):
+    id: auto
+    amazon_rule: Optional[AmazonProductTypeFilter]
+    local_instance: Optional[ProductPropertiesRuleItemFilter]
+    remote_property: Optional[AmazonPropertyFilter]
+    remote_type: auto
 
 
 @filter(AmazonSalesChannelImport)

--- a/OneSila/sales_channels/integrations/amazon/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/input.py
@@ -4,6 +4,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProperty,
     AmazonPropertySelectValue,
     AmazonProductType,
+    AmazonProductTypeItem,
     AmazonSalesChannelImport,
 )
 
@@ -52,6 +53,16 @@ class AmazonProductTypeInput:
 
 @partial(AmazonProductType, fields="__all__")
 class AmazonProductTypePartialInput(NodeInput):
+    pass
+
+
+@input(AmazonProductTypeItem, fields="__all__")
+class AmazonProductTypeItemInput:
+    pass
+
+
+@partial(AmazonProductTypeItem, fields="__all__")
+class AmazonProductTypeItemPartialInput(NodeInput):
     pass
 
 

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -5,6 +5,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProperty,
     AmazonPropertySelectValue,
     AmazonProductType,
+    AmazonProductTypeItem,
     AmazonSalesChannelImport,
 )
 
@@ -26,6 +27,11 @@ class AmazonPropertySelectValueOrder:
 
 @order(AmazonProductType)
 class AmazonProductTypeOrder:
+    id: auto
+
+
+@order(AmazonProductTypeItem)
+class AmazonProductTypeItemOrder:
     id: auto
 
 

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -15,6 +15,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProperty,
     AmazonPropertySelectValue,
     AmazonProductType,
+    AmazonProductTypeItem,
     AmazonSalesChannelImport,
 )
 from sales_channels.integrations.amazon.schema.types.filters import (
@@ -22,6 +23,7 @@ from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonPropertyFilter,
     AmazonPropertySelectValueFilter,
     AmazonProductTypeFilter,
+    AmazonProductTypeItemFilter,
     AmazonSalesChannelImportFilter,
 )
 from sales_channels.integrations.amazon.schema.types.ordering import (
@@ -29,6 +31,7 @@ from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonPropertyOrder,
     AmazonPropertySelectValueOrder,
     AmazonProductTypeOrder,
+    AmazonProductTypeItemOrder,
     AmazonSalesChannelImportOrder,
 )
 
@@ -127,6 +130,10 @@ class AmazonProductTypeType(relay.Node, GetQuerysetMultiTenantMixin):
         'ProductPropertiesRuleType',
         lazy("properties.schema.types.types")
     ]]
+    amazonproducttypeitem_set: List[Annotated[
+        'AmazonProductTypeItemType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]]
 
     @field()
     def mapped_locally(self, info) -> bool:
@@ -153,3 +160,22 @@ class AmazonSalesChannelImportType(relay.Node, GetQuerysetMultiTenantMixin):
     @field()
     def import_id(self, info) -> str:
         return to_base64(ImportType, self.pk)
+
+
+@type(
+    AmazonProductTypeItem,
+    filters=AmazonProductTypeItemFilter,
+    order=AmazonProductTypeItemOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonProductTypeItemType(relay.Node, GetQuerysetMultiTenantMixin):
+    amazon_rule: Annotated[
+        'AmazonProductTypeType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]
+    remote_property: AmazonPropertyType
+    local_instance: Optional[Annotated[
+        'ProductPropertiesRuleItemType',
+        lazy("properties.schema.types.types")
+    ]]


### PR DESCRIPTION
## Summary
- expose AmazonProductTypeItem model via GraphQL
- allow querying product type items via `amazonproducttypeitem_set`
- add filters, ordering and inputs for AmazonProductTypeItem
- update queries and mutations accordingly

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/schema/types/types.py OneSila/sales_channels/integrations/amazon/schema/types/filters.py OneSila/sales_channels/integrations/amazon/schema/types/ordering.py OneSila/sales_channels/integrations/amazon/schema/types/input.py OneSila/sales_channels/integrations/amazon/schema/queries.py OneSila/sales_channels/integrations/amazon/schema/mutations.py`
- `./OneSila/run_tests_locally.sh` *(fails: ../venv/bin/activate missing)*

------
https://chatgpt.com/codex/tasks/task_e_6863a98b95a4832ea98ab4028ea384db

## Summary by Sourcery

Expose AmazonProductTypeItem in the GraphQL API by defining its type, filters, ordering, inputs, and CRUD operations, and connect it to the existing AmazonProductType schema.

New Features:
- Expose AmazonProductTypeItem model via GraphQL schema with type, filters, ordering, pagination, and include amazonproducttypeitem_set field on AmazonProductTypeType
- Introduce AmazonProductTypeItemInput and AmazonProductTypeItemPartialInput for mutation operations
- Add GraphQL queries and mutations for AmazonProductTypeItem nodes and list connections