### PR TITLE
Implement Amazon product ownership flag

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
@@ -53,7 +53,7 @@ class AmazonPriceUpdateFactory(GetAmazonAPIMixin, RemotePriceUpdateFactory):
                 ]
             }
 
-            if self.sales_channel.listing_owner:
+            if self.sales_channel.listing_owner or self.remote_product.product_owner:
                 attributes["list_price"] = [{"currency": iso, "value": list_price}]
 
 

--- a/OneSila/sales_channels/integrations/amazon/factories/products/content.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/content.py
@@ -23,7 +23,7 @@ class AmazonProductContentUpdateFactory(GetAmazonAPIMixin, RemoteProductContentU
         )
 
     def preflight_check(self):
-        if not self.sales_channel.listing_owner:
+        if not self.sales_channel.listing_owner and not self.remote_product.product_owner:
             return False
 
         return super().preflight_check()

--- a/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
@@ -159,7 +159,8 @@ class AmazonProductPropertyBaseMixin(GetAmazonAPIMixin, AmazonRemoteValueMixin):
         usage = json.loads(public_def.usage_definition)
         payload = self._replace_tokens(usage, self.local_instance.product)
 
-        if not self.sales_channel.listing_owner:
+        remote_prod = getattr(self, "remote_product", None)
+        if not self.sales_channel.listing_owner and not getattr(remote_prod, "product_owner", False):
             allowed_properties = product_type.listing_offer_required_properties.get(self.view.api_region_code, [])
             if main_code not in allowed_properties:
                 return product_type, {}

--- a/OneSila/sales_channels/integrations/amazon/migrations/0037_amazonproduct_product_owner.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0037_amazonproduct_product_owner.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0036_alter_amazonproducttype_unique_together_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='amazonproduct',
+            name='product_owner',
+            field=models.BooleanField(default=False, help_text='Indicates if this listing was created by us and we can manage listing level data.'),
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/products.py
+++ b/OneSila/sales_channels/integrations/amazon/models/products.py
@@ -35,6 +35,11 @@ class AmazonProduct(RemoteProduct):
         help_text="EAN code used when the product was first created.",
     )
 
+    product_owner = models.BooleanField(
+        default=False,
+        help_text="Indicates if this listing was created by us and we can manage listing level data.",
+    )
+
     @property
     def remote_type(self):
         return self.get_remote_rule().product_type_code


### PR DESCRIPTION
## Summary
- add `product_owner` field to `AmazonProduct`
- set listing requirements in factories based on product ownership
- include listing price and content logic when product is owned
- generate migration for the new field
- fix listing requirement flag initialization

## Testing
- `pip install -r requirements.txt`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests` *(fails: connection to Postgres refused)*


------
https://chatgpt.com/codex/tasks/task_e_687690182514832e974db5b75adc2434

## Summary by Sourcery

Introduce a product ownership flag on AmazonProduct and update factory logic to respect ownership when determining listing requirements, building payloads, and saving remote instances.

New Features:
- Add product_owner BooleanField to AmazonProduct with corresponding migration

Enhancements:
- Initialize force_listing_requirements based on remote_instance.product_owner and payload attributes
- Include product_owner or forced listing in factory listing requirements, content attribute building, and price attribute generation
- Update post-action processing to set and persist product_owner on remote_instance when appropriate