### PR TITLE
Add signals for property creation

### DIFF
--- a/OneSila/properties/helpers.py
+++ b/OneSila/properties/helpers.py
@@ -42,3 +42,23 @@ def get_product_properties_dict(product) -> dict[str, list[str]]:
         properties_dict[str(prop.property.name)] = list(values)  # Convert back to a list for consistency
 
     return properties_dict
+
+
+def generate_unique_internal_name(name, multi_tenant_company, instance_id=None):
+    """Return a unique internal name for a property."""
+    from django.utils.text import slugify
+    from .models import Property
+
+    base_name = slugify(name).replace('-', '_')
+    internal_name = base_name
+    counter = 1
+
+    qs = Property.objects.filter(multi_tenant_company=multi_tenant_company)
+    if instance_id:
+        qs = qs.exclude(id=instance_id)
+
+    while qs.filter(internal_name=internal_name).exists():
+        internal_name = f"{base_name}_{counter}"
+        counter += 1
+
+    return internal_name

--- a/OneSila/properties/migrations/0013_property_internal_name_unique.py
+++ b/OneSila/properties/migrations/0013_property_internal_name_unique.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('properties', '0012_alter_property_options_and_more'),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name='property',
+            constraint=models.UniqueConstraint(
+                fields=['multi_tenant_company', 'internal_name'],
+                name='uniq_internal_name_per_company',
+            ),
+        ),
+    ]

--- a/OneSila/properties/schema/mutations/fields.py
+++ b/OneSila/properties/schema/mutations/fields.py
@@ -5,6 +5,7 @@ from properties.schema.mutations.mutation_classes import CompleteCreateProductPr
 from properties.schema.types.input import PropertyInput, PropertySelectValueInput, ProductPropertiesRuleInput, \
     ProductPropertiesRulePartialInput, BulkProductPropertyInput
 from properties.models import PropertyTranslation, PropertySelectValueTranslation
+from properties.signals import property_created, property_select_value_created
 from translations.schema.mutations import TranslatableCreateMutation
 
 
@@ -14,7 +15,8 @@ def create_property():
         extensions=extensions,
         translation_model=PropertyTranslation,
         translation_field='name',
-        translation_model_to_model_field='property')
+        translation_model_to_model_field='property',
+        signal=property_created)
 
 
 def create_property_select_value():
@@ -23,7 +25,8 @@ def create_property_select_value():
         extensions=extensions,
         translation_model=PropertySelectValueTranslation,
         translation_field='value',
-        translation_model_to_model_field='propertyselectvalue')
+        translation_model_to_model_field='propertyselectvalue',
+        signal=property_select_value_created)
 
 
 def complete_create_product_properties_rule():

--- a/OneSila/properties/signals.py
+++ b/OneSila/properties/signals.py
@@ -4,3 +4,6 @@ product_properties_rule_created = ModelSignal(use_caching=True)
 product_properties_rule_updated = ModelSignal(use_caching=True)
 product_properties_rule_configurator_updated = ModelSignal(use_caching=True)
 product_properties_rule_rename = ModelSignal(use_caching=True)
+
+property_created = ModelSignal(use_caching=True)
+property_select_value_created = ModelSignal(use_caching=True)


### PR DESCRIPTION
## Summary
- add `property_created` and `property_select_value_created` signals
- emit optional `signal` in `TranslatableCreateMutation`
- hook create-property mutations to the new signals
- handle unique property `internal_name`
- update sales channel receivers to use new signals
- add migration for unique `internal_name`

## Testing
- `pre-commit run --files OneSila/properties/helpers.py OneSila/properties/receivers.py OneSila/properties/schema/mutations/fields.py OneSila/properties/signals.py OneSila/sales_channels/receivers.py OneSila/translations/schema/mutations.py OneSila/properties/migrations/0013_property_internal_name_unique.py`
- `coverage run --source='.' OneSila/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687e0b284278832eb31d9dc02809d6ef

## Summary by Sourcery

Introduce explicit creation signals for properties and select values, propagate them through GraphQL translation mutations and sales channel receivers for remote provisioning, and enforce unique internal_name values with automated slug generation and a new database constraint.

New Features:
- Add property_created and property_select_value_created model signals
- Emit an optional signal from TranslatableCreateMutation and hook it into property creation mutations
- Hook sales channel receivers to property_created and property_select_value_created signals to trigger remote create actions

Enhancements:
- Generate unique internal_name values for properties using a slug-and-counter helper and add a database constraint enforcing uniqueness per company
- Simplify sales channel translation receivers to always send update signals instead of branching on translation count