### PR TITLE
Refactor Amazon product content update

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py
@@ -33,6 +33,7 @@ class AmazonProductContentUpdateFactoryTest(TestCase):
         self.sales_channel = AmazonSalesChannel.objects.create(
             multi_tenant_company=self.multi_tenant_company,
             remote_id="SELLER123",
+            listing_owner=True
         )
         self.view = AmazonSalesChannelView.objects.create(
             multi_tenant_company=self.multi_tenant_company,
@@ -157,16 +158,16 @@ class AmazonProductContentUpdateFactoryTest(TestCase):
             fac.run()
 
         expected_payload = {
-            "item_name": "Chair name",
-            "product_description": "Chair description",
-            "bullet_point": ["Point one", "Point two"],
+            "item_name": [{"value": "Chair name"}],
+            "product_description": [{"value": "Chair description"}],
+            "bullet_point": [{"value": "Point one"}, {"value": "Point two"}],
         }
         expected_body = {
             "productType": "CHAIR",
             "patches": [
-                {"op": "add", "value": [{"item_name": "Chair name"}]},
-                {"op": "add", "value": [{"product_description": "Chair description"}]},
-                {"op": "add", "value": [{"bullet_point": ["Point one", "Point two"]}]},
+                {"op": "add", "value": [{"item_name": [{"value": "Chair name"}]}]},
+                {"op": "add", "value": [{"product_description": [{"value": "Chair description"}]}]},
+                {"op": "add", "value": [{"bullet_point": [{"value": "Point one"}, {"value": "Point two"}]}]},
             ],
         }
 


### PR DESCRIPTION
## Summary
- ensure only listing owners can update content
- reuse fallback logic for Amazon product content
- update unit test expectations

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/products/content.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686fbf867100832e9ffdefbb6cb1c73c

## Summary by Sourcery

Refactor Amazon product content update to enforce listing owner checks and centralize payload building logic with improved translation fallbacks.

Enhancements:
- Restrict content updates to listing owners via a new preflight_check override
- Extract and reuse product content attribute assembly in build_content_attributes
- Combine channel-specific and default translations for item name, description, and bullet points
- Simplify customize_payload to delegate to build_content_attributes
- Update unit tests to reflect the new nested payload structure and listing_owner requirement