### PR TITLE
Implement Amazon variations theme handling

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
@@ -44,6 +44,7 @@ from properties.models import (
     PropertySelectValue,
     PropertySelectValueTranslation,
 )
+from sales_channels.models.products import RemoteProductConfigurator
 from sales_channels.integrations.amazon.factories.products import (
     AmazonProductCreateFactory,
     AmazonProductUpdateFactory,
@@ -722,7 +723,6 @@ class AmazonProductFactoriesTest(TransactionTestCase):
         # mark product as already created on this marketplace so update runs
         self.remote_product.created_marketplaces = [self.view.remote_id]
         self.remote_product.save()
-
 
         mock_instance = mock_listings.return_value
         mock_instance.put_listings_item.return_value = self.get_put_and_patch_item_listing_mock_response()
@@ -1620,8 +1620,6 @@ class AmazonProductFactoriesTest(TransactionTestCase):
             "issues": [],
         }
 
-
-
         SalesPrice.objects.filter(product=self.product).delete()
         fac = AmazonProductCreateFactory(
             sales_channel=self.sales_channel,
@@ -1735,3 +1733,105 @@ class AmazonProductFactoriesTest(TransactionTestCase):
         body = mock_instance.put_listings_item.call_args.kwargs.get("body")
         self.assertEqual(body["attributes"].get("item_name"), [{"value": "New"}])
 
+
+class AmazonVariationThemeTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        setup_product_factories_testcase(self)
+
+        # additional size property used for variation matching
+        self.size_property = baker.make(
+            Property,
+            type=Property.TYPES.SELECT,
+            internal_name="size",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertyTranslation.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            property=self.size_property,
+            language=self.multi_tenant_company.language,
+            name="Size",
+        )
+        AmazonProperty.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.size_property,
+            code="size",
+            type=Property.TYPES.SELECT,
+        )
+        ProductPropertiesRuleItem.objects.get_or_create(
+            multi_tenant_company=self.multi_tenant_company,
+            rule=self.rule,
+            property=self.size_property,
+            defaults={"type": ProductPropertiesRuleItem.OPTIONAL},
+        )
+
+        self.remote_rule = AmazonProductType.objects.get(local_instance=self.rule)
+        self.remote_rule.variation_themes = ["COLOR/SIZE", "SIZE"]
+        self.remote_rule.save()
+
+        self.configurator = RemoteProductConfigurator.objects.create(
+            remote_product=self.remote_product,
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+        )
+        self.configurator.properties.set([self.color_property, self.size_property])
+
+    def test_match_amazon_variation_theme(self):
+        fac = AmazonProductSyncFactory(
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+            remote_instance=self.remote_product,
+            view=self.view,
+        )
+        fac.remote_rule = self.remote_rule
+        theme = fac._match_amazon_variation_theme(self.configurator)
+        self.assertEqual(theme, "COLOR/SIZE")
+
+    def test_build_variation_attributes_for_child(self):
+        child_product = baker.make(
+            "products.Product",
+            sku="CHILD",
+            type="SIMPLE",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        child_remote = AmazonProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=child_product,
+            remote_parent_product=self.remote_product,
+            remote_sku="CHILD",
+            is_variation=True,
+        )
+
+        self.remote_product.remote_sku = "PARENTSKU"
+        self.remote_product.save()
+
+        self.configurator.amazon_theme = "COLOR/SIZE"
+        self.configurator.save()
+
+        fac = AmazonProductSyncFactory(
+            sales_channel=self.sales_channel,
+            local_instance=child_product,
+            parent_local_instance=self.product,
+            remote_parent_product=self.remote_product,
+            remote_instance=child_remote,
+            view=self.view,
+        )
+        fac.remote_rule = self.remote_rule
+        attrs = fac.build_variation_attributes()
+
+        expected_theme = [{"value": "COLOR/SIZE", "marketplace_id": self.view.remote_id}]
+        expected_parentage = [{"value": "child", "marketplace_id": self.view.remote_id}]
+        expected_rel = [
+            {
+                "child_relationship_type": "variation",
+                "parent_sku": "PARENTSKU",
+                "marketplace_id": self.view.remote_id,
+            }
+        ]
+
+        self.assertEqual(attrs.get("variation_theme"), expected_theme)
+        self.assertEqual(attrs.get("parentage_level"), expected_parentage)
+        self.assertEqual(attrs.get("child_parent_sku_relationship"), expected_rel)


### PR DESCRIPTION
## Summary
- enable variation theme matching for Amazon listings
- include parent/child variation attributes in payloads
- set configurator theme when syncing Amazon products
- add tests for theme matching and payload building

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/products/products.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py`
- `coverage run --source='.' OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories` *(fails: OperationalError connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6877704d392c832e91bb81cb497c23f5

## Summary by Sourcery

Implement Amazon variation theme handling by adding theme matching, configurator update, and payload augmentation to support parent/child variation attributes.

New Features:
- Add variation theme matching algorithm to AmazonProductSyncFactory
- Persist matched amazon_theme to RemoteProductConfigurator during sync
- Build and include variation_theme, parentage_level, and child_parent_sku_relationship in product payloads

Tests:
- Add unit tests for matching Amazon variation themes
- Add unit tests for building variation attributes for child products