### PR TITLE
Implement UsageDefinitionFactory and add main_code field

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
@@ -3,7 +3,10 @@ import logging
 from imports_exports.factories.imports import ImportMixin
 from spapi import DefinitionsApi
 from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
-from sales_channels.integrations.amazon.factories.sales_channels.full_schema import ExportDefinitionFactory
+from sales_channels.integrations.amazon.factories.sales_channels.full_schema import (
+    ExportDefinitionFactory,
+    UsageDefinitionFactory,
+)
 from sales_channels.integrations.amazon.models import AmazonSalesChannelView
 from sales_channels.integrations.amazon.models.properties import AmazonProductType, AmazonPublicDefinition, \
     AmazonProperty, AmazonPropertySelectValue, AmazonProductTypeItem
@@ -166,7 +169,8 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin):
             export_definition_fac = ExportDefinitionFactory(public_def)
             export_definition_fac.run()
 
-            # UsageDefinitionFactory(public_def).run()
+            usage_definition_fac = UsageDefinitionFactory(public_def)
+            public_def.usage_definition = usage_definition_fac.run()
             public_def.export_definition = export_definition_fac.results
             public_def.last_fetched = timezone.now()
             public_def.save()

--- a/OneSila/sales_channels/integrations/amazon/migrations/0024_amazonproperty_main_code.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0024_amazonproperty_main_code.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('amazon', '0023_merchant_suggested_asin'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='amazonproperty',
+            name='main_code',
+            field=models.CharField(blank=True, max_length=255, help_text='The main attribute code (part before "__").'),
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/models/properties.py
@@ -85,6 +85,12 @@ class AmazonProperty(RemoteProperty):
         verbose_name="Attribute Code",
     )
 
+    main_code = models.CharField(
+        max_length=255,
+        blank=True,
+        help_text="The main attribute code (part before '__').",
+    )
+
     name = models.CharField(
         max_length=255,
         help_text="The display label for the remote value (e.g., 'Red').",
@@ -112,12 +118,15 @@ class AmazonProperty(RemoteProperty):
                 }
             )
 
+        if self.code:
+            self.main_code = self.code.split("__", 1)[0]
+
         super().save(*args, **kwargs)
 
     class Meta:
         verbose_name = 'Amazon Property'
         verbose_name_plural = 'Amazon Properties'
-        search_terms = ['name', 'code']
+        search_terms = ['name', 'code', 'main_code']
 
 
 class AmazonPropertySelectValue(RemoteObjectMixin, models.Model):

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_usage_definition.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_usage_definition.py
@@ -1,0 +1,49 @@
+from core.tests import TestCase
+from sales_channels.integrations.amazon.factories.sales_channels.full_schema import UsageDefinitionFactory
+from sales_channels.integrations.amazon.models.properties import AmazonPublicDefinition
+from sales_channels.integrations.amazon.tests.schema_data import BATTERY_SCHEMA
+import json
+
+
+class UsageDefinitionFactoryTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.public_definition = AmazonPublicDefinition.objects.create(
+            product_type_code="BATTERY",
+            raw_schema=BATTERY_SCHEMA["battery"],
+            api_region_code="EU_UK",
+            code="battery",
+            name="Battery",
+        )
+
+    def test_battery_usage_definition(self):
+        factory = UsageDefinitionFactory(self.public_definition)
+        result = factory.run()
+        data = json.loads(result)
+        expected = {
+            "battery": [
+                {
+                    "cell_composition": [
+                        {"value": "%value:battery__cell_composition%"}
+                    ],
+                    "cell_composition_other_than_listed": [
+                        {
+                            "value": "%value:battery__cell_composition%",
+                            "language_tag": "%auto:language%"
+                        }
+                    ],
+                    "iec_code": [
+                        {"value": "%value:battery__iec_code%"}
+                    ],
+                    "weight": [
+                        {
+                            "value": "%value:battery__weight%",
+                            "unit": "%unit:weight%"
+                        }
+                    ],
+                    "marketplace_id": "%auto:marketplace_id%"
+                }
+            ]
+        }
+        self.assertEqual(data, expected)
+


### PR DESCRIPTION
## Summary
- add `main_code` field to `AmazonProperty`
- create `UsageDefinitionFactory` for rendering schema tokens
- generate usage definitions during schema import
- add migration for `main_code`
- add unit test for `UsageDefinitionFactory`

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_usage_definition` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6863ece0991c832ebe662e1f1be48303

## Summary by Sourcery

Implement generation of usage definitions via a new UsageDefinitionFactory and integrate it into schema imports, add and persist a main_code field on AmazonProperty with corresponding migration and model enhancements, and verify functionality with a dedicated unit test.

New Features:
- Introduce UsageDefinitionFactory to generate Amazon SP-API usage definitions from raw schema
- Add main_code field to AmazonProperty model to capture the primary attribute code
- Populate usage_definition on AmazonPublicDefinition during schema import

Enhancements:
- Derive and store main_code from property code in model save
- Include main_code in AmazonProperty search terms

Build:
- Add migration to add main_code field to AmazonProperty

Tests:
- Add unit test for UsageDefinitionFactory to validate generated usage definitions