### PR TITLE
Remove unique constraint from RemoteProperty

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/migrations/0022_amazonproperty_allow_multiple.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0022_amazonproperty_allow_multiple.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def set_allow_multiple(apps, schema_editor):
+    RemoteProperty = apps.get_model('sales_channels', 'RemoteProperty')
+    AmazonProperty = apps.get_model('amazon', 'AmazonProperty')
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    ct = ContentType.objects.get_for_model(AmazonProperty)
+    RemoteProperty.objects.filter(polymorphic_ctype_id=ct.id).update(allow_multiple=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0021_amazonproduct_asin'),
+        ('sales_channels', '0037_remoteproperty_allow_multiple'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_allow_multiple, migrations.RunPython.noop),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/models/properties.py
@@ -99,6 +99,8 @@ class AmazonProperty(RemoteProperty):
     objects = AmazonPropertyManager()
 
     def save(self, *args, **kwargs):
+        if self.allow_multiple is not True:
+            self.allow_multiple = True
         if self.local_instance and self.local_instance.type != self.type:
             raise ValidationError(
                 _(

--- a/OneSila/sales_channels/migrations/0037_remoteproperty_allow_multiple.py
+++ b/OneSila/sales_channels/migrations/0037_remoteproperty_allow_multiple.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sales_channels', '0036_alter_saleschannelviewassign_issues'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='remoteproperty',
+            unique_together=set(),
+        ),
+        migrations.AddField(
+            model_name='remoteproperty',
+            name='allow_multiple',
+            field=models.BooleanField(
+                default=False,
+                help_text='Set to True to allow multiple remote properties to map to the same local property.',
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='remoteproperty',
+            constraint=models.UniqueConstraint(
+                fields=('sales_channel', 'local_instance'),
+                condition=models.Q(allow_multiple=False),
+                name='uniq_remoteproperty_by_channel_local_when_not_multi',
+            ),
+        ),
+    ]

--- a/OneSila/sales_channels/models/properties.py
+++ b/OneSila/sales_channels/models/properties.py
@@ -11,8 +11,22 @@ class RemoteProperty(PolymorphicModel, RemoteObjectMixin, models.Model):
     local_instance = models.ForeignKey('properties.Property', on_delete=models.SET_NULL, null=True,
                                        help_text="The local property associated with this remote property.")
 
+    allow_multiple = models.BooleanField(
+        default=False,
+        help_text=(
+            "Set to True to allow multiple remote properties to map "
+            "to the same local property."
+        ),
+    )
+
     class Meta:
-        unique_together = ('sales_channel', 'local_instance')
+        constraints = [
+            models.UniqueConstraint(
+                fields=("sales_channel", "local_instance"),
+                condition=models.Q(allow_multiple=False),
+                name="uniq_remoteproperty_by_channel_local_when_not_multi",
+            )
+        ]
         verbose_name = 'Remote Property'
         verbose_name_plural = 'Remote Properties'
 


### PR DESCRIPTION
## Summary
- allow multiple Amazon properties per local property
- add `allow_multiple` flag to RemoteProperty
- automatically enable `allow_multiple` for AmazonProperty
- migrate AmazonProperty records to set the flag

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863a6f0930c832ea2c8ce44b2acf5fe

## Summary by Sourcery

Allow multiple remote properties to map to the same local property by adding an `allow_multiple` flag with conditional uniqueness and auto-enabling it for Amazon properties.

New Features:
- Add `allow_multiple` boolean field to `RemoteProperty` to control multiple mappings

Enhancements:
- Replace the old unique_together constraint with a conditional `UniqueConstraint` that enforces uniqueness only when `allow_multiple` is false
- Automatically set `allow_multiple` to true in `AmazonProperty.save`