### PR TITLE
Handle variation themes in Amazon schema import

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/admin.py
+++ b/OneSila/sales_channels/integrations/amazon/admin.py
@@ -106,7 +106,16 @@ class AmazonVatAdmin(SalesChannelRemoteAdmin):
 
 @admin.register(AmazonPublicDefinition)
 class AmazonPublicDefinitionAdmin(admin.ModelAdmin):
-    list_display = ("api_region_code", "product_type_code", "code", "name", "is_required", "is_internal", "last_fetched")
+    list_display = (
+        "api_region_code",
+        "product_type_code",
+        "code",
+        "name",
+        "is_required",
+        "is_internal",
+        "allowed_in_configurator",
+        "last_fetched",
+    )
     search_fields = ("code", "name", "product_type_code", "api_region_code")
     list_filter = ("api_region_code", "product_type_code", "is_required", "is_internal")
     readonly_fields = ("last_fetched",)
@@ -123,6 +132,7 @@ class AmazonPublicDefinitionAdmin(admin.ModelAdmin):
                 "usage_definition",
                 "is_required",
                 "is_internal",
+                "allowed_in_configurator",
                 "last_fetched",
             )
         }),

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
@@ -157,6 +157,15 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin):
         public_def.raw_schema = schema_definition
         public_def.is_required = attr_code in required_properties
         public_def.is_internal = attr_code in AMAZON_INTERNAL_PROPERTIES
+
+        allowed = False
+        if attr_code != "variation_theme" and product_type_obj.variation_themes:
+            attr_base = attr_code.split("__", 1)[0].upper()
+            for theme in product_type_obj.variation_themes or []:
+                if attr_base in theme:
+                    allowed = True
+                    break
+        public_def.allowed_in_configurator = allowed
         public_def.save()
 
 
@@ -306,6 +315,19 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin):
                     product_type.save()
 
                 properties = schema_data.get("properties", {})
+
+                variation_schema = properties.get("variation_theme")
+                if variation_schema:
+                    themes = (
+                        variation_schema.get("items", {})
+                        .get("properties", {})
+                        .get("name", {})
+                        .get("enum", [])
+                    )
+                    if themes:
+                        product_type.variation_themes = themes
+                        product_type.save(update_fields=["variation_themes"])
+
                 for code, schema in properties.items():
                     # create AmazonPublicDefinition we will have the thing from the view or instead we can just use the amazon domain thing like Amazon.nl or something that comes from the schema
                     # public_definition = self.get_or_create_public_definition(...)

--- a/OneSila/sales_channels/integrations/amazon/migrations/0024_variation_themes_and_allowed_in_configurator.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0024_variation_themes_and_allowed_in_configurator.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0023_merchant_suggested_asin'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='amazonproducttype',
+            name='variation_themes',
+            field=models.JSONField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='amazonpublicdefinition',
+            name='allowed_in_configurator',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/models/properties.py
@@ -55,6 +55,7 @@ class AmazonPublicDefinition(models.SharedModel):
 
     is_required = models.BooleanField(default=False)
     is_internal = models.BooleanField(default=False)
+    allowed_in_configurator = models.BooleanField(default=False)
 
     def should_refresh(self):
         if not self.last_fetched:
@@ -198,6 +199,8 @@ class AmazonProductType(RemoteObjectMixin, models.Model):
         help_text="Display name for the Amazon product type (e.g., 'Toys & Games').",
         verbose_name="Remote Name"
     )
+
+    variation_themes = JSONField(null=True, blank=True)
 
     objects = AmazonProductTypeManager()
 


### PR DESCRIPTION
## Summary
- store variation theme list on `AmazonProductType`
- mark which public definitions are allowed in configurator
- expose configurator flag in admin
- auto-apply configurator flag when importing schemas

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django_cleanup')*

------
https://chatgpt.com/codex/tasks/task_e_6863ddc41e8c832e81f05ec75654e59e

## Summary by Sourcery

Add support for Amazon variation themes and a configurator eligibility flag by storing variation options on product types, automatically flagging public definitions during schema import, and surfacing the new field in the admin UI.

New Features:
- Store variation themes on AmazonProductType to track available variation options
- Add allowed_in_configurator flag to AmazonPublicDefinition to mark definitions usable in the configurator

Enhancements:
- Extract and store variation themes from imported Amazon schemas
- Auto-assign the configurator flag to public definitions based on variation themes during import
- Expose the allowed_in_configurator field in the admin list and detail views