### PR TITLE
Fix Shopify content fallback

### DIFF
--- a/OneSila/sales_channels/integrations/shopify/factories/products/content.py
+++ b/OneSila/sales_channels/integrations/shopify/factories/products/content.py
@@ -13,27 +13,68 @@ class ShopifyProductContentUpdateFactory(GetShopifyApiMixin, RemoteProductConten
 
     def customize_payload(self):
 
-        translation = ProductTranslation.objects.filter(product=self.local_instance, language=self.local_instance.multi_tenant_company.language, sales_channel=self.sales_channel).first()
-        self.payload = {
-            "id": self.remote_product.remote_id
-        }
+        lang = self.language or self.local_instance.multi_tenant_company.language
+
+        channel_translation = ProductTranslation.objects.filter(
+            product=self.local_instance,
+            language=lang,
+            sales_channel=self.sales_channel,
+        ).first()
+
+        default_translation = ProductTranslation.objects.filter(
+            product=self.local_instance,
+            language=lang,
+            sales_channel=None,
+        ).first()
+
+        self.payload = {"id": self.remote_product.remote_id}
 
         if not self.remote_product.is_variation:
+            title = None
+            description_html = None
+            handle = None
+
+            if channel_translation:
+                title = channel_translation.name or None
+                description_html = channel_translation.description
+                if description_html == "<p><br></p>":
+                    description_html = ""
+                handle = channel_translation.url_key or None
+
+            if not title and default_translation:
+                title = default_translation.name
+
+            if (not description_html) and default_translation:
+                description_html = default_translation.description
+                if description_html == "<p><br></p>":
+                    description_html = ""
+
+            if not handle and default_translation:
+                handle = default_translation.url_key
+
             self.payload.update({
-                "title": translation.name,
-                "descriptionHtml": translation.description,
-                "handle": translation.url_key,
+                "title": title,
+                "descriptionHtml": description_html,
+                "handle": handle,
             })
 
-        short_desc = getattr(translation, 'short_description', None)
+        short_desc = None
+        if channel_translation:
+            short_desc = getattr(channel_translation, "short_description", None)
+        if (not short_desc) and default_translation:
+            short_desc = getattr(default_translation, "short_description", None)
+        if short_desc == "<p><br></p>":
+            short_desc = ""
 
         if short_desc:
-            self.payload["metafields"] = [{
-                "namespace": DEFAULT_METAFIELD_NAMESPACE,
-                "key": "short_description",
-                "type": "multi_line_text_field",
-                "value": short_desc
-            }]
+            self.payload["metafields"] = [
+                {
+                    "namespace": DEFAULT_METAFIELD_NAMESPACE,
+                    "key": "short_description",
+                    "type": "multi_line_text_field",
+                    "value": short_desc,
+                }
+            ]
 
     def update_remote(self):
 

--- a/OneSila/sales_channels/integrations/shopify/tests/tests_factories/test_product_content_update.py
+++ b/OneSila/sales_channels/integrations/shopify/tests/tests_factories/test_product_content_update.py
@@ -1,0 +1,77 @@
+from model_bakery import baker
+from core.tests import TestCase
+from products.models import ProductTranslation
+from sales_channels.integrations.shopify.constants import DEFAULT_METAFIELD_NAMESPACE
+from sales_channels.integrations.shopify.models.products import ShopifyProduct, ShopifyProductContent
+from sales_channels.integrations.shopify.models.sales_channels import ShopifySalesChannel
+from sales_channels.integrations.shopify.factories.products import ShopifyProductContentUpdateFactory
+
+
+class ShopifyProductContentUpdateFactoryTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = ShopifySalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            hostname="shop.test.com",
+        )
+        self.product = baker.make(
+            "products.Product",
+            sku="SKU123",
+            type="SIMPLE",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.remote_product = ShopifyProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+            remote_id="gid://Shopify/Product/1",
+        )
+        self.remote_content = ShopifyProductContent.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_product=self.remote_product,
+        )
+        # Default translation
+        self.default_translation = ProductTranslation.objects.create(
+            product=self.product,
+            sales_channel=None,
+            language=self.multi_tenant_company.language,
+            name="Default name",
+            short_description="Default short",
+            description="Default description",
+            url_key="default-url",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        # Channel translation with partial values
+        self.channel_translation = ProductTranslation.objects.create(
+            product=self.product,
+            sales_channel=self.sales_channel,
+            language=self.multi_tenant_company.language,
+            name="Channel name",
+            description="<p><br></p>",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def test_custom_payload_falls_back_to_default_translation(self):
+        fac = ShopifyProductContentUpdateFactory(
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+            remote_product=self.remote_product,
+            remote_instance=self.remote_content,
+        )
+        fac.customize_payload()
+        expected = {
+            "id": self.remote_product.remote_id,
+            "title": "Channel name",
+            "descriptionHtml": "Default description",
+            "handle": "default-url",
+            "metafields": [
+                {
+                    "namespace": DEFAULT_METAFIELD_NAMESPACE,
+                    "key": "short_description",
+                    "type": "multi_line_text_field",
+                    "value": "Default short",
+                }
+            ],
+        }
+        self.assertEqual(fac.payload, expected)


### PR DESCRIPTION
## Summary
- support sales channel fallback for product translations in Shopify payload
- add regression test covering fallback behaviour

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/shopify/factories/products/content.py OneSila/sales_channels/integrations/shopify/tests/tests_factories/test_product_content_update.py`
- `coverage run --source='.' OneSila/manage.py test OneSila/sales_channels/integrations/shopify/tests/tests_factories/test_product_content_update.py` *(failed: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6870defc9618832e885d41b6702119da

## Summary by Sourcery

Improve ShopifyProductContentUpdateFactory to support sales channel translation fallback by checking channel-specific then default product translations and add a regression test for this behavior

Enhancements:
- Apply fallback logic in ShopifyProductContentUpdateFactory to prefer channel-specific translations and use default translations when fields are missing
- Normalize empty HTML description placeholders and ensure short_description is correctly populated

Tests:
- Add regression test for ShopifyProductContentUpdateFactory to verify fallback behavior for title, descriptionHtml, handle, and metafields