### PR TITLE
Update unit token handling

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/sales_channels/full_schema.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sales_channels/full_schema.py
@@ -290,8 +290,8 @@ class UsageDefinitionFactory:
                 elif key == "language_tag":
                     result[key] = "%auto:language%"
                 elif key == "unit":
-                    parent = self.current_path[-2] if len(self.current_path) >= 2 else ""
-                    result[key] = f"%unit:{parent}%"
+                    attr_code = self._compose_attr_code()
+                    result[key] = f"%unit:{attr_code}%"
                 else:
                     result[key] = self._process(value)
                 self.current_path.pop()

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_usage_definition.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_usage_definition.py
@@ -47,7 +47,7 @@ class UsageDefinitionFactoryTest(TestCase):
                     "weight": [
                         {
                             "value": "%value:battery__weight%",
-                            "unit": "%unit:weight%"
+                            "unit": "%unit:battery__weight%"
                         }
                     ],
                     "marketplace_id": "%auto:marketplace_id%"


### PR DESCRIPTION
## Summary
- compute unit token using full attribute code in `UsageDefinitionFactory`
- update tests to expect `%unit:battery__weight%`

## Testing
- `pytest -q` *(fails: django settings not configured)*

------
https://chatgpt.com/codex/tasks/task_e_686420f09f04832eb957d62f441adbee

## Summary by Sourcery

Update unit token logic to use full attribute code in UsageDefinitionFactory and adjust tests accordingly

Bug Fixes:
- Correct unit token generation to include full attribute code in UsageDefinitionFactory

Tests:
- Adjust tests to expect '%unit:battery__weight%' format for unit tokens