### PR TITLE
Add marketplace to DefaultUnitConfigurator

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/migrations/0027_amazondefaultunitconfigurator_marketplace.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0027_amazondefaultunitconfigurator_marketplace.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def delete_configurators(apps, schema_editor):
+    AmazonDefaultUnitConfigurator = apps.get_model('amazon', 'AmazonDefaultUnitConfigurator')
+    AmazonDefaultUnitConfigurator.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0026_alter_amazonproperty_main_code_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_configurators, migrations.RunPython.noop),
+        migrations.AddField(
+            model_name='amazondefaultunitconfigurator',
+            name='marketplace',
+            field=models.ForeignKey(
+                default=1,
+                on_delete=django.db.models.deletion.CASCADE,
+                help_text='The Amazon marketplace for this value.',
+                to='amazon.amazonsaleschannelview',
+            ),
+            preserve_default=False,
+        ),
+        migrations.AlterUniqueTogether(
+            name='amazondefaultunitconfigurator',
+            unique_together={('sales_channel', 'marketplace', 'code')},
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/sales_channels.py
+++ b/OneSila/sales_channels/integrations/amazon/models/sales_channels.py
@@ -149,13 +149,18 @@ class AmazonDefaultUnitConfigurator(models.Model):
         on_delete=models.CASCADE,
         related_name="default_unit_configurators",
     )
+    marketplace = models.ForeignKey(
+        'amazon.AmazonSalesChannelView',
+        on_delete=models.CASCADE,
+        help_text="The Amazon marketplace for this value."
+    )
     name = models.CharField(max_length=255)
     code = models.CharField(max_length=255)
     selected_unit = models.CharField(max_length=100, null=True, blank=True)
     choices = models.JSONField(default=list, blank=True)
 
     class Meta:
-        unique_together = ("sales_channel", "code")
+        unique_together = ("sales_channel", "marketplace", "code")
         verbose_name = "Default Unit Configurator"
         verbose_name_plural = "Default Unit Configurators"
 

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -123,3 +123,4 @@ class AmazonSalesChannelImportFilter(SearchFilterMixin):
 class AmazonDefaultUnitConfiguratorFilter(SearchFilterMixin):
     id: auto
     sales_channel: Optional[SalesChannelFilter]
+    marketplace: Optional[SalesChannelViewFilter]

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -195,3 +195,7 @@ class AmazonDefaultUnitConfiguratorType(relay.Node, GetQuerysetMultiTenantMixin)
         'AmazonSalesChannelType',
         lazy("sales_channels.integrations.amazon.schema.types.types")
     ]
+    marketplace: Annotated[
+        'SalesChannelViewType',
+        lazy("sales_channels.schema.types.types")
+    ]


### PR DESCRIPTION
## Summary
- wipe old AmazonDefaultUnitConfigurators then add marketplace FK
- track marketplace in DefaultUnitConfigurator factory
- extend schema types and filters with marketplace
- adjust tests for new field

## Testing
- `coverage run --source='.' OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_default_unit_configurator -v 2` *(fails: ModuleNotFoundError: No module named 'strawberry_django')*

------
https://chatgpt.com/codex/tasks/task_e_68646872bad4832e937e744c5c64ca3d