### PR TITLE
Update tests for Amazon PUT update

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py
@@ -109,9 +109,9 @@ class AmazonPriceUpdateFactoryTest(TestCase):
 
     @patch("sales_channels.integrations.amazon.factories.mixins.ListingsApi")
     @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
-    def test_update_factory_builds_correct_body(self, mock_get_client, mock_listings):
+    def test_update_price_builds_correct_body(self, mock_get_client, mock_listings):
         mock_instance = mock_listings.return_value
-        mock_instance.patch_listings_item.side_effect = Exception("no amazon")
+        mock_instance.put_listings_item.side_effect = Exception("no amazon")
         mock_instance.get_listings_item.return_value = MagicMock(payload={"attributes": {}})
 
         factory = AmazonPriceUpdateFactory(
@@ -125,30 +125,24 @@ class AmazonPriceUpdateFactoryTest(TestCase):
 
         expected = {
             "productType": "CHAIR",
-            "patches": [
-                {
-                    "op": "add",
-                    "value": [
-                        {
-                            "purchasable_offer": [
-                                {
-                                    "audience": "ALL",
-                                    "currency": "GBP",
-                                    "marketplace_id": "GB",
-                                    "our_price": [
-                                        {
-                                            "schedule": [
-                                                {"value_with_tax": 80.0}
-                                            ]
-                                        }
-                                    ],
-                                }
-                            ]
-                        }
-                    ],
-                },
-            ],
+            "requirements": "LISTING_OFFER_ONLY",
+            "attributes": {
+                "purchasable_offer": [
+                    {
+                        "audience": "ALL",
+                        "currency": "GBP",
+                        "marketplace_id": "GB",
+                        "our_price": [
+                            {
+                                "schedule": [
+                                    {"value_with_tax": 80.0}
+                                ]
+                            }
+                        ],
+                    }
+                ]
+            },
         }
 
-        body = mock_instance.patch_listings_item.call_args.kwargs.get("body")
+        body = mock_instance.put_listings_item.call_args.kwargs.get("body")
         self.assertEqual(body, expected)

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py
@@ -141,9 +141,9 @@ class AmazonProductContentUpdateFactoryTest(TestCase):
 
     @patch("sales_channels.integrations.amazon.factories.mixins.ListingsApi")
     @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
-    def test_update_builds_correct_body(self, mock_client, mock_listings):
+    def test_update_content_builds_correct_body(self, mock_client, mock_listings):
         mock_instance = mock_listings.return_value
-        mock_instance.patch_listings_item.side_effect = Exception("no amazon")
+        mock_instance.put_listings_item.side_effect = Exception("no amazon")
         mock_instance.get_listings_item.return_value = MagicMock(payload={"attributes": {}})
 
         fac = AmazonProductContentUpdateFactory(
@@ -157,19 +157,18 @@ class AmazonProductContentUpdateFactoryTest(TestCase):
         with self.assertRaises(Exception):
             fac.run()
 
-        expected_payload = {
-            "item_name": [{"value": "Chair name"}],
-            "product_description": [{"value": "Chair description"}],
-            "bullet_point": [{"value": "Point one"}, {"value": "Point two"}],
-        }
         expected_body = {
             "productType": "CHAIR",
-            "patches": [
-                {"op": "add", "value": [{"item_name": [{"value": "Chair name"}]}]},
-                {"op": "add", "value": [{"product_description": [{"value": "Chair description"}]}]},
-                {"op": "add", "value": [{"bullet_point": [{"value": "Point one"}, {"value": "Point two"}]}]},
-            ],
+            "requirements": "LISTING",
+            "attributes": {
+                "item_name": [{"value": "Chair name"}],
+                "product_description": [{"value": "Chair description"}],
+                "bullet_point": [
+                    {"value": "Point one"},
+                    {"value": "Point two"},
+                ],
+            },
         }
 
-        body = mock_instance.patch_listings_item.call_args.kwargs.get("body")
+        body = mock_instance.put_listings_item.call_args.kwargs.get("body")
         self.assertEqual(body, expected_body)

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
@@ -720,7 +720,7 @@ class AmazonProductFactoriesTest(TransactionTestCase):
     @patch.object(AmazonMediaProductThroughBase, "_get_images", return_value=["https://example.com/img.jpg"])
     @patch("sales_channels.integrations.amazon.factories.mixins.ListingsApi")
     def test_update_product_factory_builds_correct_payload(self, mock_listings, mock_get_images, mock_get_client):
-        """This test checks that the update factory builds a correct patch payload with only changed attributes."""
+        """This test checks that the update factory builds a correct payload using PUT."""
         url = "https://example.com/img.jpg"
 
         # mark product as already created on this marketplace so update runs
@@ -732,7 +732,7 @@ class AmazonProductFactoriesTest(TransactionTestCase):
         }
 
         mock_instance = mock_listings.return_value
-        mock_instance.patch_listings_item.return_value = self.get_put_and_patch_item_listing_mock_response()
+        mock_instance.put_listings_item.return_value = self.get_put_and_patch_item_listing_mock_response()
 
         current_attrs = {"item_name": "Old name"}
         mock_instance.get_listings_item.return_value = SimpleNamespace(attributes=current_attrs)
@@ -745,11 +745,11 @@ class AmazonProductFactoriesTest(TransactionTestCase):
         )
         fac.run()
 
-        body = mock_instance.patch_listings_item.call_args.kwargs.get("body")
-        expected_patches = fac._build_patches(current_attrs, fac.payload["attributes"])
+        body = mock_instance.put_listings_item.call_args.kwargs.get("body")
         expected_body = {
-            "productType": "PRODUCT",
-            "patches": expected_patches,
+            "productType": "CHAIR",
+            "requirements": "LISTING",
+            "attributes": fac.payload["attributes"],
         }
 
         self.assertEqual(body, expected_body)


### PR DESCRIPTION
## Summary
- adapt Amazon update tests to use PUT instead of PATCH
- rename content and price update tests

## Testing
- `python manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_price_factories.AmazonPriceUpdateFactoryTest.test_update_price_builds_correct_body -v 2` *(fails: ModuleNotFoundError: No module named 'magento')*

------
https://chatgpt.com/codex/tasks/task_e_68701f96aad0832e9f201e18365b8150

## Summary by Sourcery

Update Amazon integration tests to use PUT requests instead of PATCH for listing updates, adapt the expected request body structure to use requirements and attributes fields, and rename tests for clarity.

Enhancements:
- Switch AmazonPriceUpdateFactory and AmazonProductContentUpdateFactory tests to call put_listings_item instead of patch_listings_item and update expected bodies to include requirements and attributes rather than patches
- Update product update factory test to use put_listings_item and validate the new payload structure
- Rename pricing and content update test methods to test_update_price_builds_correct_body and test_update_content_builds_correct_body for better clarity