### PR TITLE
Move rule factory invocation to task

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/receivers.py
@@ -14,7 +14,7 @@ from sales_channels.integrations.amazon.factories.sync.rule_sync import (
 from sales_channels.integrations.amazon.factories.sync.select_value_sync import (
     AmazonPropertySelectValuesSyncFactory,
 )
-from sales_channels.integrations.amazon.factories.sales_channels.full_schema import AmazonProductTypeRuleFactory
+from sales_channels.integrations.amazon.tasks import create_amazon_product_type_rule_task
 
 
 @receiver(refresh_website_pull_models, sender='sales_channels.SalesChannel')
@@ -85,15 +85,14 @@ def sales_channels__amazon_product_type__ensure_asin(sender, instance, **kwargs)
     sync_factory = AmazonProductTypeAsinSyncFactory(instance)
     sync_factory.run()
 
+
 @receiver(post_update, sender="amazon.AmazonProductType")
 def sales_channels__amazon_product_type__imported_rule(sender, instance, **kwargs):
     if instance.is_dirty_field("imported") and instance.imported:
-        fac = AmazonProductTypeRuleFactory(
+        create_amazon_product_type_rule_task(
             product_type_code=instance.product_type_code,
-            sales_channel=instance.sales_channel,
+            sales_channel_id=instance.sales_channel_id,
         )
-        fac.run()
-
 
 
 @receiver(product_properties_rule_created, sender='properties.ProductPropertiesRule')

--- a/OneSila/sales_channels/integrations/amazon/tasks.py
+++ b/OneSila/sales_channels/integrations/amazon/tasks.py
@@ -1,6 +1,7 @@
 from huey.contrib.djhuey import db_task
 from core.huey import LOW_PRIORITY
 from sales_channels.decorators import remote_task
+from core.decorators import run_task_after_commit
 
 
 @remote_task(priority=LOW_PRIORITY)
@@ -16,3 +17,20 @@ def amazon_import_db_task(import_process, sales_channel):
     elif import_process.type == AmazonSalesChannelImport.TYPE_PRODUCTS:
         fac = AmazonProductsImportProcessor(import_process=import_process, sales_channel=sales_channel)
         fac.run()
+
+
+@run_task_after_commit
+@db_task()
+def create_amazon_product_type_rule_task(product_type_code: str, sales_channel_id: int):
+    """Create local properties rule for an imported product type."""
+    from sales_channels.integrations.amazon.factories.sales_channels.full_schema import (
+        AmazonProductTypeRuleFactory,
+    )
+    from sales_channels.integrations.amazon.models import AmazonSalesChannel
+
+    sales_channel = AmazonSalesChannel.objects.get(id=sales_channel_id)
+    fac = AmazonProductTypeRuleFactory(
+        product_type_code=product_type_code,
+        sales_channel=sales_channel,
+    )
+    fac.run()

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
@@ -13,8 +13,8 @@ class AmazonProductTypeReceiversTest(TestCase):
             remote_id="SELLER",
         )
 
-    @patch("sales_channels.integrations.amazon.receivers.AmazonProductTypeRuleFactory")
-    def test_factory_run_triggered_on_imported_change(self, factory_cls):
+    @patch("sales_channels.integrations.amazon.receivers.create_amazon_product_type_rule_task")
+    def test_factory_run_triggered_on_imported_change(self, task_func):
         pt = AmazonProductType.objects.create(
             multi_tenant_company=self.multi_tenant_company,
             sales_channel=self.sales_channel,
@@ -25,9 +25,7 @@ class AmazonProductTypeReceiversTest(TestCase):
         pt.imported = True
         pt.save()
 
-        factory_cls.assert_called_once_with(
+        task_func.assert_called_once_with(
             product_type_code=pt.product_type_code,
-            sales_channel=pt.sales_channel,
+            sales_channel_id=pt.sales_channel_id,
         )
-        factory_cls.return_value.run.assert_called_once()
-


### PR DESCRIPTION
## Summary
- trigger Amazon product type rule generation via async task
- add `create_amazon_product_type_rule_task` task
- update receiver unit test to check task scheduling

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/receivers.py OneSila/sales_channels/integrations/amazon/tasks.py OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_receivers.AmazonProductTypeReceiversTest.test_factory_run_triggered_on_imported_change -v 2` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68760fc2c980832eaab97c8413d1fd1e

## Summary by Sourcery

Schedule Amazon product type rule creation via a dedicated async task and update receivers and tests accordingly

New Features:
- Introduce create_amazon_product_type_rule_task to asynchronously generate Amazon product type rules

Enhancements:
- Refactor AmazonProductType receiver to invoke the async task instead of running the factory inline

Tests:
- Update receiver unit test to patch and assert scheduling of the create_amazon_product_type_rule_task