### PR TITLE
Add Amazon price update factory test

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
@@ -52,6 +52,8 @@ class AmazonPriceUpdateFactory(GetAmazonAPIMixin, AmazonListingIssuesMixin, Remo
                 },
             }
 
+            self.body = body
+
             resp = listings.patch_listings_item(
                 seller_id=self.sales_channel.remote_id,
                 sku=self.remote_product.remote_sku,

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py
@@ -1,0 +1,103 @@
+import json
+from unittest.mock import patch, MagicMock
+from model_bakery import baker
+from core.tests import TestCase
+from currencies.models import Currency
+from currencies.currencies import currencies
+from sales_prices.models import SalesPrice
+from sales_channels.models.sales_channels import SalesChannelViewAssign
+from sales_channels.integrations.amazon.models.sales_channels import (
+    AmazonSalesChannel,
+    AmazonSalesChannelView,
+)
+from sales_channels.integrations.amazon.models.products import AmazonProduct
+from sales_channels.integrations.amazon.models import AmazonPrice, AmazonCurrency
+from sales_channels.integrations.amazon.factories.prices import AmazonPriceUpdateFactory
+
+
+class AmazonPriceUpdateFactoryTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER123",
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            name="UK",
+            api_region_code="EU_UK",
+            remote_id="GB",
+        )
+        self.currency = Currency.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            is_default_currency=True,
+            **currencies["GB"],
+        )
+        self.remote_currency = AmazonCurrency.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            sales_channel_view=self.view,
+            local_instance=self.currency,
+            remote_code=self.currency.iso_code,
+            is_default=True,
+        )
+        self.product = baker.make(
+            "products.Product",
+            sku="TESTSKU",
+            type="SIMPLE",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        SalesPrice.objects.create(
+            product=self.product,
+            currency=self.currency,
+            rrp=100,
+            price=80,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.remote_product = AmazonProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+            remote_sku="AMZSKU",
+        )
+        # remote type is required in the payload
+        self.remote_product.remote_type = "CHAIR"
+        SalesChannelViewAssign.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            product=self.product,
+            sales_channel_view=self.view,
+            sales_channel=self.sales_channel,
+            remote_product=self.remote_product,
+        )
+        self.remote_price = AmazonPrice.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_product=self.remote_product,
+            price_data={},
+        )
+
+    def test_update_factory_builds_correct_body(self):
+        factory = AmazonPriceUpdateFactory(
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+            remote_product=self.remote_product,
+            view=self.view,
+        )
+        with patch("spapi.ListingsApi.__init__", return_value=None), patch(
+            "spapi.ListingsApi.patch_listings_item", return_value=MagicMock(issues=[]) 
+        ):
+            factory.run()
+        expected = {
+            "productType": "CHAIR",
+            "requirements": "LISTING",
+            "attributes": {
+                "list_price": [
+                    {"currency": "GBP", "amount": 80.0}
+                ],
+                "uvp_list_price": [
+                    {"currency": "GBP", "amount": 100.0}
+                ],
+            },
+        }
+        self.assertEqual(factory.body, expected)


### PR DESCRIPTION
## Summary
- expose built request body on `AmazonPriceUpdateFactory`
- mock out Amazon API call in the price update factory test
- add unit test for price update payload

## Testing
- `python manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_price_factories.AmazonPriceUpdateFactoryTest.test_update_factory_builds_correct_body` *(fails: ModuleNotFoundError: No module named 'django')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68659752372c832ea19c5c3b16059253

## Summary by Sourcery

Expose the generated request payload on AmazonPriceUpdateFactory and add a unit test to verify its structure

Enhancements:
- Expose `body` attribute on AmazonPriceUpdateFactory to store the built request payload

Tests:
- Add `AmazonPriceUpdateFactoryTest` to mock the Amazon Listings API and assert the factory builds the expected price update payload