### PR TITLE
Implement Amazon media image factories

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/__init__.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/__init__.py
@@ -1,0 +1,6 @@
+from .properties import AmazonProductPropertyCreateFactory, AmazonProductPropertyUpdateFactory, AmazonProductPropertyDeleteFactory
+from .products import (
+    AmazonMediaProductThroughCreateFactory,
+    AmazonMediaProductThroughUpdateFactory,
+    AmazonMediaProductThroughDeleteFactory,
+)

--- a/OneSila/sales_channels/integrations/amazon/factories/products/__init__.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/__init__.py
@@ -1,0 +1,5 @@
+from .images import (
+    AmazonMediaProductThroughCreateFactory,
+    AmazonMediaProductThroughUpdateFactory,
+    AmazonMediaProductThroughDeleteFactory,
+)

--- a/OneSila/sales_channels/integrations/amazon/factories/products/images.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/images.py
@@ -1,0 +1,129 @@
+import json
+
+from spapi import ListingsApi
+
+from media.models import Media, MediaProductThrough
+from sales_channels.factories.products.images import (
+    RemoteMediaProductThroughCreateFactory,
+    RemoteMediaProductThroughUpdateFactory,
+    RemoteMediaProductThroughDeleteFactory,
+)
+from sales_channels.integrations.amazon.factories.mixins import (
+    GetAmazonAPIMixin,
+    AmazonListingIssuesMixin,
+)
+from sales_channels.integrations.amazon.models.products import (
+    AmazonImageProductAssociation,
+)
+
+
+class AmazonMediaProductThroughBase(GetAmazonAPIMixin, AmazonListingIssuesMixin):
+    """Common logic for Amazon media-product associations."""
+
+    remote_model_class = AmazonImageProductAssociation
+
+    OFFER_KEYS = [
+        "main_offer_image_locator",
+        *[f"other_offer_image_locator_{i}" for i in range(1, 6)],
+    ]
+    PRODUCT_KEYS = [
+        "main_product_image_locator",
+        *[f"other_product_image_locator_{i}" for i in range(1, 9)],
+    ]
+
+    def __init__(self, *args, view=None, get_value_only=False, **kwargs):
+        self.view = view
+        self.get_value_only = get_value_only
+        super().__init__(*args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _get_images(self):
+        product = self.remote_product.local_instance
+        throughs = (
+            MediaProductThrough.objects.filter(
+                product=product, media__type=Media.IMAGE
+            )
+            .order_by("sort_order")
+        )
+        return [t.media.image_web_url for t in throughs if t.media.image_web_url]
+
+    def build_attributes(self):
+        urls = self._get_images()
+        attrs = {}
+        for idx, key in enumerate(self.OFFER_KEYS):
+            attrs[key] = [{"media_location": urls[idx]}] if idx < len(urls) else None
+        for idx, key in enumerate(self.PRODUCT_KEYS):
+            attrs[key] = [{"media_location": urls[idx]}] if idx < len(urls) else None
+        return attrs
+
+    def build_body(self):
+        return {
+            "productType": self.remote_product.remote_type,
+            "requirements": "LISTING",
+            "attributes": self.build_attributes(),
+        }
+
+    def patch_listings(self, body):
+        if self.get_value_only:
+            return body["attributes"]
+        listings = ListingsApi(self._get_client())
+        response = listings.patch_listings_item(
+            seller_id=self.sales_channel.remote_id,
+            sku=self.remote_product.remote_sku,
+            marketplace_ids=[self.view.remote_id],
+            body=body,
+        )
+        self.update_assign_issues(getattr(response, "issues", []))
+        return response
+
+    def build_payload(self):
+        # override default payload building from base factories
+        self.payload = {}
+        return self.payload
+
+    def serialize_response(self, response):
+        return json.dumps(response.payload) if hasattr(response, "payload") else True
+
+    def needs_update(self):
+        return True
+
+
+class AmazonMediaProductThroughCreateFactory(
+    AmazonMediaProductThroughBase, RemoteMediaProductThroughCreateFactory
+):
+    def create_remote(self):
+        body = self.build_body()
+        return self.patch_listings(body)
+
+    def customize_remote_instance_data(self):
+        self.remote_instance_data["remote_product"] = self.remote_product
+        self.remote_instance_data["current_position"] = self.local_instance.sort_order
+        return self.remote_instance_data
+
+
+class AmazonMediaProductThroughUpdateFactory(
+    AmazonMediaProductThroughBase, RemoteMediaProductThroughUpdateFactory
+):
+    create_factory_class = AmazonMediaProductThroughCreateFactory
+
+    def update_remote(self):
+        body = self.build_body()
+        return self.patch_listings(body)
+
+    def customize_remote_instance_data(self):
+        self.remote_instance_data["remote_product"] = self.remote_product
+        self.remote_instance_data["current_position"] = self.local_instance.sort_order
+        return self.remote_instance_data
+
+
+class AmazonMediaProductThroughDeleteFactory(
+    AmazonMediaProductThroughBase, RemoteMediaProductThroughDeleteFactory
+):
+    delete_remote_instance = True
+
+    def delete_remote(self):
+        body = self.build_body()
+        return self.patch_listings(body)
+


### PR DESCRIPTION
## Summary
- add factories for Amazon media product associations
- expose new factories in integration package

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'huey')*

------
https://chatgpt.com/codex/tasks/task_e_6865245b7e28832e9bf741136abcd5bf

## Summary by Sourcery

Introduce factories for syncing local product images with Amazon listings via the SP API.

New Features:
- Add AmazonMediaProductThroughBase and associated Create, Update, and Delete factories for managing Amazon image associations
- Expose the new media image factories in the Amazon integration package