### PR TITLE
Stop auto-create of Amazon product types

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/receivers.py
@@ -1,7 +1,6 @@
 from core.receivers import receiver
 from core.signals import post_create, post_update
 from sales_channels.signals import refresh_website_pull_models, sales_channel_created
-from properties.signals import product_properties_rule_created
 from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
     AmazonProperty,
@@ -92,13 +91,4 @@ def sales_channels__amazon_product_type__imported_rule(sender, instance, **kwarg
         create_amazon_product_type_rule_task(
             product_type_code=instance.product_type_code,
             sales_channel_id=instance.sales_channel_id,
-        )
-
-
-@receiver(product_properties_rule_created, sender='properties.ProductPropertiesRule')
-def sales_channels__amazon_product_type__create_from_local_rule(sender, instance, **kwargs):
-    for sc in AmazonSalesChannel.objects.filter(multi_tenant_company=instance.multi_tenant_company):
-        AmazonProductType.objects.get_or_create_from_local_instance(
-            local_instance=instance,
-            sales_channel=sc,
         )

--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -193,3 +193,35 @@ class AmazonSalesChannelMutation:
             product_type_version=data.get("product_type_version", ""),
             product_types=product_types,
         )
+
+    @strawberry_django.mutation(handle_django_errors=False, extensions=default_extensions)
+    def create_amazon_product_types_from_local_rules(
+        self,
+        instance: AmazonSalesChannelPartialInput,
+        info: Info,
+    ) -> List[AmazonProductTypeType]:
+        """Create Amazon product types for all local rules on a given sales channel."""
+        from sales_channels.integrations.amazon.models import (
+            AmazonSalesChannel,
+            AmazonProductType,
+        )
+        from properties.models import ProductPropertiesRule
+
+        multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
+
+        sales_channel = AmazonSalesChannel.objects.get(
+            id=instance.id.node_id,
+            multi_tenant_company=multi_tenant_company,
+        )
+
+        product_types: list[AmazonProductType] = []
+        for rule in ProductPropertiesRule.objects.filter(
+            multi_tenant_company=multi_tenant_company
+        ).iterator():
+            product_type, _ = AmazonProductType.objects.get_or_create_from_local_instance(
+                local_instance=rule,
+                sales_channel=sales_channel,
+            )
+            product_types.append(product_type)
+
+        return product_types


### PR DESCRIPTION
## Summary
- remove signal receiver that automatically creates AmazonProductType
- provide GraphQL mutation to create missing AmazonProductType from local rules

## Testing
- `pycodestyle OneSila/sales_channels/integrations/amazon/receivers.py OneSila/sales_channels/integrations/amazon/schema/mutations.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687646b9a060832ea5436541eabc120f

## Summary by Sourcery

Stop automatic creation of AmazonProductType via Django signal and add a GraphQL mutation to manually create missing product types based on local rules.

New Features:
- Introduce a GraphQL mutation createAmazonProductTypesFromLocalRules to generate missing AmazonProductType entries from local rules for a given sales channel.

Enhancements:
- Remove the Django signal receiver that automatically created AmazonProductType instances on ProductPropertiesRule creation.