### PR TITLE
Add Amazon submission logging

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
@@ -1,9 +1,9 @@
 from sales_channels.factories.prices.prices import RemotePriceUpdateFactory
-from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin, AmazonListingIssuesMixin
+from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
 from sales_channels.integrations.amazon.models import AmazonPrice, AmazonCurrency
 
 
-class AmazonPriceUpdateFactory(GetAmazonAPIMixin, AmazonListingIssuesMixin, RemotePriceUpdateFactory):
+class AmazonPriceUpdateFactory(GetAmazonAPIMixin, RemotePriceUpdateFactory):
     """Update product prices for a specific Amazon marketplace."""
 
     remote_model_class = AmazonPrice
@@ -63,7 +63,6 @@ class AmazonPriceUpdateFactory(GetAmazonAPIMixin, AmazonListingIssuesMixin, Remo
                 current_attrs,
                 body.get("attributes", {}),
             )
-            self.update_assign_issues(getattr(resp, "issues", []))
             responses.append(resp)
 
         return responses

--- a/OneSila/sales_channels/integrations/amazon/factories/products/content.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/content.py
@@ -1,11 +1,11 @@
 from products.models import ProductTranslation, ProductTranslationBulletPoint
 from sales_channels.factories.products.content import RemoteProductContentUpdateFactory
-from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin, AmazonListingIssuesMixin
+from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
 from sales_channels.integrations.amazon.models.products import AmazonProductContent
 from sales_channels.integrations.amazon.models.properties import AmazonProductType
 
 
-class AmazonProductContentUpdateFactory(GetAmazonAPIMixin, AmazonListingIssuesMixin, RemoteProductContentUpdateFactory):
+class AmazonProductContentUpdateFactory(GetAmazonAPIMixin, RemoteProductContentUpdateFactory):
     """Update product content like name and description on Amazon."""
 
     remote_model_class = AmazonProductContent
@@ -91,7 +91,6 @@ class AmazonProductContentUpdateFactory(GetAmazonAPIMixin, AmazonListingIssuesMi
             current_attrs,
             body.get("attributes", {}),
         )
-        self.update_assign_issues(getattr(response, "issues", []))
 
         return response
 

--- a/OneSila/sales_channels/integrations/amazon/factories/products/images.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/images.py
@@ -8,14 +8,13 @@ from sales_channels.factories.products.images import (
 )
 from sales_channels.integrations.amazon.factories.mixins import (
     GetAmazonAPIMixin,
-    AmazonListingIssuesMixin,
 )
 from sales_channels.integrations.amazon.models.products import (
     AmazonImageProductAssociation,
 )
 
 
-class AmazonMediaProductThroughBase(GetAmazonAPIMixin, AmazonListingIssuesMixin):
+class AmazonMediaProductThroughBase(GetAmazonAPIMixin):
     """Common logic for Amazon media-product associations."""
 
     remote_model_class = AmazonImageProductAssociation
@@ -77,7 +76,6 @@ class AmazonMediaProductThroughBase(GetAmazonAPIMixin, AmazonListingIssuesMixin)
             current_attrs,
             body.get("attributes", {}),
         )
-        self.update_assign_issues(getattr(response, "issues", []))
         return response
 
     def build_payload(self):

--- a/OneSila/sales_channels/integrations/amazon/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/products.py
@@ -11,7 +11,6 @@ from sales_channels.factories.products.products import (
 )
 from sales_channels.integrations.amazon.factories.mixins import (
     GetAmazonAPIMixin,
-    AmazonListingIssuesMixin,
 )
 from sales_channels.integrations.amazon.factories.products.images import (
     AmazonMediaProductThroughCreateFactory,
@@ -39,7 +38,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class AmazonProductBaseFactory(GetAmazonAPIMixin, AmazonListingIssuesMixin, RemoteProductSyncFactory):
+class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
     remote_model_class = AmazonProduct
     remote_image_assign_create_factory = AmazonMediaProductThroughCreateFactory
     remote_image_assign_update_factory = AmazonMediaProductThroughUpdateFactory
@@ -350,7 +349,6 @@ class AmazonProductUpdateFactory(AmazonProductBaseFactory, RemoteProductUpdateFa
             self.current_attrs,
             self.payload.get("attributes", {}),
         )
-        self.update_assign_issues(getattr(resp, "issues", []))
         return resp
 
     def serialize_response(self, response):
@@ -371,7 +369,6 @@ class AmazonProductCreateFactory(AmazonProductBaseFactory, RemoteProductCreateFa
             product_type=self.payload.get("productType"),
             attributes=self.payload.get("attributes", {}),
         )
-        self.update_assign_issues(getattr(resp, "issues", []))
         return resp
 
     def post_action_process(self):

--- a/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
@@ -4,7 +4,7 @@ from sales_channels.integrations.amazon.models.properties import (
     AmazonPublicDefinition,
     AmazonPropertySelectValue,
 )
-from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin, AmazonListingIssuesMixin
+from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
 from properties.models import Property, ProductProperty
 import json
 import re
@@ -65,7 +65,7 @@ class AmazonRemoteValueMixin:
         return value
 
 
-class AmazonProductPropertyBaseMixin(GetAmazonAPIMixin, AmazonRemoteValueMixin, AmazonListingIssuesMixin):
+class AmazonProductPropertyBaseMixin(GetAmazonAPIMixin, AmazonRemoteValueMixin):
     """Common helpers for Amazon product property factories."""
 
     # ------------------------------------------------------------------

--- a/OneSila/sales_channels/integrations/amazon/factories/properties/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/properties/properties.py
@@ -51,7 +51,6 @@ class AmazonProductPropertyCreateFactory(AmazonProductPropertyBaseMixin, RemoteP
             current_attrs,
             body.get("attributes", {}),
         )
-        self.update_assign_issues(getattr(response, "issues", []))
         return response
 
     def serialize_response(self, response):
@@ -106,7 +105,6 @@ class AmazonProductPropertyUpdateFactory(AmazonProductPropertyBaseMixin, RemoteP
             current_attrs,
             body.get("attributes", {}),
         )
-        self.update_assign_issues(getattr(response, "issues", []))
         return response
 
     def serialize_response(self, response):
@@ -149,7 +147,6 @@ class AmazonProductPropertyDeleteFactory(AmazonProductPropertyBaseMixin, RemoteP
                 current_attrs,
                 {self.remote_instance.remote_property.main_code: None},
             )
-            self.update_assign_issues(getattr(response, "issues", []))
             return response
         except Exception:
             return True


### PR DESCRIPTION
## Summary
- move issue tracking into `GetAmazonAPIMixin`
- log submission details for `create_product` and `update_product`
- remove `AmazonListingIssuesMixin` usages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686916e408f0832e946c6cd8c7b98240

## Summary by Sourcery

Consolidate Amazon issue tracking into a single mixin and enhance product API calls with submission logging

Enhancements:
- Refactor issue tracking by merging AmazonListingIssuesMixin into GetAmazonAPIMixin
- Add logging of submission details (ID, status, payload, issues) for create_product and update_product via RemoteLog