### PR TITLE
Fix queryset mixins to avoid missing method errors

### DIFF
--- a/OneSila/core/schema/core/mixins.py
+++ b/OneSila/core/schema/core/mixins.py
@@ -25,33 +25,42 @@ class GetPropertyQuerysetMultiTenantMixin:
     @classmethod
     def get_queryset(cls, queryset, info, **kwargs):
         multi_tenant_company = get_multi_tenant_company(info)
-        return (
-            queryset.filter(multi_tenant_company=multi_tenant_company)
-            .with_translated_name()
-            .order_by('translated_name')
-        )
+        queryset = queryset.filter(multi_tenant_company=multi_tenant_company)
+
+        if hasattr(queryset, "with_translated_name"):
+            queryset = queryset.with_translated_name().order_by("translated_name")
+        else:
+            queryset = queryset.order_by(*queryset.model._meta.ordering)
+
+        return queryset
 
 
 class GetPropertySelectValueQuerysetMultiTenantMixin:
     @classmethod
     def get_queryset(cls, queryset, info, **kwargs):
         multi_tenant_company = get_multi_tenant_company(info)
-        return (
-            queryset.filter(multi_tenant_company=multi_tenant_company)
-            .with_translated_value()
-            .order_by('translated_value')
-        )
+        queryset = queryset.filter(multi_tenant_company=multi_tenant_company)
+
+        if hasattr(queryset, "with_translated_value"):
+            queryset = queryset.with_translated_value().order_by("translated_value")
+        else:
+            queryset = queryset.order_by(*queryset.model._meta.ordering)
+
+        return queryset
 
 
 class GetProductQuerysetMultiTenantMixin:
     @classmethod
     def get_queryset(cls, queryset, info, **kwargs):
         multi_tenant_company = get_multi_tenant_company(info)
-        return (
-            queryset.filter(multi_tenant_company=multi_tenant_company)
-            .with_translated_name()
-            .order_by('translated_name')
-        )
+        queryset = queryset.filter(multi_tenant_company=multi_tenant_company)
+
+        if hasattr(queryset, "with_translated_name"):
+            queryset = queryset.with_translated_name().order_by("translated_name")
+        else:
+            queryset = queryset.order_by(*queryset.model._meta.ordering)
+
+        return queryset
 
 
 class GetCurrentUserMixin:


### PR DESCRIPTION
## Summary
- guard custom queryset mixins against missing translation methods

## Testing
- `pre-commit` *(fails: command not found)*
- `coverage run --source='.' OneSila/manage.py test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657d400398832ea6e1eb645b536758

## Summary by Sourcery

Guard custom multi-tenant queryset mixins against missing translation methods by checking for their presence and falling back to default model ordering.

Bug Fixes:
- Prevent attribute errors in multi-tenant queryset mixins when translation methods are unavailable by wrapping calls in hasattr checks.

Enhancements:
- Fall back to model’s default _meta.ordering when with_translated_name or with_translated_value methods are not present.