### PR TITLE
Implement Amazon product type suggestions

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -85,6 +85,17 @@ class GetAmazonAPIMixin:
             raise Exception(f"SP-API failed: {e}")
 
     @throttle_safe(max_retries=5, base_delay=1)
+    def search_product_types(self, marketplace_id: str, name: str):
+        """Return product type suggestions for an item name."""
+        definitions_api = DefinitionsApi(self._get_client())
+        resp = definitions_api.search_definitions_product_types([
+            marketplace_id
+        ], item_name=name)
+        if hasattr(resp, "to_dict"):
+            return resp.to_dict()
+        return resp
+
+    @throttle_safe(max_retries=5, base_delay=1)
     def get_listing_item(self, sku, marketplace_id, *, included_data=None, issue_locale=None):
         """Return listing item payload for the given sku and marketplace."""
 

--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ValidationError
+from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
 
 from sales_channels.integrations.amazon.schema.types.input import (
     AmazonSalesChannelInput,
@@ -26,8 +27,12 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonRedirectUrlType,
     AmazonSalesChannelImportType,
     AmazonDefaultUnitConfiguratorType,
+    SuggestedAmazonProductType,
 )
-from sales_channels.schema.types.input import SalesChannelViewAssignPartialInput
+from sales_channels.schema.types.input import (
+    SalesChannelViewAssignPartialInput,
+    SalesChannelViewPartialInput,
+)
 from sales_channels.schema.types.types import SalesChannelViewAssignType
 from core.schema.core.mutations import create, type, List, update, delete
 from strawberry import Info
@@ -149,3 +154,42 @@ class AmazonSalesChannelMutation:
         factory.run()
 
         return assign
+
+    @strawberry_django.mutation(handle_django_errors=False, extensions=default_extensions)
+    def suggest_amazon_product_type(
+        self,
+        name: str,
+        marketplace: SalesChannelViewPartialInput,
+        info: Info,
+    ) -> SuggestedAmazonProductType:
+        """Return suggested product types for a given name and marketplace."""
+        from sales_channels.models import SalesChannelView
+
+        multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
+
+        view = SalesChannelView.objects.select_related("sales_channel").get(
+            id=marketplace.id.node_id,
+            sales_channel__multi_tenant_company=multi_tenant_company,
+        )
+
+        class _Client(GetAmazonAPIMixin):
+            pass
+
+        client = _Client()
+        client.sales_channel = view.sales_channel.get_real_instance()
+
+        data = client.search_product_types(view.remote_id, name) or {}
+
+        product_types = [
+            SuggestedAmazonProductTypeEntry(
+                display_name=pt.get("display_name"),
+                marketplace_ids=pt.get("marketplace_ids", []),
+                name=pt.get("name"),
+            )
+            for pt in data.get("product_types", [])
+        ]
+
+        return SuggestedAmazonProductType(
+            product_type_version=data.get("product_type_version", ""),
+            product_types=product_types,
+        )

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -247,3 +247,16 @@ class AmazonRemoteLogType(relay.Node, GetQuerysetMultiTenantMixin):
             )
 
         return formatted
+
+
+@strawberry_type
+class SuggestedAmazonProductTypeEntry:
+    display_name: str
+    marketplace_ids: List[str]
+    name: str
+
+
+@strawberry_type
+class SuggestedAmazonProductType:
+    product_type_version: str
+    product_types: List[SuggestedAmazonProductTypeEntry]


### PR DESCRIPTION
## Summary
- extend Amazon mixin with `search_product_types`
- expose new `SuggestedAmazonProductType` GraphQL type
- add `suggest_amazon_product_type` mutation

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/mixins.py OneSila/sales_channels/integrations/amazon/schema/types/types.py OneSila/sales_channels/integrations/amazon/schema/mutations.py`
- `pytest -q` *(fails: ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68757aa22b94832ea785214fa83123d0

## Summary by Sourcery

Implement Amazon product type suggestion feature by extending the Amazon mixin with a search_product_types method, defining new GraphQL types for suggestions, and exposing a suggest_amazon_product_type mutation.

New Features:
- Add search_product_types method to Amazon mixin for fetching product type suggestions from SP-API
- Define SuggestedAmazonProductTypeEntry and SuggestedAmazonProductType GraphQL types to model suggestion results
- Introduce suggest_amazon_product_type GraphQL mutation to retrieve product type suggestions by name and marketplace