### PR TITLE
Fix usage definition attr codes

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/sales_channels/full_schema.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sales_channels/full_schema.py
@@ -303,9 +303,16 @@ class UsageDefinitionFactory:
     def _compose_attr_code(self):
         keys = []
         for part in self.current_path:
-            if part in {"value", "language_tag", "marketplace_id", "unit"}:
+            if part in {"value", "language_tag", "marketplace_id", "unit", "standardized_values"}:
                 continue
             if part.endswith("_other_than_listed"):
                 part = part.replace("_other_than_listed", "")
             keys.append(part)
-        return "__".join([self.public_definition.code] + keys) if keys and keys[0] != self.public_definition.code else "__".join(keys)
+
+        if not keys:
+            return self.public_definition.code
+
+        if keys[0] != self.public_definition.code:
+            return "__".join([self.public_definition.code] + keys)
+
+        return "__".join(keys)

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_usage_definition.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_usage_definition.py
@@ -96,7 +96,7 @@ class UsageDefinitionFactoryTest(TestCase):
         expected = {
             "number_of_lithium_metal_cells": [
                 {
-                    "value": "%value:%",
+                    "value": "%value:number_of_lithium_metal_cells%",
                     "marketplace_id": "%auto:marketplace_id%",
                 }
             ]
@@ -119,7 +119,7 @@ class UsageDefinitionFactoryTest(TestCase):
         expected = {
             "customer_package_type": [
                 {
-                    "value": "%value:%",
+                    "value": "%value:customer_package_type%",
                     "language_tag": "%auto:language%",
                     "marketplace_id": "%auto:marketplace_id%",
                 }
@@ -143,7 +143,7 @@ class UsageDefinitionFactoryTest(TestCase):
         expected = {
             "power_plug_type": [
                 {
-                    "value": "%value:%",
+                    "value": "%value:power_plug_type%",
                     "marketplace_id": "%auto:marketplace_id%",
                 }
             ]
@@ -166,7 +166,7 @@ class UsageDefinitionFactoryTest(TestCase):
         expected = {
             "controller_type": [
                 {
-                    "value": "%value:%",
+                    "value": "%value:controller_type%",
                     "language_tag": "%auto:language%",
                     "marketplace_id": "%auto:marketplace_id%",
                 }
@@ -191,7 +191,7 @@ class UsageDefinitionFactoryTest(TestCase):
             "product_site_launch_date": [
                 {
                     "marketplace_id": "%auto:marketplace_id%",
-                    "value": "%value:%",
+                    "value": "%value:product_site_launch_date%",
                 }
             ]
         }
@@ -213,8 +213,8 @@ class UsageDefinitionFactoryTest(TestCase):
         expected = {
             "color": [
                 {
-                    "standardized_values": ["%value:color__standardized_values%"],
-                    "value": "%value:%",
+                    "standardized_values": ["%value:color%"],
+                    "value": "%value:color%",
                     "language_tag": "%auto:language%",
                     "marketplace_id": "%auto:marketplace_id%",
                 }


### PR DESCRIPTION
## Summary
- ensure UsageDefinitionFactory includes root code in composed attribute names
- handle `standardized_values` in attr code composition
- update UsageDefinitionFactory tests to expect correct attribute placeholders

## Testing
- `python manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_usage_definition -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6864199fbc28832e9b3ad177d7845b9c

## Summary by Sourcery

Fix attribute code composition in UsageDefinitionFactory to properly include the root code, handle standardized_values, and update tests to expect correct attribute placeholders.

Bug Fixes:
- Include standardized_values in the attr code composition skip list.
- Return the public definition code when no nested keys are present.
- Always prepend the public definition code for nested attribute codes if not already present.

Tests:
- Update UsageDefinitionFactory tests to expect the correct %value:attribute% placeholders instead of %value:% for various attributes.