### PR TITLE
Refactor Amazon update_product

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
@@ -64,8 +64,8 @@ class AmazonPriceUpdateFactory(GetAmazonAPIMixin, RemotePriceUpdateFactory):
                 self.remote_product.remote_sku,
                 self.view.remote_id,
                 self.remote_product.remote_type,
-                current_attrs,
                 attributes,
+                current_attrs,
             )
             responses.append(resp)
 

--- a/OneSila/sales_channels/integrations/amazon/factories/products/content.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/content.py
@@ -112,8 +112,8 @@ class AmazonProductContentUpdateFactory(GetAmazonAPIMixin, RemoteProductContentU
             self.remote_product.remote_sku,
             self.view.remote_id,
             product_type.product_type_code,
-            current_attrs,
             body.get("attributes", {}),
+            current_attrs,
         )
 
         return response

--- a/OneSila/sales_channels/integrations/amazon/factories/products/images.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/images.py
@@ -73,8 +73,8 @@ class AmazonMediaProductThroughBase(GetAmazonAPIMixin):
             self.remote_product.remote_sku,
             self.view.remote_id,
             self.remote_product.remote_type,
-            current_attrs,
             body.get("attributes", {}),
+            current_attrs,
         )
         return response
 

--- a/OneSila/sales_channels/integrations/amazon/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/products.py
@@ -421,8 +421,8 @@ class AmazonProductUpdateFactory(AmazonProductBaseFactory, RemoteProductUpdateFa
             self.sku,
             self.view.remote_id,
             self.remote_rule,
-            self.current_attrs,
             self.payload.get("attributes", {}),
+            self.current_attrs,
         )
         return resp
 
@@ -471,8 +471,8 @@ class AmazonProductSyncFactory(AmazonProductBaseFactory, RemoteProductSyncFactor
             self.sku,
             self.view.remote_id,
             self.remote_rule,
-            self.current_attrs,
             self.payload.get("attributes", {}),
+            self.current_attrs,
         )
         return resp
 

--- a/OneSila/sales_channels/integrations/amazon/factories/properties/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/properties/properties.py
@@ -48,8 +48,8 @@ class AmazonProductPropertyCreateFactory(AmazonProductPropertyBaseMixin, RemoteP
             self.remote_product.remote_sku,
             self.view.remote_id,
             body.get("productType"),
-            current_attrs,
             body.get("attributes", {}),
+            current_attrs,
         )
         return response
 
@@ -102,8 +102,8 @@ class AmazonProductPropertyUpdateFactory(AmazonProductPropertyBaseMixin, RemoteP
             self.remote_product.remote_sku,
             self.view.remote_id,
             body.get("productType"),
-            current_attrs,
             body.get("attributes", {}),
+            current_attrs,
         )
         return response
 
@@ -144,8 +144,8 @@ class AmazonProductPropertyDeleteFactory(AmazonProductPropertyBaseMixin, RemoteP
                 self.remote_instance.remote_product.remote_sku,
                 self.view.remote_id,
                 self.remote_instance.remote_product.remote_type,
-                current_attrs,
                 {self.remote_instance.remote_property.main_code: None},
+                current_attrs,
             )
             return response
         except Exception:


### PR DESCRIPTION
## Summary
- refactor `update_product` to perform PUT requests with merged attributes
- allow `get_listing_item` to accept included data
- update factories to new update_product signature
- adjust Amazon tests for PUT logic
- add regression test for attribute fetch when updating

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.TestCase --noinput -v 2` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687017180618832e8323d3de8ddfdcdc