### PR TITLE
Add GraphQL schema for AmazonDefaultUnitConfigurator

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -13,6 +13,7 @@ from sales_channels.integrations.amazon.schema.types.input import (
     AmazonProductTypeItemPartialInput,
     AmazonSalesChannelImportInput,
     AmazonSalesChannelImportPartialInput,
+    AmazonDefaultUnitConfiguratorPartialInput,
     AmazonValidateAuthInput,
 )
 from sales_channels.integrations.amazon.schema.types.types import (
@@ -23,6 +24,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonProductTypeItemType,
     AmazonRedirectUrlType,
     AmazonSalesChannelImportType,
+    AmazonDefaultUnitConfiguratorType,
 )
 from core.schema.core.mutations import create, type, List, update, delete
 from strawberry import Info
@@ -82,6 +84,8 @@ class AmazonSalesChannelMutation:
     update_amazon_property_select_value: AmazonPropertySelectValueType = update(AmazonPropertySelectValuePartialInput)
     update_amazon_product_type: AmazonProductTypeType = update(AmazonProductTypePartialInput)
     update_amazon_product_type_item: AmazonProductTypeItemType = update(AmazonProductTypeItemPartialInput)
+
+    update_amazon_default_unit_configurator: AmazonDefaultUnitConfiguratorType = update(AmazonDefaultUnitConfiguratorPartialInput)
 
     create_amazon_import_process: AmazonSalesChannelImportType = create(AmazonSalesChannelImportInput)
     update_amazon_import_process: AmazonSalesChannelImportType = update(AmazonSalesChannelImportPartialInput)

--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -6,6 +6,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonProductTypeType,
     AmazonProductTypeItemType,
     AmazonSalesChannelImportType,
+    AmazonDefaultUnitConfiguratorType,
 )
 
 
@@ -28,3 +29,6 @@ class AmazonSalesChannelsQuery:
 
     amazon_import_process: AmazonSalesChannelImportType = node()
     amazon_import_processes: DjangoListConnection[AmazonSalesChannelImportType] = connection()
+
+    amazon_default_unit_configurator: AmazonDefaultUnitConfiguratorType = node()
+    amazon_default_unit_configurators: DjangoListConnection[AmazonDefaultUnitConfiguratorType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -13,6 +13,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonPropertySelectValue,
     AmazonProductType,
     AmazonSalesChannelImport, AmazonProductTypeItem,
+    AmazonDefaultUnitConfigurator,
 )
 from properties.schema.types.filters import (
     PropertyFilter,
@@ -116,3 +117,9 @@ class AmazonSalesChannelImportFilter(SearchFilterMixin):
     sales_channel: Optional[SalesChannelFilter]
     status: auto
     type: auto
+
+
+@filter(AmazonDefaultUnitConfigurator)
+class AmazonDefaultUnitConfiguratorFilter(SearchFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]

--- a/OneSila/sales_channels/integrations/amazon/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/input.py
@@ -6,6 +6,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProductType,
     AmazonProductTypeItem,
     AmazonSalesChannelImport,
+    AmazonDefaultUnitConfigurator,
 )
 
 
@@ -73,4 +74,14 @@ class AmazonSalesChannelImportInput:
 
 @partial(AmazonSalesChannelImport, fields="__all__")
 class AmazonSalesChannelImportPartialInput(NodeInput):
+    pass
+
+
+@input(AmazonDefaultUnitConfigurator, fields="__all__")
+class AmazonDefaultUnitConfiguratorInput:
+    pass
+
+
+@partial(AmazonDefaultUnitConfigurator, fields="__all__")
+class AmazonDefaultUnitConfiguratorPartialInput(NodeInput):
     pass

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -7,6 +7,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProductType,
     AmazonProductTypeItem,
     AmazonSalesChannelImport,
+    AmazonDefaultUnitConfigurator,
 )
 
 
@@ -37,4 +38,9 @@ class AmazonProductTypeItemOrder:
 
 @order(AmazonSalesChannelImport)
 class AmazonSalesChannelImportOrder:
+    id: auto
+
+
+@order(AmazonDefaultUnitConfigurator)
+class AmazonDefaultUnitConfiguratorOrder:
     id: auto

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -17,6 +17,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProductType,
     AmazonProductTypeItem,
     AmazonSalesChannelImport,
+    AmazonDefaultUnitConfigurator,
 )
 from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonSalesChannelFilter,
@@ -33,6 +34,7 @@ from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonProductTypeOrder,
     AmazonProductTypeItemOrder,
     AmazonSalesChannelImportOrder,
+    AmazonDefaultUnitConfiguratorOrder,
 )
 
 
@@ -179,3 +181,17 @@ class AmazonProductTypeItemType(relay.Node, GetQuerysetMultiTenantMixin):
         'ProductPropertiesRuleItemType',
         lazy("properties.schema.types.types")
     ]]
+
+
+@type(
+    AmazonDefaultUnitConfigurator,
+    filters=AmazonDefaultUnitConfiguratorFilter,
+    order=AmazonDefaultUnitConfiguratorOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonDefaultUnitConfiguratorType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'AmazonSalesChannelType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]


### PR DESCRIPTION
## Summary
- add AmazonDefaultUnitConfigurator to GraphQL inputs, filters and ordering
- expose AmazonDefaultUnitConfigurator type and queries
- allow updating AmazonDefaultUnitConfigurator via mutations

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/schema/types/input.py OneSila/sales_channels/integrations/amazon/schema/types/filters.py OneSila/sales_channels/integrations/amazon/schema/types/ordering.py OneSila/sales_channels/integrations/amazon/schema/types/types.py OneSila/sales_channels/integrations/amazon/schema/queries.py OneSila/sales_channels/integrations/amazon/schema/mutations.py`
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6864322a2c00832e9bd440d2fb961be9

## Summary by Sourcery

Add GraphQL schema support for AmazonDefaultUnitConfigurator including type, inputs, filters, ordering, queries, and update mutation.

New Features:
- Add AmazonDefaultUnitConfiguratorType to GraphQL schema with filtering, ordering, and pagination support
- Add GraphQL input and partial input types for AmazonDefaultUnitConfigurator
- Add filter and ordering definitions for AmazonDefaultUnitConfigurator
- Expose single and list queries for AmazonDefaultUnitConfigurator
- Add GraphQL mutation for updating AmazonDefaultUnitConfigurator