### PR TITLE
Add AmazonRemoteLog GraphQL query & ordering/filter support

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -7,6 +7,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonProductTypeItemType,
     AmazonSalesChannelImportType,
     AmazonDefaultUnitConfiguratorType,
+    AmazonRemoteLogType,
 )
 
 
@@ -32,3 +33,6 @@ class AmazonSalesChannelsQuery:
 
     amazon_default_unit_configurator: AmazonDefaultUnitConfiguratorType = node()
     amazon_default_unit_configurators: DjangoListConnection[AmazonDefaultUnitConfiguratorType] = connection()
+
+    amazon_remote_log: AmazonRemoteLogType = node()
+    amazon_remote_logs: DjangoListConnection[AmazonRemoteLogType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -14,6 +14,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProductType,
     AmazonSalesChannelImport, AmazonProductTypeItem,
     AmazonDefaultUnitConfigurator,
+    AmazonRemoteLog,
 )
 from properties.schema.types.filters import (
     PropertyFilter,
@@ -24,6 +25,7 @@ from properties.schema.types.filters import (
 from sales_channels.schema.types.filters import (
     SalesChannelFilter,
     SalesChannelViewFilter,
+    RemoteProductFilter,
 )
 
 
@@ -124,3 +126,9 @@ class AmazonDefaultUnitConfiguratorFilter(SearchFilterMixin):
     id: auto
     sales_channel: Optional[SalesChannelFilter]
     marketplace: Optional[SalesChannelViewFilter]
+
+
+@filter(AmazonRemoteLog)
+class AmazonRemoteLogFilter(SearchFilterMixin):
+    id: auto
+    remote_product: Optional[RemoteProductFilter]

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -8,6 +8,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProductTypeItem,
     AmazonSalesChannelImport,
     AmazonDefaultUnitConfigurator,
+    AmazonRemoteLog,
 )
 
 
@@ -43,4 +44,9 @@ class AmazonSalesChannelImportOrder:
 
 @order(AmazonDefaultUnitConfigurator)
 class AmazonDefaultUnitConfiguratorOrder:
+    id: auto
+
+
+@order(AmazonRemoteLog)
+class AmazonRemoteLogOrder:
     id: auto

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -18,6 +18,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProductTypeItem,
     AmazonSalesChannelImport,
     AmazonDefaultUnitConfigurator,
+    AmazonRemoteLog,
 )
 from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonSalesChannelFilter,
@@ -26,6 +27,7 @@ from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonProductTypeFilter,
     AmazonProductTypeItemFilter,
     AmazonSalesChannelImportFilter, AmazonDefaultUnitConfiguratorFilter,
+    AmazonRemoteLogFilter,
 )
 from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonSalesChannelOrder,
@@ -35,6 +37,7 @@ from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonProductTypeItemOrder,
     AmazonSalesChannelImportOrder,
     AmazonDefaultUnitConfiguratorOrder,
+    AmazonRemoteLogOrder,
 )
 
 
@@ -198,4 +201,18 @@ class AmazonDefaultUnitConfiguratorType(relay.Node, GetQuerysetMultiTenantMixin)
     marketplace: Annotated[
         'SalesChannelViewType',
         lazy("sales_channels.schema.types.types")
+    ]
+
+
+@type(
+    AmazonRemoteLog,
+    filters=AmazonRemoteLogFilter,
+    order=AmazonRemoteLogOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonRemoteLogType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'AmazonSalesChannelType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
     ]


### PR DESCRIPTION
## Summary
- expose `AmazonRemoteLog` through GraphQL
- add type, filter and ordering classes
- include new node/connection in Amazon queries

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/schema/queries.py OneSila/sales_channels/integrations/amazon/schema/types/filters.py OneSila/sales_channels/integrations/amazon/schema/types/ordering.py OneSila/sales_channels/integrations/amazon/schema/types/types.py`
- `python OneSila/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687041f0ead4832e8aac9ef56f578c5f

## Summary by Sourcery

Expose AmazonRemoteLog entity through GraphQL with filtering, ordering, and pagination support

New Features:
- Add AmazonRemoteLogType to the GraphQL schema with multi-tenant pagination and all fields
- Implement AmazonRemoteLogFilter and AmazonRemoteLogOrder classes to enable filtering by id and remote_product and ordering
- Extend AmazonSalesChannelsQuery to provide amazon_remote_log node and amazon_remote_logs connection