### PR TITLE
Fix select value sync duplication

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/sync/select_value_sync.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sync/select_value_sync.py
@@ -46,6 +46,7 @@ class AmazonPropertySelectValuesSyncFactory:
     # @TODO: before we create we need to match by existing value in oter marketplace (by its local instance) to avoid duplciates
     def _link_duplicate_values(self, values: list) -> None:
         """Create/link a local PropertySelectValue for each provided remote value."""
+        existing_psv = None
         for val in values:
             lang = val.marketplace.remote_languages.first()
             if not lang or not val.remote_name:
@@ -53,16 +54,20 @@ class AmazonPropertySelectValuesSyncFactory:
                 continue
 
             language_code = lang.local_instance
-            existing_psv = PropertySelectValue.objects.filter(
-                property=self.local_property,
-                propertyselectvaluetranslation__value__iexact=val.remote_name.strip(),
-            ).first()
 
-            if not existing_psv:
-                existing_psv = PropertySelectValue.objects.create(
+            # Create the PropertySelectValue only once for the first valid entry
+            if existing_psv is None:
+                existing_psv = PropertySelectValue.objects.filter(
                     property=self.local_property,
-                    multi_tenant_company=self.amazon_property.multi_tenant_company,
-                )
+                    propertyselectvaluetranslation__language=language_code,
+                    propertyselectvaluetranslation__value__iexact=val.remote_name.strip(),
+                ).first()
+
+                if not existing_psv:
+                    existing_psv = PropertySelectValue.objects.create(
+                        property=self.local_property,
+                        multi_tenant_company=self.amazon_property.multi_tenant_company,
+                    )
 
             PropertySelectValueTranslation.objects.get_or_create(
                 propertyselectvalue=existing_psv,


### PR DESCRIPTION
## Summary
- avoid creating duplicate PropertySelectValue objects when syncing

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/sync/select_value_sync.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_sync_factories.AmazonSyncFactoriesTest.test_property_select_values_sync_maps_duplicates` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686fc1ce899c832e89b9436e0747f948

## Summary by Sourcery

Prevent duplicate creation of local PropertySelectValue objects during sync by caching and reusing the first found or created instance

Bug Fixes:
- Avoid creating duplicate PropertySelectValue records when syncing remote values

Enhancements:
- Introduce an existing_psv cache to fetch or create the PropertySelectValue only once per sync operation