### PR TITLE
Update Amazon product factory to use mixin

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/products.py
@@ -236,7 +236,6 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, AmazonListingIssuesMixin, Remo
             self.attributes.update(data)
             return create_fac.remote_instance.id
 
-
     def build_payload(self):
         super().build_payload()
         # gather image attributes before building payload so they are sent with the product
@@ -328,12 +327,12 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, AmazonListingIssuesMixin, Remo
         self.remote_instance = fac.remote_instance
 
     def assign_ean_code(self):
-        pass # there is no ean code sync for Amazon. This is used as an identifier and cannot be updated later on
+        pass  # there is no ean code sync for Amazon. This is used as an identifier and cannot be updated later on
 
     def set_product_properties(self):
         rule_properties_ids = self.local_instance.get_required_and_optional_properties(product_rule=self.rule).values_list('property_id', flat=True)
-        self.product_properties = (ProductProperty.objects.filter_multi_tenant(self.sales_channel.multi_tenant_company). \
-            filter(product=self.local_instance, property_id__in=rule_properties_ids). \
+        self.product_properties = (ProductProperty.objects.filter_multi_tenant(self.sales_channel.multi_tenant_company).
+            filter(product=self.local_instance, property_id__in=rule_properties_ids).
             exclude(property__internal_name='merchant_suggested_asin'))
 
 
@@ -363,12 +362,11 @@ class AmazonProductCreateFactory(AmazonProductBaseFactory, RemoteProductCreateFa
     remote_product_eancode_class = None
 
     def perform_remote_action(self):
-        listings = ListingsApi(self._get_client())
-        resp = listings.put_listings_item(
-            seller_id=self.sales_channel.remote_id,
+        resp = self.create_product(
             sku=self.remote_instance.remote_sku,
-            marketplace_ids=[self.view.remote_id],
-            body=self.payload,
+            marketplace_id=self.view.remote_id,
+            product_type=self.remote_type,
+            attributes=self.attributes,
         )
         self.update_assign_issues(getattr(resp, "issues", []))
         return resp
@@ -388,6 +386,7 @@ class AmazonProductCreateFactory(AmazonProductBaseFactory, RemoteProductCreateFa
 class AmazonProductSyncFactory(AmazonProductBaseFactory, RemoteProductSyncFactory):
     """Sync Amazon products using marketplace-specific create or update."""
     create_product_factory = AmazonProductCreateFactory
+
 
 class AmazonProductDeleteFactory(GetAmazonAPIMixin, RemoteProductDeleteFactory):
     remote_model_class = AmazonProduct

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
@@ -77,7 +77,6 @@ class AmazonProductFactoriesTest(TransactionTestCase):
         )
         self.product_type_property = Property.objects.filter(is_product_type=True, multi_tenant_company=self.multi_tenant_company).first()
 
-
         self.product_type_value = baker.make(
             PropertySelectValue,
             property=self.product_type_property,
@@ -575,7 +574,7 @@ class AmazonProductFactoriesTest(TransactionTestCase):
         )
 
     @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
-    @patch("sales_channels.integrations.amazon.factories.products.products.ListingsApi")
+    @patch("sales_channels.integrations.amazon.factories.mixins.ListingsApi")
     def test_create_product_factory_builds_correct_body(self, mock_listings, mock_client):
         mock_instance = mock_listings.return_value
 
@@ -604,13 +603,13 @@ class AmazonProductFactoriesTest(TransactionTestCase):
         )
         fac.run()
 
-        body = mock_instance.put_listings_item.call_args.kwargs.get("body") # put_listings_item because the create is used
+        body = mock_instance.put_listings_item.call_args.kwargs.get("body")  # put_listings_item because the create is used
         self.assertIsInstance(body, dict)
         self.assertEqual(body.get("requirements"), "LISTING")
 
     @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
     @patch.object(AmazonMediaProductThroughBase, "_get_images", return_value=["https://example.com/img.jpg"])
-    @patch("sales_channels.integrations.amazon.factories.products.products.ListingsApi")
+    @patch("sales_channels.integrations.amazon.factories.mixins.ListingsApi")
     def test_create_product_factory_builds_correct_payload(self, mock_listings, mock_get_images, mock_get_client):
         """This test checks if the CreateFactory gives the expected payload including attributes, prices, and content."""
         mock_instance = mock_listings.return_value
@@ -683,96 +682,77 @@ class AmazonProductFactoriesTest(TransactionTestCase):
         pprint.pprint(expected_body)
         self.assertEqual(body, expected_body)
 
-
     def test_sync_switches_to_create_if_product_not_exists(self):
         """This test ensures that calling sync triggers a create if the product doesn't exist remotely."""
         pass
-
 
     def test_create_product_on_different_marketplace(self):
         """This test ensures the product is created on a second marketplace correctly and independently using PUT."""
         pass
 
-
     def test_update_product_factory_builds_correct_payload(self):
         """This test checks that the update factory builds a correct patch payload with only changed attributes."""
         pass
-
 
     def test_delete_product_uses_correct_sku_and_marketplace(self):
         """This test ensures delete factory calls the correct endpoint with the proper SKU and marketplace ID."""
         pass
 
-
     def test_update_falls_back_to_create_if_product_missing_remotely(self):
         """This test ensures update falls back to create if the product doesn’t exist remotely in the given marketplace."""
         pass
-
 
     def test_update_images_overwrites_old_ones_correctly(self):
         """This test validates that old images are removed and only the new ones are included in the payload."""
         pass
 
-
     def test_payload_includes_all_supported_property_types(self):
         """This test adds text, select, and multiselect properties and confirms their correct payload structure."""
         pass
-
 
     def test_unmapped_attributes_are_ignored_in_payload(self):
         """This test confirms that unmapped or unknown attributes are not added to the final payload."""
         pass
 
-
     def test_missing_ean_or_asin_raises_exception(self):
         """This test ensures the factory raises ValueError if no EAN/GTIN or ASIN is provided."""
         pass
-
 
     def test_create_product_with_asin_in_payload(self):
         """This test confirms that ASIN is correctly added and EAN is skipped if ASIN exists."""
         pass
 
-
     def test_create_product_with_ean_in_payload(self):
         """This test verifies that EAN is included properly in the absence of ASIN."""
         pass
-
 
     def test_custom_properties_are_processed_correctly(self):
         """This test ensures that various valid custom properties are processed using process_single_property and included in payload."""
         pass
 
-
     def test_existing_remote_property_gets_updated(self):
         """This test simulates an existing remote property and checks that update payload reflects correct values."""
         pass
-
 
     def test_translation_from_sales_channel_is_used_in_payload(self):
         """This test checks that product content is pulled from sales channel translations if available."""
         pass
 
-
     def test_translation_fallbacks_to_global_if_not_in_channel(self):
         """This test ensures fallback to global translation when channel-specific translation is missing."""
         pass
-
 
     def test_price_sync_enabled_includes_price_fields(self):
         """This test ensures that enabling price sync includes correct pricing fields like list_price and uvp_list_price."""
         pass
 
-
     def test_price_sync_disabled_skips_price_fields(self):
         """This test ensures that price fields are skipped when price sync is turned off."""
         pass
 
-
     def test_payload_skips_empty_price_fields_gracefully(self):
         """This test confirms that missing prices do not break payload generation and are omitted silently."""
         pass
-
 
     def test_missing_view_argument_raises_value_error(self):
         """This test confirms that initializing a factory without a view raises ValueError."""


### PR DESCRIPTION
## Summary
- use `create_product` helper from the mixin for Amazon product creation
- adjust tests to patch the mixin's API usage

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/products/products.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductFactoriesTest.test_create_product_factory_builds_correct_body -v 2` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6868086bbe64832e8bfa49ac5df364a2

## Summary by Sourcery

Refactor Amazon product factories to leverage the mixin’s create_product helper for all API interactions, and update tests to mock the ListingsApi import from the mixin.

Enhancements:
- Replace direct ListingsApi instantiation and put_listings_item calls in AmazonProductCreateFactory.perform_remote_action with the mixin’s create_product method
- Simplify set_product_properties logic and clean up formatting within Amazon product factory classes

Tests:
- Adjust tests to patch ListingsApi from sales_channels.integrations.amazon.factories.mixins and update mocks accordingly