### PR TITLE
Update Shopify integration to use per-channel credentials

### DIFF
--- a/OneSila/OneSila/settings/base.py
+++ b/OneSila/OneSila/settings/base.py
@@ -351,8 +351,6 @@ MAGENTO_LOG_DIR_PATH = os.getenv('MAGENTO_LOG_DIR_PATH', '/var/log/OneSilaHeadle
 
 SHOPIFY_SCOPES = ['read_products', 'write_products', 'read_locales', 'read_orders', 'read_publications', 'write_publications']
 SHOPIFY_API_VERSION = "2025-04"
-SHOPIFY_API_KEY = os.getenv('SHOPIFY_API_KEY')
-SHOPIFY_API_SECRET = os.getenv('SHOPIFY_API_SECRET')
 SHOPIFY_TEST_REDIRECT_URI = os.getenv('SHOPIFY_TEST_REDIRECT_URI')
 
 #

--- a/OneSila/OneSila/settings/local_template.py
+++ b/OneSila/OneSila/settings/local_template.py
@@ -95,8 +95,6 @@ REPLICATE_API_TOKEN = ""
 
 ADMIN_ROUTE_SUFFIX = "_somethingSecure"
 
-SHOPIFY_API_KEY = None
-SHOPIFY_API_SECRET = None
 SHOPIFY_SCOPES = ['read_products', 'write_products']
 SHOPIFY_API_VERSION = "2025-04"
 SHOPIFY_TEST_REDIRECT_URI = "https://dcfa-79-118-110-129.ngrok-free.app/integrations/shopify/oauth/callback"

--- a/OneSila/sales_channels/integrations/shopify/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/shopify/factories/mixins.py
@@ -17,8 +17,8 @@ class GetShopifyApiMixin:
     def get_api(self):
         # Configure your app credentials (once per process)
         shopify.Session.setup(
-            api_key=settings.SHOPIFY_API_KEY,
-            secret=settings.SHOPIFY_API_SECRET,
+            api_key=self.sales_channel.api_key,
+            secret=self.sales_channel.api_secret,
         )
 
         # Create and activate a session for the specific shop

--- a/OneSila/sales_channels/integrations/shopify/factories/sales_channels/oauth.py
+++ b/OneSila/sales_channels/integrations/shopify/factories/sales_channels/oauth.py
@@ -19,8 +19,8 @@ class GetShopifyRedirectUrlFactory:
         self.redirect_url = None
 
         shopify.Session.setup(
-            api_key=settings.SHOPIFY_API_KEY,
-            secret=settings.SHOPIFY_API_SECRET
+            api_key=self.sales_channel.api_key,
+            secret=self.sales_channel.api_secret
         )
 
     def clean_shop_hostname(self, hostname: str) -> str:
@@ -77,7 +77,10 @@ class ValidateShopifyAuthFactory(GetShopifyApiMixin):
 
 
     def exchange_token(self):
-        shopify.Session.setup(api_key=settings.SHOPIFY_API_KEY, secret=settings.SHOPIFY_API_SECRET)
+        shopify.Session.setup(
+            api_key=self.sales_channel.api_key,
+            secret=self.sales_channel.api_secret,
+        )
         session = shopify.Session(self.shop, settings.SHOPIFY_API_VERSION)
 
         try:

--- a/OneSila/sales_channels/integrations/shopify/helpers.py
+++ b/OneSila/sales_channels/integrations/shopify/helpers.py
@@ -1,10 +1,30 @@
 import base64
 import hashlib
 import hmac
-from django.conf import settings
+import json
+from sales_channels.integrations.shopify.models import ShopifySalesChannel
 
 def verify_shopify_webhook_hmac(request):
-    secret = settings.SHOPIFY_API_SECRET
+    secret = None
+    domain = request.headers.get('X-Shopify-Shop-Domain')
+    channel = None
+
+    if domain:
+        channel = ShopifySalesChannel.objects.filter(hostname__icontains=domain).first()
+    else:
+        try:
+            payload = json.loads(request.body)
+            shop_domain = payload.get('shop_domain')
+            if shop_domain:
+                channel = ShopifySalesChannel.objects.filter(hostname__icontains=shop_domain).first()
+        except Exception:
+            pass
+
+    if channel:
+        secret = channel.api_secret
+
+    if not secret:
+        return False
     shopify_hmac = request.headers.get('X-Shopify-Hmac-Sha256')
     if not shopify_hmac:
         return False

--- a/OneSila/sales_channels/integrations/shopify/migrations/0014_shopifysaleschannel_api_credentials.py
+++ b/OneSila/sales_channels/integrations/shopify/migrations/0014_shopifysaleschannel_api_credentials.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('shopify', '0013_remove_shopifysaleschannel_is_external_install'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='shopifysaleschannel',
+            name='api_key',
+            field=models.CharField(blank=True, help_text='API key of the Shopify custom app associated with this store.', max_length=255, null=True),
+        ),
+        migrations.AddField(
+            model_name='shopifysaleschannel',
+            name='api_secret',
+            field=models.CharField(blank=True, help_text='API secret of the Shopify custom app associated with this store.', max_length=255, null=True),
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/shopify/models/sales_channels.py
+++ b/OneSila/sales_channels/integrations/shopify/models/sales_channels.py
@@ -15,6 +15,20 @@ class ShopifySalesChannel(SalesChannel):
         null=True, blank=True
     )
 
+    api_key = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text="API key of the Shopify custom app associated with this store.",
+    )
+
+    api_secret = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text="API secret of the Shopify custom app associated with this store.",
+    )
+
     state = models.CharField(
         max_length=64,
         unique=True,


### PR DESCRIPTION
## Summary
- drop usage of deprecated `SHOPIFY_API_KEY` and `SHOPIFY_API_SECRET`
- rely solely on `ShopifySalesChannel.api_key` and `.api_secret`
- update webhook HMAC helper to fail if no secret found
- clean up settings templates

## Testing
- `python OneSila/manage.py test --keepdb --verbosity 2` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_686b94a82c24832ea8e7512c89a0d049