### PR TITLE
Add unique constraint for Property internal names

### DIFF
--- a/OneSila/properties/migrations/0013_internal_name_unique.py
+++ b/OneSila/properties/migrations/0013_internal_name_unique.py
@@ -1,0 +1,49 @@
+from django.db import migrations, models
+
+
+def deduplicate_internal_names(apps, schema_editor):
+    Property = apps.get_model('properties', 'Property')
+    MultiTenantCompany = apps.get_model('core', 'MultiTenantCompany')
+
+    for company in MultiTenantCompany.objects.all():
+        seen = {}
+        props = (
+            Property.objects
+            .filter(multi_tenant_company=company)
+            .exclude(internal_name__isnull=True)
+            .order_by('id')
+            .values('id', 'internal_name')
+        )
+        for prop in props:
+            name = prop['internal_name']
+            if not name:
+                continue
+            if name not in seen:
+                seen[name] = 1
+                continue
+            idx = seen[name]
+            new_name = f"{name}_{idx}"
+            while new_name in seen:
+                idx += 1
+                new_name = f"{name}_{idx}"
+            seen[name] = idx + 1
+            seen[new_name] = 1
+            Property.objects.filter(pk=prop['id']).update(internal_name=new_name)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('properties', '0012_alter_property_options_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(deduplicate_internal_names, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name='property',
+            constraint=models.UniqueConstraint(
+                fields=['multi_tenant_company', 'internal_name'],
+                name='unique_internal_name_per_company',
+            ),
+        ),
+    ]

--- a/OneSila/properties/models.py
+++ b/OneSila/properties/models.py
@@ -96,6 +96,11 @@ class Property(TranslatedModelMixin, models.Model):
                 name='unique_is_product_type',
                 violation_error_message=_("You can only have one product type per multi-tenant company.")
             ),
+            models.UniqueConstraint(
+                fields=['multi_tenant_company', 'internal_name'],
+                name='unique_internal_name_per_company',
+                violation_error_message=_("This internal name already exists for this company.")
+            ),
         ]
 
 


### PR DESCRIPTION
## Summary
- ensure Property.internal_name is unique per company
- migrate existing duplicate internal names to unique values

## Testing
- `pre-commit run --files OneSila/properties/models.py OneSila/properties/migrations/0013_internal_name_unique.py`
- `python OneSila/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687e0b9e9520832e8ebc1e00c8b48cfb