### PR TITLE
Fix refresh latest issues mutation for single assign

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/sales_channels/issues.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sales_channels/issues.py
@@ -1,0 +1,28 @@
+from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
+from sales_channels.models import SalesChannelViewAssign
+
+
+class RefreshLatestIssuesFactory(GetAmazonAPIMixin):
+    """Fetch latest listing issues for a single marketplace assignment."""
+
+    def __init__(self, assign: SalesChannelViewAssign):
+        self.assign = assign
+        self.sales_channel = assign.sales_channel
+        self.view = assign.sales_channel_view
+
+    def run(self):
+        remote_product = self.assign.remote_product
+        if not remote_product or not remote_product.remote_sku:
+            return
+
+        response = self.get_listing_item(
+            remote_product.remote_sku,
+            self.view.remote_id,
+            included_data=["issues", "updates"],
+        )
+        issues = getattr(response, "issues", []) or []
+        self.assign.issues = [
+            issue.to_dict() if hasattr(issue, "to_dict") else issue
+            for issue in issues
+        ]
+        self.assign.save()

--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -27,6 +27,8 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonSalesChannelImportType,
     AmazonDefaultUnitConfiguratorType,
 )
+from sales_channels.schema.types.input import SalesChannelViewAssignPartialInput
+from sales_channels.schema.types.types import SalesChannelViewAssignType
 from core.schema.core.mutations import create, type, List, update, delete
 from strawberry import Info
 import strawberry_django
@@ -123,3 +125,27 @@ class AmazonSalesChannelMutation:
             value.save()
 
         return values
+
+    @strawberry_django.mutation(handle_django_errors=True, extensions=default_extensions)
+    def refresh_latest_issues(
+        self, instance: SalesChannelViewAssignPartialInput, info: Info
+    ) -> SalesChannelViewAssignType:
+        """Refresh listing issues for a specific Amazon listing."""
+        from sales_channels.models import SalesChannelViewAssign
+        from sales_channels.integrations.amazon.factories.sales_channels.issues import (
+            RefreshLatestIssuesFactory,
+        )
+
+        multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
+
+        assign = SalesChannelViewAssign.objects.select_related(
+            "remote_product", "sales_channel_view", "sales_channel"
+        ).get(
+            id=instance.id.node_id,
+            sales_channel__multi_tenant_company=multi_tenant_company,
+        )
+
+        factory = RefreshLatestIssuesFactory(assign=assign)
+        factory.run()
+
+        return assign


### PR DESCRIPTION
## Summary
- update `RefreshLatestIssuesFactory` to accept one view assign
- modify `refresh_latest_issues` mutation to use `SalesChannelViewAssignPartialInput`

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/sales_channels/issues.py OneSila/sales_channels/integrations/amazon/schema/mutations.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687048882814832ea18236d1d5cf617b