### PR TITLE
Update WooCommerce variation add logic

### DIFF
--- a/OneSila/sales_channels/factories/products/variations.py
+++ b/OneSila/sales_channels/factories/products/variations.py
@@ -64,9 +64,7 @@ class RemoteProductVariationAddFactory(RemoteInstanceUpdateFactory):
                     sales_channel=self.sales_channel,
                     local_instance=self.local_instance,
                     parent_local_instance=self.parent_product,
-                    remote_parent_product=self.remote_parent_product,
                     api=self.api,
-                    is_variation_add=True,
                 )
                 factory.run()
                 self.remote_instance = factory.remote_instance

--- a/OneSila/sales_channels/factories/products/variations.py
+++ b/OneSila/sales_channels/factories/products/variations.py
@@ -64,7 +64,9 @@ class RemoteProductVariationAddFactory(RemoteInstanceUpdateFactory):
                     sales_channel=self.sales_channel,
                     local_instance=self.local_instance,
                     parent_local_instance=self.parent_product,
-                    api=self.api
+                    remote_parent_product=self.remote_parent_product,
+                    api=self.api,
+                    is_variation_add=True,
                 )
                 factory.run()
                 self.remote_instance = factory.remote_instance

--- a/OneSila/sales_channels/integrations/woocommerce/factories/products.py
+++ b/OneSila/sales_channels/integrations/woocommerce/factories/products.py
@@ -14,6 +14,8 @@ from sales_channels.integrations.woocommerce.mixins import GetWoocommerceAPIMixi
 from sales_channels.integrations.woocommerce.models import WoocommerceProduct, \
     WoocommerceProductProperty, WoocommerceProductProperty, WoocommercePrice, \
     WoocommerceProductContent, WoocommerceEanCode, WoocommerceCurrency
+from sales_channels.models.products import RemoteProduct
+from sales_channels.models.sales_channels import SalesChannelViewAssign
 from .mixins import WooCommerceUpdateRemoteProductMixin, WoocommerceProductTypeMixin, \
     WooCommercePayloadMixin, SerialiserMixin, GetWoocommerceAPIMixin
 from .properties import WooCommerceProductPropertyCreateFactory, \
@@ -123,10 +125,6 @@ class WooCommerceProductCreateFactory(WooCommerceProductSyncFactory, Woocommerce
         Creates a remote product in WooCommerce.
         """
         if self.is_woocommerce_variant_product:
-            resp = self.api.create_product_variation(
-                self.remote_instance.remote_parent_product.remote_id,
-                **self.payload,
-            )
             if getattr(self, "is_variation_add", False):
                 parent_factory = WooCommerceProductUpdateFactory(
                     sales_channel=self.sales_channel,
@@ -135,6 +133,10 @@ class WooCommerceProductCreateFactory(WooCommerceProductSyncFactory, Woocommerce
                     api=self.api,
                 )
                 parent_factory.run()
+            resp = self.api.create_product_variation(
+                self.remote_instance.remote_parent_product.remote_id,
+                **self.payload,
+            )
         else:
             resp = self.api.create_product(**self.payload)
 
@@ -185,6 +187,52 @@ class WooCommerceProductVariationAddFactory(SerialiserMixin, GetWoocommerceAPIMi
     """
     remote_model_class = WoocommerceProduct
     create_factory_class = WooCommerceProductCreateFactory
+
+    def preflight_check(self):
+        """Extends the base check to ensure the parent product is updated when
+        a new variation is added."""
+        if self.skip_checks:
+            return True
+
+        # Check for SalesChannelViewAssign associated with the remote parent product
+        parent_assign_exists = SalesChannelViewAssign.objects.filter(
+            product=self.parent_product,
+            sales_channel=self.sales_channel,
+        ).exists()
+
+        if not parent_assign_exists:
+            return False
+
+        try:
+            self.remote_parent_product = RemoteProduct.objects.get(
+                local_instance=self.parent_product,
+                sales_channel=self.sales_channel,
+            )
+        except RemoteProduct.DoesNotExist:
+            return False
+
+        try:
+            self.remote_instance = RemoteProduct.objects.get(
+                local_instance=self.local_instance,
+                sales_channel=self.sales_channel,
+                remote_parent_product=self.remote_parent_product,
+            )
+        except RemoteProduct.DoesNotExist:
+            if self.create_if_not_exists:
+                factory = self.create_factory_class(
+                    sales_channel=self.sales_channel,
+                    local_instance=self.local_instance,
+                    parent_local_instance=self.parent_product,
+                    remote_parent_product=self.remote_parent_product,
+                    api=self.api,
+                    is_variation_add=True,
+                )
+                factory.run()
+                self.remote_instance = factory.remote_instance
+            else:
+                raise
+
+        return True
 
     def update_remote(self, *args, **kwargs):
         # Woocommerce doesnt need assinging a variation.


### PR DESCRIPTION
## Summary
- allow WooCommerce product create factory to know when a variation is added after initial creation
- update parent product when adding a variation via WooCommerceProductVariationAddFactory

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/woocommerce/factories/products.py OneSila/sales_channels/factories/products/variations.py`
- `pytest -k thisisnotatest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687947e6ef14832e8112fb74a352de24

## Summary by Sourcery

Add variation-add logic to WooCommerce product factories to trigger updating the parent product when a variation is added

Enhancements:
- Add is_variation_add parameter to WooCommerceProductCreateFactory
- Trigger parent product update via WooCommerceProductUpdateFactory after creating a variation when is_variation_add is true
- Pass is_variation_add flag and remote_parent_product to WooCommerceProductVariationAddFactory