### PR TITLE
Add merchant_suggested_asin support

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
@@ -7,9 +7,10 @@ from sales_channels.integrations.amazon.factories.sales_channels.full_schema imp
 from sales_channels.integrations.amazon.models import AmazonSalesChannelView
 from sales_channels.integrations.amazon.models.properties import AmazonProductType, AmazonPublicDefinition, \
     AmazonProperty, AmazonPropertySelectValue, AmazonProductTypeItem
-from properties.models import ProductPropertiesRuleItem, Property
+from properties.models import ProductPropertiesRuleItem, Property, PropertyTranslation
 from sales_channels.integrations.amazon.constants import AMAZON_INTERNAL_PROPERTIES
 from sales_channels.integrations.amazon.decorators import throttle_safe
+from django.db.models import Max
 from django.utils import timezone
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,7 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin):
         self.sales_channel = sales_channel
         self.initial_sales_channel_status = sales_channel.active
         self.api = self.get_api()
+        self.merchant_asin_property = self._ensure_merchant_suggested_asin()
 
     def prepare_import_process(self):
         # during the import this needs to stay false to prevent trying to create the mirror models because
@@ -97,6 +99,41 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin):
             schema_data["title"] = response.display_name
 
         return schema_data
+
+    def _ensure_merchant_suggested_asin(self):
+        remote_property, _ = AmazonProperty.objects.get_or_create(
+            allow_multiple=True,
+            multi_tenant_company=self.sales_channel.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            code="merchant_suggested_asin",
+            defaults={"type": Property.TYPES.TEXT},
+        )
+
+        if not remote_property.local_instance:
+            local_property, _ = Property.objects.get_or_create(
+                internal_name="amazon_asin",
+                multi_tenant_company=self.sales_channel.multi_tenant_company,
+                defaults={
+                    "type": Property.TYPES.TEXT,
+                    "non_deletable": True,
+                },
+            )
+
+            PropertyTranslation.objects.get_or_create(
+                property=local_property,
+                language=self.sales_channel.multi_tenant_company.language,
+                multi_tenant_company=self.sales_channel.multi_tenant_company,
+                defaults={"name": "Amazon Asin"},
+            )
+
+            if not local_property.non_deletable:
+                local_property.non_deletable = True
+                local_property.save(update_fields=["non_deletable"])
+
+            remote_property.local_instance = local_property
+            remote_property.save()
+
+        return remote_property
 
     def sync_public_definitions(self, attr_code, schema_definition, required_properties, product_type_obj, view):
         """
@@ -197,6 +234,40 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin):
                 remote_rule_item.remote_type = new_type
                 remote_rule_item.save()
 
+    def _ensure_asin_item(self, product_type):
+        if not self.merchant_asin_property:
+            return
+
+        item, created = AmazonProductTypeItem.objects.get_or_create(
+            multi_tenant_company=self.sales_channel.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            amazon_rule=product_type,
+            remote_property=self.merchant_asin_property,
+        )
+
+        if created or item.remote_type != ProductPropertiesRuleItem.REQUIRED:
+            item.remote_type = ProductPropertiesRuleItem.REQUIRED
+            item.save()
+
+        if (
+            product_type.local_instance
+            and self.merchant_asin_property.local_instance
+        ):
+            rule = product_type.local_instance
+            max_sort = rule.items.aggregate(max_sort=Max("sort_order")).get("max_sort") or 0
+            rule_item, created_local = ProductPropertiesRuleItem.objects.get_or_create(
+                multi_tenant_company=rule.multi_tenant_company,
+                rule=rule,
+                property=self.merchant_asin_property.local_instance,
+                defaults={
+                    "type": ProductPropertiesRuleItem.REQUIRED,
+                    "sort_order": max_sort + 1,
+                },
+            )
+            if not created_local and rule_item.type != ProductPropertiesRuleItem.REQUIRED:
+                rule_item.type = ProductPropertiesRuleItem.REQUIRED
+                rule_item.save(update_fields=["type"])
+
     def import_rules_process(self):
         sales_channel_views = AmazonSalesChannelView.objects.filter(sales_channel=self.sales_channel)
         self.update_percentage()
@@ -208,6 +279,8 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin):
                 product_type_code=product_type_code,
                 sales_channel=self.sales_channel,
                 multi_tenant_company=self.sales_channel.multi_tenant_company)
+
+            self._ensure_asin_item(product_type)
 
             # Step 1: Get schemas for all marketplaces
             for view in sales_channel_views:

--- a/OneSila/sales_channels/integrations/amazon/factories/rule_sync.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/rule_sync.py
@@ -47,3 +47,50 @@ class AmazonPropertyRuleItemSyncFactory:
                     ):
                         rule_item.type = new_type
                         rule_item.save(update_fields=["type"])
+
+
+class AmazonProductTypeAsinSyncFactory:
+    """Ensure merchant_suggested_asin is required when a product type is mapped."""
+
+    def __init__(self, amazon_product_type):
+        self.amazon_product_type = amazon_product_type
+
+    def run(self):
+        if not self.amazon_product_type.local_instance:
+            return
+
+        asin_property = AmazonProperty.objects.filter(
+            sales_channel=self.amazon_product_type.sales_channel,
+            code="merchant_suggested_asin",
+        ).first()
+
+        if not asin_property or not asin_property.local_instance:
+            return
+
+        item, created = AmazonProductTypeItem.objects.get_or_create(
+            multi_tenant_company=self.amazon_product_type.multi_tenant_company,
+            sales_channel=self.amazon_product_type.sales_channel,
+            amazon_rule=self.amazon_product_type,
+            remote_property=asin_property,
+            defaults={"remote_type": ProductPropertiesRuleItem.REQUIRED},
+        )
+
+        if created or item.remote_type != ProductPropertiesRuleItem.REQUIRED:
+            item.remote_type = ProductPropertiesRuleItem.REQUIRED
+            item.save()
+
+        rule = self.amazon_product_type.local_instance
+        max_sort = rule.items.aggregate(max_sort=Max("sort_order")).get("max_sort") or 0
+        rule_item, created_local = ProductPropertiesRuleItem.objects.get_or_create(
+            multi_tenant_company=rule.multi_tenant_company,
+            rule=rule,
+            property=asin_property.local_instance,
+            defaults={
+                "type": ProductPropertiesRuleItem.REQUIRED,
+                "sort_order": max_sort + 1,
+            },
+        )
+
+        if not created_local and rule_item.type != ProductPropertiesRuleItem.REQUIRED:
+            rule_item.type = ProductPropertiesRuleItem.REQUIRED
+            rule_item.save(update_fields=["type"])

--- a/OneSila/sales_channels/integrations/amazon/migrations/0023_merchant_suggested_asin.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0023_merchant_suggested_asin.py
@@ -1,0 +1,81 @@
+from django.db import migrations
+from django.db.models import Max
+
+def add_merchant_asin(apps, schema_editor):
+    AmazonSalesChannel = apps.get_model('amazon', 'AmazonSalesChannel')
+    AmazonProperty = apps.get_model('amazon', 'AmazonProperty')
+    AmazonProductType = apps.get_model('amazon', 'AmazonProductType')
+    AmazonProductTypeItem = apps.get_model('amazon', 'AmazonProductTypeItem')
+    Property = apps.get_model('properties', 'Property')
+    PropertyTranslation = apps.get_model('properties', 'PropertyTranslation')
+    ProductPropertiesRuleItem = apps.get_model('properties', 'ProductPropertiesRuleItem')
+
+    for sc in AmazonSalesChannel.objects.all().iterator():
+        remote_prop, _ = AmazonProperty.objects.get_or_create(
+            allow_multiple=True,
+            sales_channel=sc,
+            multi_tenant_company=sc.multi_tenant_company,
+            code='merchant_suggested_asin',
+            defaults={'type': 'TEXT'},
+        )
+
+        if not remote_prop.local_instance:
+            local_prop, _ = Property.objects.get_or_create(
+                internal_name='amazon_asin',
+                multi_tenant_company=sc.multi_tenant_company,
+                defaults={'type': 'TEXT', 'non_deletable': True},
+            )
+            PropertyTranslation.objects.get_or_create(
+                property=local_prop,
+                language=sc.multi_tenant_company.language,
+                multi_tenant_company=sc.multi_tenant_company,
+                defaults={'name': 'Amazon Asin'},
+            )
+            if not local_prop.non_deletable:
+                local_prop.non_deletable = True
+                local_prop.save(update_fields=['non_deletable'])
+            remote_prop.local_instance = local_prop
+            remote_prop.save()
+        else:
+            local_prop = remote_prop.local_instance
+
+        for pt in AmazonProductType.objects.filter(sales_channel=sc):
+            item, created = AmazonProductTypeItem.objects.get_or_create(
+                multi_tenant_company=sc.multi_tenant_company,
+                sales_channel=sc,
+                amazon_rule=pt,
+                remote_property=remote_prop,
+                defaults={'remote_type': ProductPropertiesRuleItem.REQUIRED},
+            )
+            if created or item.remote_type != ProductPropertiesRuleItem.REQUIRED:
+                item.remote_type = ProductPropertiesRuleItem.REQUIRED
+                item.save()
+
+            if pt.local_instance:
+                rule = pt.local_instance
+                max_sort = rule.items.aggregate(max_sort=Max('sort_order')).get('max_sort') or 0
+                rule_item, created_local = ProductPropertiesRuleItem.objects.get_or_create(
+                    multi_tenant_company=rule.multi_tenant_company,
+                    rule=rule,
+                    property=local_prop,
+                    defaults={'type': ProductPropertiesRuleItem.REQUIRED, 'sort_order': max_sort + 1},
+                )
+                if not created_local and rule_item.type != ProductPropertiesRuleItem.REQUIRED:
+                    rule_item.type = ProductPropertiesRuleItem.REQUIRED
+                    rule_item.save(update_fields=['type'])
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0022_amazonproperty_allow_multiple'),
+        ('properties', '0012_alter_property_options_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_merchant_asin, noop),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/receivers.py
@@ -7,6 +7,7 @@ from sales_channels.integrations.amazon.models import (
 )
 from sales_channels.integrations.amazon.factories.rule_sync import (
     AmazonPropertyRuleItemSyncFactory,
+    AmazonProductTypeAsinSyncFactory,
 )
 
 
@@ -49,4 +50,15 @@ def sales_channels__amazon_property__sync_rule_item(sender, instance: AmazonProp
         return
 
     sync_factory = AmazonPropertyRuleItemSyncFactory(instance)
+    sync_factory.run()
+
+
+@receiver(post_create, sender='amazon.AmazonProductType')
+@receiver(post_update, sender='amazon.AmazonProductType')
+def sales_channels__amazon_product_type__ensure_asin(sender, instance, **kwargs):
+    signal = kwargs.get('signal')
+    if signal == post_update and not instance.is_dirty_field('local_instance', check_relationship=True):
+        return
+
+    sync_factory = AmazonProductTypeAsinSyncFactory(instance)
     sync_factory.run()


### PR DESCRIPTION
## Summary
- create merchant suggested asin property during schema import
- map local `Amazon Asin` property and prevent deletion
- add property to each product type and sync local rule
- ensure product type mapping also syncs required asin property
- migrate existing data to include new property

## Testing
- `pip install -r requirements.txt`
- `./manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6863bcf6aa34832eaacfdce19751672c