### PR TITLE
Fix ordering on translated querysets

### DIFF
--- a/OneSila/core/schema/core/mixins.py
+++ b/OneSila/core/schema/core/mixins.py
@@ -21,6 +21,39 @@ class GetQuerysetMultiTenantMixin:
         return queryset.filter(multi_tenant_company=multi_tenant_company).order_by(*ordering)
 
 
+class GetPropertyQuerysetMultiTenantMixin:
+    @classmethod
+    def get_queryset(cls, queryset, info, **kwargs):
+        multi_tenant_company = get_multi_tenant_company(info)
+        return (
+            queryset.filter(multi_tenant_company=multi_tenant_company)
+            .with_translated_name()
+            .order_by('translated_name')
+        )
+
+
+class GetPropertySelectValueQuerysetMultiTenantMixin:
+    @classmethod
+    def get_queryset(cls, queryset, info, **kwargs):
+        multi_tenant_company = get_multi_tenant_company(info)
+        return (
+            queryset.filter(multi_tenant_company=multi_tenant_company)
+            .with_translated_value()
+            .order_by('translated_value')
+        )
+
+
+class GetProductQuerysetMultiTenantMixin:
+    @classmethod
+    def get_queryset(cls, queryset, info, **kwargs):
+        multi_tenant_company = get_multi_tenant_company(info)
+        return (
+            queryset.filter(multi_tenant_company=multi_tenant_company)
+            .with_translated_name()
+            .order_by('translated_name')
+        )
+
+
 class GetCurrentUserMixin:
     @classmethod
     def get_current_user(self, info, fail_silently=False):

--- a/OneSila/products/schema/types/types.py
+++ b/OneSila/products/schema/types/types.py
@@ -2,7 +2,8 @@ from decimal import Decimal
 
 from strawberry.relay.utils import to_base64
 from contacts.schema.types.types import CompanyType
-from core.schema.core.types.types import relay, type, GetQuerysetMultiTenantMixin, field, Annotated, lazy, strawberry_type
+from core.schema.core.types.types import relay, type, field, Annotated, lazy, strawberry_type
+from core.schema.core.mixins import GetProductQuerysetMultiTenantMixin, GetQuerysetMultiTenantMixin
 
 from typing import List, Optional
 
@@ -46,7 +47,7 @@ from .ordering import (
 
 
 @type(Product, filters=ProductFilter, order=ProductOrder, pagination=True, fields="__all__")
-class ProductType(relay.Node, GetQuerysetMultiTenantMixin):
+class ProductType(relay.Node, GetProductQuerysetMultiTenantMixin):
     vat_rate: Optional[VatRateType]
     inspector: Optional[Annotated['InspectorType', lazy('products_inspector.schema.types.types')]]
     saleschannelviewassign_set: List[Annotated['SalesChannelViewAssignType', lazy("sales_channels.schema.types.types")]]
@@ -108,36 +109,36 @@ class ProductTranslationType(relay.Node, GetQuerysetMultiTenantMixin):
 
 
 @type(BundleProduct, filters=BundleProductFilter, order=BundleProductOrder, pagination=True, fields="__all__")
-class BundleProductType(relay.Node, GetQuerysetMultiTenantMixin):
+class BundleProductType(relay.Node, GetProductQuerysetMultiTenantMixin):
     pass
 
 
 @type(ConfigurableProduct, filters=ConfigurableProductFilter, order=ConfigurableProductOrder, pagination=True, fields="__all__")
-class ConfigurableProductType(relay.Node, GetQuerysetMultiTenantMixin):
+class ConfigurableProductType(relay.Node, GetProductQuerysetMultiTenantMixin):
     pass
 
 
 @type(SimpleProduct, filters=SimpleProductFilter, order=SimpleProductOrder, pagination=True, fields="__all__")
-class SimpleProductType(relay.Node, GetQuerysetMultiTenantMixin):
+class SimpleProductType(relay.Node, GetProductQuerysetMultiTenantMixin):
     @field()
     def name(self, info) -> str | None:
         return self.name
 
 
 @type(ConfigurableVariation, filters=ConfigurableVariationFilter, order=ConfigurableVariationOrder, pagination=True, fields="__all__")
-class ConfigurableVariationType(relay.Node, GetQuerysetMultiTenantMixin):
+class ConfigurableVariationType(relay.Node, GetProductQuerysetMultiTenantMixin):
     parent: Optional[ProductType]
     variation: Optional[ProductType]
 
 
 @type(BundleVariation, filters=BundleVariationFilter, order=BundleVariationOrder, pagination=True, fields="__all__")
-class BundleVariationType(relay.Node, GetQuerysetMultiTenantMixin):
+class BundleVariationType(relay.Node, GetProductQuerysetMultiTenantMixin):
     parent: Optional[ProductType]
     variation: Optional[ProductType]
 
 
 @type(AliasProduct, filters=AliasProductFilter, order=AliasProductOrder, pagination=True, fields="__all__")
-class AliasProductType(relay.Node, GetQuerysetMultiTenantMixin):
+class AliasProductType(relay.Node, GetProductQuerysetMultiTenantMixin):
 
     @field()
     def name(self, info) -> str | None:

--- a/OneSila/properties/managers.py
+++ b/OneSila/properties/managers.py
@@ -69,7 +69,6 @@ class PropertyQuerySet(MultiTenantQuerySet):
 
         super().delete(*args, **kwargs)
 
-
     def with_translated_name(self):
         from .models import PropertyTranslation
 
@@ -81,6 +80,7 @@ class PropertyQuerySet(MultiTenantQuerySet):
                 .values('name')[:1]
             )
         )
