### PR TITLE
Add admin for AmazonDefaultUnitConfigurator

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/admin.py
+++ b/OneSila/sales_channels/integrations/amazon/admin.py
@@ -19,9 +19,11 @@ from sales_channels.integrations.amazon.models import (
     AmazonEanCode,
     AmazonImageProductAssociation,
     AmazonVat,
+    AmazonDefaultUnitConfigurator,
 )
 from sales_channels.integrations.amazon.models.properties import AmazonPublicDefinition
 from sales_channels.models import SalesChannelViewAssign
+
 
 @admin.register(AmazonSalesChannel)
 class AmazonSalesChannelAdmin(PolymorphicChildModelAdmin):
@@ -40,69 +42,91 @@ class AmazonSalesChannelAdmin(PolymorphicChildModelAdmin):
         }),
     )
 
+
 @admin.register(AmazonProperty)
 class AmazonPropertyAdmin(SalesChannelRemoteAdmin):
     pass
+
 
 @admin.register(AmazonPropertySelectValue)
 class AmazonPropertySelectValueAdmin(SalesChannelRemoteAdmin):
     pass
 
+
 @admin.register(AmazonProductProperty)
 class AmazonProductPropertyAdmin(SalesChannelRemoteAdmin):
     pass
+
 
 @admin.register(AmazonSalesChannelView)
 class AmazonSalesChannelViewAdmin(SalesChannelRemoteAdmin):
     pass
 
+
 @admin.register(AmazonRemoteLanguage)
 class AmazonRemoteLanguageAdmin(SalesChannelRemoteAdmin):
     pass
+
 
 @admin.register(AmazonCurrency)
 class AmazonCurrencyAdmin(SalesChannelRemoteAdmin):
     pass
 
+
 @admin.register(AmazonProductType)
 class AmazonProductTypeAdmin(SalesChannelRemoteAdmin):
     pass
+
 
 @admin.register(AmazonProductTypeItem)
 class AmazonProductTypeItemAdmin(SalesChannelRemoteAdmin):
     pass
 
+
 @admin.register(AmazonOrder)
 class AmazonOrderAdmin(SalesChannelRemoteAdmin):
     pass
+
 
 @admin.register(AmazonOrderItem)
 class AmazonOrderItemAdmin(SalesChannelRemoteAdmin):
     pass
 
+
 @admin.register(AmazonProduct)
 class AmazonProductAdmin(SalesChannelRemoteProductAdmin):
     pass
+
 
 @admin.register(AmazonProductContent)
 class AmazonProductContentAdmin(SalesChannelRemoteAdmin):
     pass
 
+
 @admin.register(AmazonPrice)
 class AmazonPriceAdmin(SalesChannelRemoteAdmin):
     pass
+
 
 @admin.register(AmazonEanCode)
 class AmazonEanCodeAdmin(SalesChannelRemoteAdmin):
     pass
 
+
 @admin.register(AmazonImageProductAssociation)
 class AmazonImageProductAssociationAdmin(SalesChannelRemoteAdmin):
     pass
 
+
 @admin.register(AmazonVat)
 class AmazonVatAdmin(SalesChannelRemoteAdmin):
     pass
+
+
+@admin.register(AmazonDefaultUnitConfigurator)
+class AmazonDefaultUnitConfiguratorAdmin(SalesChannelRemoteAdmin):
+    pass
+
 
 @admin.register(AmazonPublicDefinition)
 class AmazonPublicDefinitionAdmin(admin.ModelAdmin):


### PR DESCRIPTION
## Summary
- register AmazonDefaultUnitConfigurator in Amazon admin
- provide admin class for managing default unit configurators

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/admin.py`

------
https://chatgpt.com/codex/tasks/task_e_686465cf4b94832eb386c9c52b62aa94