### PR TITLE
Add duplicate property check mutation

### DIFF
--- a/OneSila/properties/schema/mutations/mutation_classes.py
+++ b/OneSila/properties/schema/mutations/mutation_classes.py
@@ -1,6 +1,5 @@
 from strawberry.exceptions import StrawberryException
 
-from core.schema.core.helpers import get_multi_tenant_company
 from core.schema.core.mixins import GetCurrentUserMixin
 from core.schema.core.mutations import CreateMutation, UpdateMutation
 from strawberry_django.optimizer import DjangoOptimizerExtension
@@ -160,3 +159,5 @@ class BulkCreateProductProperties(CreateMutation):
                 translation.save()
 
             return obj
+
+

--- a/OneSila/properties/schema/mutations/mutation_type.py
+++ b/OneSila/properties/schema/mutations/mutation_type.py
@@ -1,9 +1,13 @@
-from core.schema.core.mutations import type
 from core.schema.core.mutations import create, update, delete, type, List
+from strawberry import Info
+import strawberry_django
+from core.schema.core.extensions import default_extensions
+from core.schema.core.helpers import get_multi_tenant_company
 from .fields import complete_create_product_properties_rule, complete_update_product_properties_rule, \
-                     bulk_create_product_properties, create_property, create_property_select_value
+    bulk_create_product_properties, create_property, create_property_select_value
 from ..types.types import PropertyType, PropertyTranslationType, PropertySelectValueType, ProductPropertyType, ProductPropertyTextTranslationType, \
-    PropertySelectValueTranslationType, ProductPropertiesRuleType, ProductPropertiesRuleItemType
+    PropertySelectValueTranslationType, ProductPropertiesRuleType, ProductPropertiesRuleItemType, PropertyDuplicatesType
+from properties.models import Property
 from ..types.input import PropertyInput, PropertyTranslationInput, PropertySelectValueInput, ProductPropertyInput, \
     PropertyPartialInput, PropertyTranslationPartialInput, PropertySelectValuePartialInput, ProductPropertyPartialInput, ProductPropertyTextTranslationInput, \
     PropertySelectValueTranslationInput, PropertySelectValueTranslationPartialInput, ProductPropertyTextTranslationPartialInput, ProductPropertiesRuleInput, \
@@ -62,3 +66,12 @@ class PropertiesMutation:
     update_product_properties_rule_item: ProductPropertiesRuleItemType = update(ProductPropertiesRuleItemPartialInput)
     delete_product_properties_rule_item: ProductPropertiesRuleItemType = delete()
     delete_product_properties_rule_items: List[ProductPropertiesRuleItemType] = delete()
+
+    @strawberry_django.mutation(handle_django_errors=True, extensions=default_extensions)
+    def check_property_for_duplicates(self, name: str, info: Info) -> PropertyDuplicatesType:
+        multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
+        duplicates = Property.objects.check_for_duplicates(name, multi_tenant_company)
+        return PropertyDuplicatesType(
+            duplicate_found=duplicates.exists(),
+            duplicates=list(duplicates),
+        )

--- a/OneSila/properties/schema/types/types.py
+++ b/OneSila/properties/schema/types/types.py
@@ -1,4 +1,5 @@
 from core.schema.core.types.types import relay, type, field, Annotated, lazy
+import strawberry
 from core.schema.core.mixins import (
     GetPropertyQuerysetMultiTenantMixin,
     GetPropertySelectValueQuerysetMultiTenantMixin,
@@ -88,3 +89,9 @@ class ProductPropertiesRuleType(relay.Node, GetQuerysetMultiTenantMixin):
 class ProductPropertiesRuleItemType(relay.Node, GetQuerysetMultiTenantMixin):
     rule: ProductPropertiesRuleType
     property: PropertyType
+
+
+@strawberry.type
+class PropertyDuplicatesType:
+    duplicate_found: bool
+    duplicates: List[PropertyType]

--- a/OneSila/properties/tests/tests_schemas/tests_mutations.py
+++ b/OneSila/properties/tests/tests_schemas/tests_mutations.py
@@ -1,0 +1,51 @@
+from django.test import TransactionTestCase
+from core.tests.tests_schemas.tests_queries import TransactionTestCaseMixin
+from properties.models import Property, PropertyTranslation
+
+
+class CheckPropertyForDuplicatesTestCase(TransactionTestCaseMixin, TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.prop = Property.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.TEXT,
+        )
+        PropertyTranslation.objects.create(
+            property=self.prop,
+            language=self.multi_tenant_company.language,
+            name="Color",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def test_duplicate_found(self):
+        mutation = """
+            mutation($name: String!) {
+              checkPropertyForDuplicates(name: $name) {
+                duplicateFound
+                duplicates { id }
+              }
+            }
+        """
+        resp = self.strawberry_test_client(query=mutation, variables={"name": "Color"})
+
+        self.assertIsNone(resp.errors)
+        data = resp.data["checkPropertyForDuplicates"]
+        self.assertTrue(data["duplicateFound"])
+        self.assertEqual(len(data["duplicates"]), 1)
+
+    def test_no_duplicate_found(self):
+        mutation = """
+            mutation($name: String!) {
+              checkPropertyForDuplicates(name: $name) {
+                duplicateFound
+                duplicates { id }
+              }
+            }
+        """
+        resp = self.strawberry_test_client(query=mutation, variables={"name": "Weight"})
+
+        self.assertIsNone(resp.errors)
+        data = resp.data["checkPropertyForDuplicates"]
+        self.assertFalse(data["duplicateFound"])
+        self.assertEqual(len(data["duplicates"]), 0)


### PR DESCRIPTION
## Summary
- add duplicate-checking helper to `PropertyManager`
- expose new `checkPropertyForDuplicates` GraphQL mutation
- add return type `PropertyDuplicatesType`
- test GraphQL duplicate check

## Testing
- `pre-commit run --files OneSila/properties/managers.py OneSila/properties/schema/mutations/mutation_type.py OneSila/properties/schema/types/types.py OneSila/properties/tests/tests_schemas/tests_mutations.py`
- `./manage.py test properties.tests.tests_schemas.tests_mutations.CheckPropertyForDuplicatesTestCase` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687dfd912d80832e97a28d8d3b995e05

## Summary by Sourcery

Add functionality to check for duplicate property names and expose it via a new GraphQL mutation.

New Features:
- Implement find_duplicates and check_for_duplicates methods to detect similar properties by name.
- Expose a new GraphQL mutation checkPropertyForDuplicates that returns a duplicateFound flag and list of duplicates.
- Define PropertyDuplicatesType GraphQL type for representing duplicate check results.

Tests:
- Add GraphQL tests for the duplicate check mutation covering cases where duplicates are found and not found.