### PR TITLE
Add bulk update for Amazon property select value

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -15,6 +15,7 @@ from sales_channels.integrations.amazon.schema.types.input import (
     AmazonSalesChannelImportPartialInput,
     AmazonDefaultUnitConfiguratorPartialInput,
     AmazonValidateAuthInput,
+    BulkAmazonPropertySelectValueLocalInstanceInput,
 )
 from sales_channels.integrations.amazon.schema.types.types import (
     AmazonSalesChannelType,
@@ -89,3 +90,36 @@ class AmazonSalesChannelMutation:
 
     create_amazon_import_process: AmazonSalesChannelImportType = create(AmazonSalesChannelImportInput)
     update_amazon_import_process: AmazonSalesChannelImportType = update(AmazonSalesChannelImportPartialInput)
+
+    @strawberry_django.mutation(handle_django_errors=True, extensions=default_extensions)
+    def bulk_update_amazon_property_select_value_local_instance(
+        self,
+        instance: BulkAmazonPropertySelectValueLocalInstanceInput,
+        info: Info,
+    ) -> List[AmazonPropertySelectValueType]:
+        from sales_channels.integrations.amazon.models import AmazonPropertySelectValue
+        from properties.models import PropertySelectValue
+
+        multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
+
+        local_instance = None
+        if instance.local_instance_id:
+            local_instance = PropertySelectValue.objects.get(
+                id=instance.local_instance_id.node_id,
+                multi_tenant_company=multi_tenant_company,
+            )
+
+        value_ids = [gid.node_id for gid in instance.ids]
+
+        values = list(
+            AmazonPropertySelectValue.objects.filter(
+                id__in=value_ids,
+                multi_tenant_company=multi_tenant_company,
+            )
+        )
+
+        for value in values:
+            value.local_instance = local_instance
+            value.save()
+
+        return values

--- a/OneSila/sales_channels/integrations/amazon/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/input.py
@@ -8,6 +8,9 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannelImport,
     AmazonDefaultUnitConfigurator,
 )
+from properties.schema.types.input import PropertySelectValuePartialInput
+from strawberry.relay import GlobalID
+from typing import List, Optional
 
 
 @input(AmazonSalesChannel, exclude=['integration_ptr', 'saleschannel_ptr'])
@@ -85,3 +88,9 @@ class AmazonDefaultUnitConfiguratorInput:
 @partial(AmazonDefaultUnitConfigurator, fields="__all__")
 class AmazonDefaultUnitConfiguratorPartialInput(NodeInput):
     pass
+
+
+@strawberry_input
+class BulkAmazonPropertySelectValueLocalInstanceInput:
+    ids: List[GlobalID]
+    local_instance_id: Optional[GlobalID] = None


### PR DESCRIPTION
## Summary
- allow bulk mapping of Amazon select values to a local instance

## Testing
- `pycodestyle OneSila/sales_channels/integrations/amazon/schema/mutations.py OneSila/sales_channels/integrations/amazon/schema/types/input.py`
- `python OneSila/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68666bb83c88832ebe9ee72e4bc9e7d0

## Summary by Sourcery

Add a new GraphQL mutation and input type to support bulk updating the local instance for Amazon property select values.

New Features:
- Add `bulk_update_amazon_property_select_value_local_instance` mutation to assign a local PropertySelectValue to multiple AmazonPropertySelectValue records.
- Introduce `BulkAmazonPropertySelectValueLocalInstanceInput` input type for specifying target select value IDs and an optional local instance ID.