### PR TITLE
Ensure Amazon ASIN property on product type import

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
@@ -1,14 +1,11 @@
 import logging
 from imports_exports.factories.imports import ImportMixin
-from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
+from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin, EnsureMerchantSuggestedAsinMixin
 from sales_channels.integrations.amazon.factories.sales_channels.full_schema import AmazonProductTypeRuleFactory
-from sales_channels.integrations.amazon.models.properties import AmazonProperty
-from properties.models import Property, PropertyTranslation
-
 logger = logging.getLogger(__name__)
 
 
-class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin):
+class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin, EnsureMerchantSuggestedAsinMixin):
     import_properties = False
     import_select_values = False
     import_rules = True
@@ -32,41 +29,6 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin):
     def get_total_instances(self):
         return 100
 
-    def _ensure_merchant_suggested_asin(self):
-        remote_property, _ = AmazonProperty.objects.get_or_create(
-            allow_multiple=True,
-            multi_tenant_company=self.sales_channel.multi_tenant_company,
-            sales_channel=self.sales_channel,
-            code="merchant_suggested_asin",
-            defaults={"type": Property.TYPES.TEXT},
-        )
-
-        if not remote_property.local_instance:
-            local_property, _ = Property.objects.get_or_create(
-                internal_name="merchant_suggested_asin",
-                multi_tenant_company=self.sales_channel.multi_tenant_company,
-                defaults={
-                    "type": Property.TYPES.TEXT,
-                    "non_deletable": True,
-                },
-            )
-
-            PropertyTranslation.objects.get_or_create(
-                property=local_property,
-                language=self.sales_channel.multi_tenant_company.language,
-                multi_tenant_company=self.sales_channel.multi_tenant_company,
-                defaults={"name": "Amazon Asin"},
-            )
-
-            remote_property.local_instance = local_property
-            remote_property.save()
-
-        local_property = remote_property.local_instance
-        if not local_property.non_deletable:
-            local_property.non_deletable = True
-            local_property.save(update_fields=["non_deletable"])
-
-        return remote_property
 
 
     def import_rules_process(self):

--- a/OneSila/sales_channels/integrations/amazon/factories/sales_channels/full_schema.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sales_channels/full_schema.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 from spapi import DefinitionsApi, ListingsApi
 from sales_channels.integrations.amazon.constants import AMAZON_INTERNAL_PROPERTIES
 from sales_channels.integrations.amazon.decorators import throttle_safe
-from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
+from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin, EnsureMerchantSuggestedAsinMixin
 from sales_channels.integrations.amazon.models import (
     AmazonSalesChannelView,
     AmazonDefaultUnitConfigurator,
@@ -393,15 +393,17 @@ class DefaultUnitConfiguratorFactory:
             path.pop()
 
 
-class AmazonProductTypeRuleFactory(GetAmazonAPIMixin):
+class AmazonProductTypeRuleFactory(GetAmazonAPIMixin, EnsureMerchantSuggestedAsinMixin):
     def __init__(self, product_type_code, sales_channel, merchant_asin_property=None, api=None, language=None):
         self.product_type_code = product_type_code
         self.sales_channel = sales_channel
         self.language = language or sales_channel.multi_tenant_company.language
         self.multi_tenant_company = sales_channel.multi_tenant_company
-        self.merchant_asin_property = merchant_asin_property
         self.sales_channel_views = AmazonSalesChannelView.objects.filter(sales_channel=sales_channel)
-        self.product_type = self.get_or_create_product_type()
+        if merchant_asin_property is None:
+            self.merchant_asin_property = self._ensure_merchant_suggested_asin()
+        else:
+            self.merchant_asin_property = merchant_asin_property
 
         if api is None:
             self.api = self.get_api()

--- a/OneSila/sales_channels/integrations/amazon/receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/receivers.py
@@ -14,6 +14,7 @@ from sales_channels.integrations.amazon.factories.sync.rule_sync import (
 from sales_channels.integrations.amazon.factories.sync.select_value_sync import (
     AmazonPropertySelectValuesSyncFactory,
 )
+from sales_channels.integrations.amazon.factories.sales_channels.full_schema import AmazonProductTypeRuleFactory
 
 
 @receiver(refresh_website_pull_models, sender='sales_channels.SalesChannel')
@@ -83,6 +84,16 @@ def sales_channels__amazon_product_type__ensure_asin(sender, instance, **kwargs)
 
     sync_factory = AmazonProductTypeAsinSyncFactory(instance)
     sync_factory.run()
+
+@receiver(post_update, sender="amazon.AmazonProductType")
+def sales_channels__amazon_product_type__imported_rule(sender, instance, **kwargs):
+    if instance.is_dirty_field("imported") and instance.imported:
+        fac = AmazonProductTypeRuleFactory(
+            product_type_code=instance.product_type_code,
+            sales_channel=instance.sales_channel,
+        )
+        fac.run()
+
 
 
 @receiver(product_properties_rule_created, sender='properties.ProductPropertiesRule')

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+from core.tests import TestCase
+from sales_channels.integrations.amazon.models import AmazonSalesChannel
+from sales_channels.integrations.amazon.models.properties import AmazonProductType
+
+
+class AmazonProductTypeReceiversTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+
+    @patch("sales_channels.integrations.amazon.receivers.AmazonProductTypeRuleFactory")
+    def test_factory_run_triggered_on_imported_change(self, factory_cls):
+        pt = AmazonProductType.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            product_type_code="CHAIR",
+            imported=False,
+        )
+
+        pt.imported = True
+        pt.save()
+
+        factory_cls.assert_called_once_with(
+            product_type_code=pt.product_type_code,
+            sales_channel=pt.sales_channel,
+        )
+        factory_cls.return_value.run.assert_called_once()
+


### PR DESCRIPTION
## Summary
- add `EnsureMerchantSuggestedAsinMixin` for creating `merchant_suggested_asin`
- use the mixin in product type rule factory and schema import processor
- trigger product type rule sync when `imported` becomes `True`
- test that the rule factory is invoked on update

## Testing
- `coverage run --source='.' manage.py test sales_channels.integrations.amazon.tests.tests_receivers.AmazonProductTypeReceiversTest.test_factory_run_triggered_on_imported_change` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68758e86c740832e941b1df8a64cd0ad