+
 
 class PropertyManager(MultiTenantManager):
     def get_queryset(self):
@@ -107,6 +107,18 @@ class PropertySelectValueQuerySet(MultiTenantQuerySet):
                   "Please delete the product type rule to remove them."))
 
         return super().delete(*args, **kwargs)
+
+    def with_translated_value(self):
+        from .models import PropertySelectValueTranslation
+
+        return self.annotate(
+            translated_value=Subquery(
+                PropertySelectValueTranslation.objects
+                .filter(propertyselectvalue=OuterRef('pk'))
+                .order_by('value')
+                .values('value')[:1]
+            )
+        )
 
 
 class PropertySelectValueManager(MultiTenantManager):

--- a/OneSila/properties/schema/types/types.py
+++ b/OneSila/properties/schema/types/types.py
@@ -1,4 +1,9 @@
-from core.schema.core.types.types import relay, type, GetQuerysetMultiTenantMixin, field, Annotated, lazy
+from core.schema.core.types.types import relay, type, field, Annotated, lazy
+from core.schema.core.mixins import (
+    GetPropertyQuerysetMultiTenantMixin,
+    GetPropertySelectValueQuerysetMultiTenantMixin,
+    GetQuerysetMultiTenantMixin,
+)
 
 from typing import List, Optional
 from media.schema.types.types import ImageType
@@ -13,7 +18,7 @@ from .ordering import PropertyOrder, PropertyTranslationOrder, \
 
 
 @type(Property, filters=PropertyFilter, order=PropertyOrder, pagination=True, fields="__all__")
-class PropertyType(relay.Node, GetQuerysetMultiTenantMixin):
+class PropertyType(relay.Node, GetPropertyQuerysetMultiTenantMixin):
     propertytranslation_set: List[Annotated['PropertyTranslationType', lazy("properties.schema.types.types")]]
 
     @field()
@@ -27,7 +32,7 @@ class PropertyTranslationType(relay.Node, GetQuerysetMultiTenantMixin):
 
 
 @type(PropertySelectValue, filters=PropertySelectValueFilter, order=PropertySelectValueOrder, pagination=True, fields="__all__")
-class PropertySelectValueType(relay.Node, GetQuerysetMultiTenantMixin):
+class PropertySelectValueType(relay.Node, GetPropertySelectValueQuerysetMultiTenantMixin):
     property: PropertyType
     image: Optional[ImageType]
     productpropertiesrule_set: List[Annotated['ProductPropertiesRuleType', lazy("properties.schema.types.types")]]


### PR DESCRIPTION
## Summary
- add queryset mixins that order by translations via annotations
- expose custom ordering for properties and products

## Testing
- `pre-commit run --files OneSila/core/schema/core/mixins.py OneSila/properties/managers.py OneSila/products/managers.py OneSila/products/schema/types/types.py OneSila/properties/schema/types/types.py`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'daphne')*

------
https://chatgpt.com/codex/tasks/task_e_686576b7303c832e861d49fbe4762ae3

## Summary by Sourcery

Expose ordering on translated querysets by adding annotation methods in managers and applying new queryset mixins to property and product GraphQL types.

Enhancements:
- Add GraphQL queryset mixins (GetPropertyQuerysetMultiTenantMixin, GetPropertySelectValueQuerysetMultiTenantMixin, GetProductQuerysetMultiTenantMixin) to order querysets by translation annotations
- Implement with_translated_name and with_translated_value methods in property and product managers to annotate and order by the first available translation
- Update property, property select value, and product GraphQL type classes to use the new mixins for consistent translation-based ordering