### PR TITLE
Fix Amazon price update payload

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py
@@ -128,11 +128,24 @@ class AmazonPriceUpdateFactoryTest(TestCase):
             "patches": [
                 {
                     "op": "add",
-                    "value": [{"list_price": [{"currency": "GBP", "amount": 80.0}]}],
-                },
-                {
-                    "op": "add",
-                    "value": [{"uvp_list_price": [{"currency": "GBP", "amount": 100.0}]}],
+                    "value": [
+                        {
+                            "purchasable_offer": [
+                                {
+                                    "audience": "ALL",
+                                    "currency": "GBP",
+                                    "marketplace_id": "GB",
+                                    "our_price": [
+                                        {
+                                            "schedule": [
+                                                {"value_with_tax": 80.0}
+                                            ]
+                                        }
+                                    ],
+                                }
+                            ]
+                        }
+                    ],
                 },
             ],
         }


### PR DESCRIPTION
## Summary
- add purchasable_offer when updating Amazon prices
- only send list_price when the sales channel owns the listing
- remove uvp_list_price and simplify price update logic

## Testing
- `coverage run --source='.' OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_price_factories.AmazonPriceUpdateFactoryTest.test_update_factory_builds_correct_body` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686fbee55f50832e96b36d9bc3f2d04a

## Summary by Sourcery

Update Amazon price update factory to use the new 'purchasable_offer' payload structure and send 'list_price' only when the channel owns the listing, removing outdated uvp_list_price logic.

Bug Fixes:
- Fix Amazon price update payload to match API requirements by using the new ‘purchasable_offer’ field.

Enhancements:
- Always include ‘purchasable_offer’ with price details and conditionally attach ‘list_price’ only if the channel owns the listing.
- Simplify price determination by preferring ‘discount_price’ over base price when available.

Tests:
- Update unit test to expect the revised payload structure in AmazonPriceUpdateFactory.