### PR TITLE
Update listing offer logic

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/migrations/0034_alter_listing_offer_required_properties_to_dict.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0034_alter_listing_offer_required_properties_to_dict.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0033_amazonpublicdefinition_allowed_in_listing_offer_request'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='amazonproducttype',
+            name='listing_offer_required_properties',
+            field=models.JSONField(blank=True, default=dict),
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/models/properties.py
@@ -211,7 +211,7 @@ class AmazonProductType(RemoteObjectMixin, models.Model):
     )
 
     variation_themes = JSONField(null=True, blank=True)
-    listing_offer_required_properties = JSONField(default=list, blank=True)
+    listing_offer_required_properties = JSONField(default=dict, blank=True)
 
     objects = AmazonProductTypeManager()
 


### PR DESCRIPTION
## Summary
- track listing offer properties by api region using keys only
- return allowed offer property codes when syncing Amazon definitions
- mark attributes allowed in listing offer requests
- migrate listing offer property field to dict

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/sales_channels/full_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_686fddaf9da0832e97dcca5d2bfb925e

## Summary by Sourcery

Track and persist Amazon listing-offer property codes per region, return them with product type schemas, and flag attributes allowed in listing-offer requests.

Enhancements:
- Persist listing-offer property keys per API region in AmazonProductType
- Return allowed offer property codes alongside schema in _get_schema_for_marketplace
- Flag AmazonPublicDefinitions.allowed_in_listing_offer_request based on allowed offer properties
- Propagate allowed offer properties through process_property and sync_public_definitions methods
- Migrate listing_offer_required_properties field from a list to a dict