### PR TITLE
Use update_product helper for Amazon patches

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
@@ -1,7 +1,6 @@
 from sales_channels.factories.prices.prices import RemotePriceUpdateFactory
 from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin, AmazonListingIssuesMixin
 from sales_channels.integrations.amazon.models import AmazonPrice, AmazonCurrency
-from spapi import ListingsApi
 
 
 class AmazonPriceUpdateFactory(GetAmazonAPIMixin, AmazonListingIssuesMixin, RemotePriceUpdateFactory):
@@ -54,11 +53,16 @@ class AmazonPriceUpdateFactory(GetAmazonAPIMixin, AmazonListingIssuesMixin, Remo
 
             self.body = body
 
-            resp = listings.patch_listings_item(
-                seller_id=self.sales_channel.remote_id,
-                sku=self.remote_product.remote_sku,
-                marketplace_ids=[self.view.remote_id],
-                body=body,
+            current_attrs = self.get_listing_attributes(
+                self.remote_product.remote_sku,
+                self.view.remote_id,
+            )
+            resp = self.update_product(
+                self.remote_product.remote_sku,
+                self.view.remote_id,
+                self.remote_product.remote_type,
+                current_attrs,
+                body.get("attributes", {}),
             )
             self.update_assign_issues(getattr(resp, "issues", []))
             responses.append(resp)

--- a/OneSila/sales_channels/integrations/amazon/factories/properties/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/properties/properties.py
@@ -1,5 +1,4 @@
 import json
-from spapi import ListingsApi
 from sales_channels.integrations.amazon.factories.properties.mixins import AmazonProductPropertyBaseMixin
 from sales_channels.integrations.amazon.models.properties import AmazonProductProperty
 
@@ -14,21 +13,43 @@ from sales_channels.factories.properties.properties import (
 class AmazonProductPropertyCreateFactory(AmazonProductPropertyBaseMixin, RemoteProductPropertyCreateFactory):
     remote_model_class = AmazonProductProperty
 
-    def __init__(self, sales_channel, local_instance, remote_product, view, api=None, skip_checks=False, get_value_only=False, language=None):
+    def __init__(
+        self,
+        sales_channel,
+        local_instance,
+        remote_product,
+        view,
+        api=None,
+        skip_checks=False,
+        get_value_only=False,
+        language=None,
+    ):
         self.view = view
-        super().__init__(sales_channel, local_instance, remote_product=remote_product, api=api, skip_checks=skip_checks, get_value_only=get_value_only, language=language)
+        super().__init__(
+            sales_channel,
+            local_instance,
+            remote_product=remote_product,
+            api=api,
+            skip_checks=skip_checks,
+            get_value_only=get_value_only,
+            language=language,
+        )
 
     def create_remote(self):
         body = self.create_body()
         if body is None:
             return
         api = self.get_api()
-        listings = ListingsApi(self._get_client())
-        response = listings.patch_listings_item(
-            seller_id=self.sales_channel.remote_id,
-            sku=self.remote_product.remote_sku,
-            marketplace_ids=[self.view.remote_id],
-            body=body,
+        current_attrs = self.get_listing_attributes(
+            self.remote_product.remote_sku,
+            self.view.remote_id,
+        )
+        response = self.update_product(
+            self.remote_product.remote_sku,
+            self.view.remote_id,
+            body.get("productType"),
+            current_attrs,
+            body.get("attributes", {}),
         )
         self.update_assign_issues(getattr(response, "issues", []))
         return response
@@ -44,10 +65,29 @@ class AmazonProductPropertyUpdateFactory(AmazonProductPropertyBaseMixin, RemoteP
     remote_model_class = AmazonProductProperty
     create_factory_class = AmazonProductPropertyCreateFactory
 
-    def __init__(self, sales_channel, local_instance, remote_product, view, api=None, get_value_only=False, remote_instance=None, skip_checks=False, language=None):
+    def __init__(
+        self,
+        sales_channel,
+        local_instance,
+        remote_product,
+        view,
+        api=None,
+        get_value_only=False,
+        remote_instance=None,
+        skip_checks=False,
+        language=None,
+    ):
         self.view = view
-        super().__init__(sales_channel, local_instance, remote_product=remote_product, api=api,
-              get_value_only=get_value_only, remote_instance=remote_instance, skip_checks=skip_checks, language=language)
+        super().__init__(
+            sales_channel,
+            local_instance,
+            remote_product=remote_product,
+            api=api,
+            get_value_only=get_value_only,
+            remote_instance=remote_instance,
+            skip_checks=skip_checks,
+            language=language,
+        )
 
     def update_remote(self):
 
@@ -55,12 +95,16 @@ class AmazonProductPropertyUpdateFactory(AmazonProductPropertyBaseMixin, RemoteP
         if body is None:
             return
 
-        listings = ListingsApi(self._get_client())
-        response = listings.patch_listings_item(
-            seller_id=self.sales_channel.remote_id,
-            sku=self.remote_product.remote_sku,
-            marketplace_ids=[self.view.remote_id],
-            body=body,
+        current_attrs = self.get_listing_attributes(
+            self.remote_product.remote_sku,
+            self.view.remote_id,
+        )
+        response = self.update_product(
+            self.remote_product.remote_sku,
+            self.view.remote_id,
+            body.get("productType"),
+            current_attrs,
+            body.get("attributes", {}),
         )
         self.update_assign_issues(getattr(response, "issues", []))
         return response
@@ -93,17 +137,17 @@ class AmazonProductPropertyDeleteFactory(AmazonProductPropertyBaseMixin, RemoteP
         super().__init__(sales_channel, local_instance, remote_product=remote_product, api=api, remote_instance=remote_instance)
 
     def delete_remote(self):
-        listings = ListingsApi(self._get_client())
         try:
-            response = listings.patch_listings_item(
-                seller_id=self.sales_channel.remote_id,
-                sku=self.remote_instance.remote_product.remote_sku,
-                marketplace_ids=[self.view.remote_id],
-                body={
-                    "productType": self.remote_instance.remote_product.remote_type,
-                    "requirements": "LISTING",
-                    "attributes": {self.remote_instance.remote_property.main_code: None},
-                },
+            current_attrs = self.get_listing_attributes(
+                self.remote_instance.remote_product.remote_sku,
+                self.view.remote_id,
+            )
+            response = self.update_product(
+                self.remote_instance.remote_product.remote_sku,
+                self.view.remote_id,
+                self.remote_instance.remote_product.remote_type,
+                current_attrs,
+                {self.remote_instance.remote_property.main_code: None},
             )
             self.update_assign_issues(getattr(response, "issues", []))
             return response

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py
@@ -112,6 +112,7 @@ class AmazonPriceUpdateFactoryTest(TestCase):
     def test_update_factory_builds_correct_body(self, mock_client, mock_listings):
         mock_instance = mock_listings.return_value
         mock_instance.patch_listings_item.side_effect = Exception("no amazon")
+        mock_instance.get_listings_item.return_value = MagicMock(payload={"attributes": {}})
 
         factory = AmazonPriceUpdateFactory(
             sales_channel=self.sales_channel,
@@ -125,15 +126,17 @@ class AmazonPriceUpdateFactoryTest(TestCase):
 
         expected = {
             "productType": "CHAIR",
-            "requirements": "LISTING",
-            "attributes": {
-                "list_price": [
-                    {"currency": "GBP", "amount": 80.0}
-                ],
-                "uvp_list_price": [
-                    {"currency": "GBP", "amount": 100.0}
-                ],
-            },
+            "patches": [
+                {
+                    "op": "add",
+                    "value": [{"list_price": [{"currency": "GBP", "amount": 80.0}]}],
+                },
+                {
+                    "op": "add",
+                    "value": [{"uvp_list_price": [{"currency": "GBP", "amount": 100.0}]}],
+                },
+            ],
+            "issueLocale": None,
         }
 
         body = mock_instance.patch_listings_item.call_args.kwargs.get("body")

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from model_bakery import baker
 
@@ -143,6 +143,7 @@ class AmazonProductContentUpdateFactoryTest(TestCase):
     def test_update_builds_correct_body(self, mock_client, mock_listings):
         mock_instance = mock_listings.return_value
         mock_instance.patch_listings_item.side_effect = Exception("no amazon")
+        mock_instance.get_listings_item.return_value = MagicMock(payload={"attributes": {}})
 
         fac = AmazonProductContentUpdateFactory(
             sales_channel=self.sales_channel,
@@ -162,10 +163,13 @@ class AmazonProductContentUpdateFactoryTest(TestCase):
         }
         expected_body = {
             "productType": "CHAIR",
-            "requirements": "LISTING",
-            "attributes": expected_payload,
+            "patches": [
+                {"op": "add", "value": [{"item_name": "Chair name"}]},
+                {"op": "add", "value": [{"product_description": "Chair description"}]},
+                {"op": "add", "value": [{"bullet_point": ["Point one", "Point two"]}]},
+            ],
+            "issueLocale": "en",
         }
 
         body = mock_instance.patch_listings_item.call_args.kwargs.get("body")
         self.assertEqual(body, expected_body)
-


### PR DESCRIPTION
## Summary
- add helpers to fetch listing details
- use `update_product` from `GetAmazonAPIMixin` to build patches
- adapt product, price, content, image, and property factories
- update Amazon unit tests

## Testing
- `pycodestyle OneSila/sales_channels/integrations/amazon/factories/mixins.py OneSila/sales_channels/integrations/amazon/factories/products/images.py OneSila/sales_channels/integrations/amazon/factories/prices/prices.py OneSila/sales_channels/integrations/amazon/factories/products/content.py OneSila/sales_channels/integrations/amazon/factories/products/products.py OneSila/sales_channels/integrations/amazon/factories/properties/properties.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_price_factories sales_channels.integrations.amazon.tests.tests_factories.tests_product_content_factories` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6868099596f0832ea3ff5dcdbb2d757b

## Summary by Sourcery

Use the shared update_product helper to build and send Amazon listing patches instead of calling ListingsApi.patch_listings_item directly.

Enhancements:
- Replace direct patch_listings_item calls with update_product helper in property, product, content, image, and price factories.
- Introduce get_listing_item and get_listing_attributes methods in GetAmazonAPIMixin to fetch current listing attributes.
- Convert factory payloads to JSON Patch format with 'patches' arrays and include issueLocale.
- Refactor translation fetching and code formatting in factories for consistency.
- Reformat long product types list into a multiline array.

Tests:
- Update Amazon factory unit tests to mock get_listings_item and assert new patch-based request bodies.