### PR TITLE
Refactor amazon product property factories

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
@@ -72,10 +72,9 @@ class AmazonProductPropertyBaseMixin(GetAmazonAPIMixin, AmazonRemoteValueMixin):
     # Helpers
     # ------------------------------------------------------------------
     def _get_remote_property(self) -> AmazonProperty:
-        return AmazonProperty.objects.get(
-            sales_channel=self.sales_channel,
-            local_instance=self.local_property,
-        )
+        if not getattr(self, "remote_property", None):
+            raise AmazonProperty.DoesNotExist("Remote property not set")
+        return self.remote_property
 
     def _get_product_type(self, rule) -> AmazonProductType:
         return AmazonProductType.objects.get(
@@ -201,4 +200,3 @@ class AmazonProductPropertyBaseMixin(GetAmazonAPIMixin, AmazonRemoteValueMixin):
     def set_remote_id(self, response_data):
         # the product properties have na remote id
         pass
-

--- a/OneSila/sales_channels/integrations/amazon/factories/properties/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/properties/properties.py
@@ -19,12 +19,14 @@ class AmazonProductPropertyCreateFactory(AmazonProductPropertyBaseMixin, RemoteP
         local_instance,
         remote_product,
         view,
+        remote_property,
         api=None,
         skip_checks=False,
         get_value_only=False,
         language=None,
     ):
         self.view = view
+        self.remote_property = remote_property
         super().__init__(
             sales_channel,
             local_instance,
@@ -65,6 +67,7 @@ class AmazonProductPropertyUpdateFactory(AmazonProductPropertyBaseMixin, RemoteP
         local_instance,
         remote_product,
         view,
+        remote_property,
         api=None,
         get_value_only=False,
         remote_instance=None,
@@ -72,6 +75,9 @@ class AmazonProductPropertyUpdateFactory(AmazonProductPropertyBaseMixin, RemoteP
         language=None,
     ):
         self.view = view
+        self.remote_property = remote_property or (
+            remote_instance.remote_property if remote_instance else None
+        )
         super().__init__(
             sales_channel,
             local_instance,
@@ -120,8 +126,11 @@ class AmazonProductPropertyDeleteFactory(AmazonProductPropertyBaseMixin, RemoteP
     remote_model_class = AmazonProductProperty
     delete_remote_instance = True
 
-    def __init__(self, sales_channel, local_instance, remote_product, view, api=None, remote_instance=None):
+    def __init__(self, sales_channel, local_instance, remote_product, view, remote_property, api=None, remote_instance=None):
         self.view = view
+        self.remote_property = remote_property or (
+            remote_instance.remote_property if remote_instance else None
+        )
         super().__init__(sales_channel, local_instance, remote_product=remote_product, api=api, remote_instance=remote_instance)
 
     def delete_remote(self):

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_property_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_property_factories.py
@@ -168,6 +168,7 @@ class AmazonProductPropertyTestSetupMixin:
             ),
         )
 
+
 class AmazonProductPropertyFactoryTest(TestCase, AmazonProductPropertyTestSetupMixin):
     def setUp(self):
         super().setUp()
@@ -179,6 +180,7 @@ class AmazonProductPropertyFactoryTest(TestCase, AmazonProductPropertyTestSetupM
             local_instance=self.product_property,
             remote_product=self.remote_product,
             view=self.view,
+            remote_property=self.amazon_property,
             get_value_only=True,
         )
 
@@ -208,6 +210,7 @@ class AmazonProductPropertyFactoryTest(TestCase, AmazonProductPropertyTestSetupM
             local_instance=self.product_property,
             remote_product=self.remote_product,
             view=self.view,
+            remote_property=self.amazon_property,
             remote_instance=remote_instance,
             get_value_only=True,
         )
@@ -261,6 +264,7 @@ class AmazonProductPropertyFactoryTest(TestCase, AmazonProductPropertyTestSetupM
             local_instance=prop_instance,
             remote_product=self.remote_product,
             view=self.view,
+            remote_property=None,
             get_value_only=True,
         )
 
@@ -274,6 +278,7 @@ class AmazonProductPropertyFactoryTest(TestCase, AmazonProductPropertyTestSetupM
             local_instance=self.product_property,
             remote_product=self.remote_product,
             view=self.view,
+            remote_property=self.amazon_property,
             get_value_only=True,
         )
 
@@ -289,6 +294,7 @@ class AmazonProductPropertyFactoryTest(TestCase, AmazonProductPropertyTestSetupM
             local_instance=self.product_property,
             remote_product=self.remote_product,
             view=self.view,
+            remote_property=self.amazon_property,
             get_value_only=True,
         )
 
@@ -309,6 +315,7 @@ class AmazonProductPropertyFactoryWithoutListingOwnerTest(TestCase, AmazonProduc
             local_instance=self.product_property,
             remote_product=self.remote_product,
             view=self.view,
+            remote_property=self.amazon_property,
             get_value_only=True,
         )
 
@@ -329,6 +336,7 @@ class AmazonProductPropertyFactoryWithoutListingOwnerTest(TestCase, AmazonProduc
             local_instance=self.product_property,
             remote_product=self.remote_product,
             view=self.view,
+            remote_property=self.amazon_property,
             remote_instance=remote_instance,
             get_value_only=True,
         )


### PR DESCRIPTION
## Summary
- refactor amazon property factories to accept remote property
- update amazon property mixin to use provided property
- adapt tests for remote property argument
- wire property argument in product factory

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py OneSila/sales_channels/integrations/amazon/factories/properties/properties.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_property_factories.py OneSila/sales_channels/integrations/amazon/factories/products/products.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_property_factories.AmazonProductPropertyFactoryTest` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68750a4370f4832eab27114969b5bcf7