### PR TITLE
Import only primary Shopify currency

### DIFF
--- a/OneSila/sales_channels/integrations/shopify/factories/sales_channels/currencies.py
+++ b/OneSila/sales_channels/integrations/shopify/factories/sales_channels/currencies.py
@@ -3,6 +3,7 @@ import json
 from sales_channels.factories.mixins import PullRemoteInstanceMixin
 from sales_channels.integrations.shopify.factories.mixins import GetShopifyApiMixin
 from sales_channels.integrations.shopify.models import ShopifyCurrency
+from currencies.models import Currency
 
 
 class ShopifyRemoteCurrencyPullFactory(GetShopifyApiMixin, PullRemoteInstanceMixin):
@@ -28,7 +29,6 @@ class ShopifyRemoteCurrencyPullFactory(GetShopifyApiMixin, PullRemoteInstanceMix
         {
           shop {
             currencyCode
-            enabledPresentmentCurrencies
           }
         }
         """
@@ -37,11 +37,28 @@ class ShopifyRemoteCurrencyPullFactory(GetShopifyApiMixin, PullRemoteInstanceMix
         shop_data = data["data"]["shop"]
 
         primary = shop_data["currencyCode"]
-        presentment = shop_data.get("enabledPresentmentCurrencies", [])
 
-        self.remote_instances = []
-        for code in presentment:
-            self.remote_instances.append({
-                'code': code,
-                'primary': (code == primary)
-            })
+        local_currency = Currency.objects.filter(
+            iso_code=primary,
+            multi_tenant_company=self.sales_channel.multi_tenant_company,
+        ).first()
+
+        self.remote_instances = [{
+            'code': primary,
+            'primary': True,
+            'local_currency': local_currency,
+        }]
+
+    def create_remote_instance_mirror(self, remote_data, remote_instance_mirror):
+        super().create_remote_instance_mirror(remote_data, remote_instance_mirror)
+        currency = remote_data.get('local_currency')
+        if currency and not remote_instance_mirror.local_instance:
+            remote_instance_mirror.local_instance = currency
+            remote_instance_mirror.save(update_fields=['local_instance'])
+
+    def update_remote_instance_mirror(self, remote_data, remote_instance_mirror):
+        super().update_remote_instance_mirror(remote_data, remote_instance_mirror)
+        currency = remote_data.get('local_currency')
+        if currency and remote_instance_mirror.local_instance != currency:
+            remote_instance_mirror.local_instance = currency
+            remote_instance_mirror.save(update_fields=['local_instance'])


### PR DESCRIPTION
## Summary
- pull only the store's primary currency from Shopify
- map the currency to a local currency when possible

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/shopify/factories/sales_channels/currencies.py`

------
https://chatgpt.com/codex/tasks/task_e_687aa265ffd8832eae5cebb0cb97e609

## Summary by Sourcery

Adjust the Shopify currency pull factory to fetch and store only the primary currency and map it to a local Currency instance, while removing support for presentment currencies.

New Features:
- Restrict Shopify currency pull to only the store's primary currency instead of all enabled presentment currencies
- Lookup and associate the primary Shopify currency with a matching local Currency record when available
- Enhance factory hooks to assign the local Currency instance on remote mirrors during creation and update