### PR TITLE
Add Amazon image factory test

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_image_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_image_factories.py
@@ -1,0 +1,127 @@
+import json
+from unittest.mock import patch
+
+from model_bakery import baker
+
+from core.tests import TestCase
+from media.models import Media, MediaProductThrough
+from sales_channels.models.sales_channels import SalesChannelViewAssign
+from sales_channels.integrations.amazon.models.sales_channels import (
+    AmazonSalesChannel,
+    AmazonSalesChannelView,
+    AmazonRemoteLanguage,
+)
+from sales_channels.integrations.amazon.models.products import (
+    AmazonProduct,
+    AmazonImageProductAssociation,
+)
+from sales_channels.integrations.amazon.factories.products.images import (
+    AmazonMediaProductThroughCreateFactory,
+    AmazonMediaProductThroughBase,
+)
+
+
+class AmazonProductImageFactoryTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER123",
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            name="UK",
+            api_region_code="EU_UK",
+            remote_id="GB",
+        )
+        AmazonRemoteLanguage.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            sales_channel_view=self.view,
+            remote_code="en",
+        )
+
+        # Local product
+        self.product = baker.make(
+            "products.Product",
+            sku="TESTSKU",
+            type="SIMPLE",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        # Remote product
+        self.remote_product = AmazonProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+            remote_sku="AMZSKU",
+        )
+        # set remote_type attribute used by factories
+        self.remote_product.remote_type = "PRODUCT"
+
+        SalesChannelViewAssign.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            product=self.product,
+            sales_channel_view=self.view,
+            sales_channel=self.sales_channel,
+            remote_product=self.remote_product,
+        )
+
+        # Create two image throughs
+        self.throughs = []
+        for idx in range(2):
+            media = Media.objects.create(
+                multi_tenant_company=self.multi_tenant_company,
+                type=Media.IMAGE,
+                owner=self.user,
+            )
+            through = MediaProductThrough.objects.create(
+                product=self.product,
+                media=media,
+                sort_order=idx,
+                multi_tenant_company=self.multi_tenant_company,
+            )
+            self.throughs.append(through)
+
+    def test_create_factory_value_only(self):
+        urls = ["https://example.com/img1.jpg", "https://example.com/img2.jpg"]
+        expected_attrs = {}
+        for idx, key in enumerate(AmazonMediaProductThroughBase.OFFER_KEYS):
+            expected_attrs[key] = (
+                [{"media_location": urls[idx]}] if idx < len(urls) else None
+            )
+        for idx, key in enumerate(AmazonMediaProductThroughBase.PRODUCT_KEYS):
+            expected_attrs[key] = (
+                [{"media_location": urls[idx]}] if idx < len(urls) else None
+            )
+
+        with patch.object(
+            AmazonMediaProductThroughBase, "_get_images", return_value=urls
+        ):
+            fac = AmazonMediaProductThroughCreateFactory(
+                sales_channel=self.sales_channel,
+                local_instance=self.throughs[0],
+                remote_product=self.remote_product,
+                view=self.view,
+                get_value_only=True,
+            )
+            body = fac.build_body()
+            self.assertEqual(body["attributes"], expected_attrs)
+            fac.run()
+
+            # run for the second image as well
+            fac = AmazonMediaProductThroughCreateFactory(
+                sales_channel=self.sales_channel,
+                local_instance=self.throughs[1],
+                remote_product=self.remote_product,
+                view=self.view,
+                get_value_only=True,
+            )
+            fac.run()
+
+        cnt = AmazonImageProductAssociation.objects.filter(
+            remote_product=self.remote_product,
+            sales_channel=self.sales_channel,
+        ).count()
+        self.assertEqual(cnt, 2)


### PR DESCRIPTION
## Summary
- add tests for AmazonMediaProductThrough create factory

## Testing
- `python -m pycodestyle OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_image_factories.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_image_factories.AmazonProductImageFactoryTest.test_create_factory_value_only -v 2` *(fails: OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_686596f197fc832e80659a1770f3219a

## Summary by Sourcery

Add tests for AmazonMediaProductThroughCreateFactory to verify attribute payload generation and remote image association creation with the get_value_only flag

Tests:
- Introduce AmazonProductImageFactoryTest covering build_body attribute mapping for image URLs
- Verify that AmazonMediaProductThroughCreateFactory.run creates the expected AmazonImageProductAssociation records