### PR TITLE
Refactor unit configurator handling

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
@@ -6,8 +6,11 @@ from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixi
 from sales_channels.integrations.amazon.factories.sales_channels.full_schema import (
     ExportDefinitionFactory,
     UsageDefinitionFactory,
+    DefaultUnitConfiguratorFactory,
 )
-from sales_channels.integrations.amazon.models import AmazonSalesChannelView
+from sales_channels.integrations.amazon.models import (
+    AmazonSalesChannelView,
+)
 from sales_channels.integrations.amazon.models.properties import AmazonProductType, AmazonPublicDefinition, \
     AmazonProperty, AmazonPropertySelectValue, AmazonProductTypeItem
 from properties.models import ProductPropertiesRuleItem, Property, PropertyTranslation
@@ -250,6 +253,7 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin):
                 remote_rule_item.remote_type = new_type
                 remote_rule_item.save()
 
+
     def _ensure_asin_item(self, product_type):
         if not self.merchant_asin_property:
             return
@@ -341,6 +345,11 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin):
                         continue
 
                     self.create_remote_properties(public_definition, product_type, view, is_default)
+                    DefaultUnitConfiguratorFactory(
+                        public_definition,
+                        self.sales_channel,
+                        is_default,
+                    ).run()
 
             self.update_percentage()
 


### PR DESCRIPTION
## Summary
- move default unit configurator logic to `DefaultUnitConfiguratorFactory`
- call new factory from schema import processor

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6864327e08f0832e9340f36755df5d42

## Summary by Sourcery

Extract default unit configurator logic into a dedicated factory and integrate its invocation into the Amazon schema import process

Enhancements:
- Introduce DefaultUnitConfiguratorFactory to centralize creation and updating of AmazonDefaultUnitConfigurator entries based on schema definitions
- Invoke DefaultUnitConfiguratorFactory within the schema import processor after remote property creation to register unit configurators