### PR TITLE
Add Amazon API helpers and logging

### DIFF
--- a/OneSila/integrations/factories/mixins.py
+++ b/OneSila/integrations/factories/mixins.py
@@ -51,7 +51,7 @@ class IntegrationInstanceOperationMixin:
 
         return f"{class_name}:{caller}", fixing_identifier
 
-    def log_action_for_instance(self, remote_instance, action, response_data, payload, identifier):
+    def log_action_for_instance(self, remote_instance, action, response_data, payload, identifier, **extra):
         if not remote_instance:
             raise ValueError("A valid remote_instance must be provided for logging.")
 
@@ -60,10 +60,11 @@ class IntegrationInstanceOperationMixin:
             response=response_data,
             payload=payload,
             identifier=identifier,
-            remote_product=getattr(self, 'remote_product', None)
+            remote_product=getattr(self, 'remote_product', None),
+            **extra
         )
 
-    def log_action(self, action, response_data, payload, identifier):
+    def log_action(self, action, response_data, payload, identifier, **extra):
         """
         Logs actions for remote instance operations.
         """
@@ -72,7 +73,8 @@ class IntegrationInstanceOperationMixin:
             response=response_data,
             payload=payload,
             identifier=identifier,
-            remote_product=getattr(self, 'remote_product', None)
+            remote_product=getattr(self, 'remote_product', None),
+            **extra
         )
 
     def log_error(self, exception, action, identifier, payload, fixing_identifier=None):

--- a/OneSila/integrations/models.py
+++ b/OneSila/integrations/models.py
@@ -423,9 +423,14 @@ class IntegrationObjectMixin(models.Model):
         Method to create a log entry.
         """
         from sales_channels.models import RemoteLog
+        from sales_channels.integrations.amazon.models import AmazonSalesChannel
+        from sales_channels.integrations.amazon.models import AmazonRemoteLog
 
-        # @TODO: the class here should be configurable but for now we will let the RemoteLog
-        RemoteLog.objects.create(
+        log_model = (
+            AmazonRemoteLog if isinstance(self.integration, AmazonSalesChannel) else RemoteLog
+        )
+
+        log_model.objects.create(
             content_type=ContentType.objects.get_for_model(self),
             object_id=self.pk,
             content_object=self,

--- a/OneSila/sales_channels/integrations/amazon/migrations/0011_amazonremotelog.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0011_amazonremotelog.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0010_amazonproducttype_remote_name_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AmazonRemoteLog',
+            fields=[
+                ('remotelog_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE,
+                                                       parent_link=True, primary_key=True, serialize=False,
+                                                       to='sales_channels.remotelog')),
+                ('submission_id', models.CharField(max_length=255, null=True, blank=True)),
+                ('issues', models.JSONField(null=True, blank=True)),
+                ('processing_status', models.CharField(max_length=32, null=True, blank=True)),
+            ],
+            options={
+                'verbose_name': 'Amazon Remote Log',
+                'verbose_name_plural': 'Amazon Remote Logs',
+                'ordering': ['-created_at'],
+            },
+            bases=('sales_channels.remotelog',),
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/__init__.py
+++ b/OneSila/sales_channels/integrations/amazon/models/__init__.py
@@ -15,3 +15,4 @@ from .sales_channels import (
 )
 from .taxes import AmazonCurrency, AmazonTaxCode
 from .imports import *
+from .logs import AmazonRemoteLog

--- a/OneSila/sales_channels/integrations/amazon/models/logs.py
+++ b/OneSila/sales_channels/integrations/amazon/models/logs.py
@@ -1,0 +1,15 @@
+from core import models
+from sales_channels.models.logs import RemoteLog
+
+
+class AmazonRemoteLog(RemoteLog):
+    """Remote log extended with Amazon submission details."""
+
+    submission_id = models.CharField(max_length=255, null=True, blank=True)
+    issues = models.JSONField(null=True, blank=True)
+    processing_status = models.CharField(max_length=32, null=True, blank=True)
+
+    class Meta:
+        verbose_name = "Amazon Remote Log"
+        verbose_name_plural = "Amazon Remote Logs"
+        ordering = ["-created_at"]


### PR DESCRIPTION
## Summary
- add AmazonRemoteLog model
- hook up AmazonRemoteLog via IntegrationObjectMixin
- support extra log kwargs in Integration factory mixins
- add create/update product helpers for Amazon
- add migration for AmazonRemoteLog
- compute patches when updating Amazon products

## Testing
- `python OneSila/manage.py test core` *(fails: Could not import Django)*


------
https://chatgpt.com/codex/tasks/task_e_686802468724832ebe1b3902ff491170

## Summary by Sourcery

Add Amazon-specific remote logging and API factory helpers for creating and updating products with locale support and JSON patch computation

New Features:
- Introduce AmazonRemoteLog model with corresponding migration
- Add create_product and update_product methods in Amazon integration mixins

Enhancements:
- Hook AmazonRemoteLog into the integration logging flow
- Support extra logging keyword arguments in factory mixins
- Implement JSON patch generation for product updates
- Add issueLocale detection and common request body builder for Amazon API calls