### PR TITLE
Add test for missing ASIN/EAN check

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
@@ -24,6 +24,7 @@ from sales_channels.integrations.amazon.models.sales_channels import (
     AmazonDefaultUnitConfigurator,
 )
 from sales_channels.integrations.amazon.models import AmazonCurrency
+from eancodes.models import EanCode
 from sales_prices.models import SalesPrice
 from currencies.models import Currency
 from currencies.currencies import currencies
@@ -1006,9 +1007,35 @@ class AmazonProductFactoriesTest(TransactionTestCase):
         pass
 
 
-    def test_missing_ean_or_asin_raises_exception(self):
+    @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
+    @patch("sales_channels.integrations.amazon.factories.mixins.ListingsApi")
+    def test_missing_ean_or_asin_raises_exception(self, mock_listings, mock_get_client):
         """This test ensures the factory raises ValueError if no EAN/GTIN or ASIN is provided."""
-        pass
+        ProductProperty.objects.filter(
+            product=self.product,
+            property__internal_name="merchant_suggested_asin",
+        ).delete()
+        AmazonProperty.objects.filter(
+            sales_channel=self.sales_channel,
+            code="merchant_suggested_asin",
+        ).delete()
+
+        EanCode.objects.filter(product=self.product).delete()
+        self.remote_product.ean_code = None
+        self.remote_product.save()
+
+        fac = AmazonProductCreateFactory(
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+            remote_instance=self.remote_product,
+            view=self.view,
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            fac.run()
+
+        self.assertIn("ASIN or EAN", str(ctx.exception))
+        mock_listings.return_value.put_listings_item.assert_not_called()
 
 
     def test_create_product_with_asin_in_payload(self):


### PR DESCRIPTION
## Summary
- test for ValueError when Amazon create factory lacks ASIN/EAN

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductFactoriesTest.test_missing_ean_or_asin_raises_exception -v 2` *(fails: OperationalError connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686d4ae03d88832e9748398e49492dc3

## Summary by Sourcery

Tests:
- Add test_missing_ean_or_asin_raises_exception to verify a ValueError is raised and no API request is made when both ASIN and EAN are absent