### PR TITLE
Add duplicate check for property select values

### DIFF
--- a/OneSila/properties/schema/mutations/mutation_type.py
+++ b/OneSila/properties/schema/mutations/mutation_type.py
@@ -6,8 +6,8 @@ from core.schema.core.helpers import get_multi_tenant_company
 from .fields import complete_create_product_properties_rule, complete_update_product_properties_rule, \
     bulk_create_product_properties, create_property, create_property_select_value
 from ..types.types import PropertyType, PropertyTranslationType, PropertySelectValueType, ProductPropertyType, ProductPropertyTextTranslationType, \
-    PropertySelectValueTranslationType, ProductPropertiesRuleType, ProductPropertiesRuleItemType, PropertyDuplicatesType
-from properties.models import Property
+    PropertySelectValueTranslationType, ProductPropertiesRuleType, ProductPropertiesRuleItemType, PropertyDuplicatesType, PropertySelectValueDuplicatesType
+from properties.models import Property, PropertySelectValue
 from ..types.input import PropertyInput, PropertyTranslationInput, PropertySelectValueInput, ProductPropertyInput, \
     PropertyPartialInput, PropertyTranslationPartialInput, PropertySelectValuePartialInput, ProductPropertyPartialInput, ProductPropertyTextTranslationInput, \
     PropertySelectValueTranslationInput, PropertySelectValueTranslationPartialInput, ProductPropertyTextTranslationPartialInput, ProductPropertiesRuleInput, \
@@ -72,6 +72,25 @@ class PropertiesMutation:
         multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
         duplicates = Property.objects.check_for_duplicates(name, multi_tenant_company)
         return PropertyDuplicatesType(
+            duplicate_found=duplicates.exists(),
+            duplicates=list(duplicates),
+        )
+
+    @strawberry_django.mutation(handle_django_errors=False, extensions=default_extensions)
+    def check_property_select_value_for_duplicates(
+        self,
+        value: str,
+        property: PropertyPartialInput,
+        info: Info,
+    ) -> PropertySelectValueDuplicatesType:
+        multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
+        property_instance = property.pk
+        duplicates = PropertySelectValue.objects.check_for_duplicates(
+            value,
+            property_instance,
+            multi_tenant_company,
+        )
+        return PropertySelectValueDuplicatesType(
             duplicate_found=duplicates.exists(),
             duplicates=list(duplicates),
         )

--- a/OneSila/properties/schema/types/types.py
+++ b/OneSila/properties/schema/types/types.py
@@ -95,3 +95,9 @@ class ProductPropertiesRuleItemType(relay.Node, GetQuerysetMultiTenantMixin):
 class PropertyDuplicatesType:
     duplicate_found: bool
     duplicates: List[PropertyType]
+
+
+@strawberry.type
+class PropertySelectValueDuplicatesType:
+    duplicate_found: bool
+    duplicates: List[PropertySelectValueType]

--- a/OneSila/properties/tests/tests_schemas/tests_mutations.py
+++ b/OneSila/properties/tests/tests_schemas/tests_mutations.py
@@ -1,6 +1,6 @@
 from django.test import TransactionTestCase
 from core.tests.tests_schemas.tests_queries import TransactionTestCaseMixin
-from properties.models import Property, PropertyTranslation
+from properties.models import Property, PropertyTranslation, PropertySelectValue, PropertySelectValueTranslation
 
 
 class CheckPropertyForDuplicatesTestCase(TransactionTestCaseMixin, TransactionTestCase):
@@ -47,5 +47,69 @@ class CheckPropertyForDuplicatesTestCase(TransactionTestCaseMixin, TransactionTe
 
         self.assertIsNone(resp.errors)
         data = resp.data["checkPropertyForDuplicates"]
+        self.assertFalse(data["duplicateFound"])
+        self.assertEqual(len(data["duplicates"]), 0)
+
+
+class CheckPropertySelectValueForDuplicatesTestCase(TransactionTestCaseMixin, TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.prop = Property.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.SELECT,
+        )
+        PropertyTranslation.objects.create(
+            property=self.prop,
+            language=self.multi_tenant_company.language,
+            name="Color",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.select_value = PropertySelectValue.objects.create(
+            property=self.prop,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertySelectValueTranslation.objects.create(
+            propertyselectvalue=self.select_value,
+            language=self.multi_tenant_company.language,
+            value="Red",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def test_duplicate_found(self):
+        mutation = """
+            mutation($property: GlobalID!, $value: String!) {
+              checkPropertySelectValueForDuplicates(property: $property, value: $value) {
+                duplicateFound
+                duplicates { id }
+              }
+            }
+        """
+        resp = self.strawberry_test_client(
+            query=mutation,
+            variables={"property": self.to_global_id(self.prop), "value": "Red"},
+        )
+
+        self.assertIsNone(resp.errors)
+        data = resp.data["checkPropertySelectValueForDuplicates"]
+        self.assertTrue(data["duplicateFound"])
+        self.assertEqual(len(data["duplicates"]), 1)
+
+    def test_no_duplicate_found(self):
+        mutation = """
+            mutation($property: GlobalID!, $value: String!) {
+              checkPropertySelectValueForDuplicates(property: $property, value: $value) {
+                duplicateFound
+                duplicates { id }
+              }
+            }
+        """
+        resp = self.strawberry_test_client(
+            query=mutation,
+            variables={"property": self.to_global_id(self.prop), "value": "Blue"},
+        )
+
+        self.assertIsNone(resp.errors)
+        data = resp.data["checkPropertySelectValueForDuplicates"]
         self.assertFalse(data["duplicateFound"])
         self.assertEqual(len(data["duplicates"]), 0)


### PR DESCRIPTION
## Summary
- add `find_duplicates` and `check_for_duplicates` for `PropertySelectValue`
- expose `checkPropertySelectValueForDuplicates` mutation
- define `PropertySelectValueDuplicatesType`
- test new duplicate logic for select values

## Testing
- `pip install -r requirements.txt`
- `./manage.py test properties.tests.tests_schemas.tests_mutations.CheckPropertySelectValueForDuplicatesTestCase --verbosity 2` *(fails: OperationalError: connection to server at "localhost" (::1) port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e13d08eec832ea3f2bca57cf356fe

## Summary by Sourcery

Implement duplicate checking for property select values by adding backend detection methods, exposing a GraphQL mutation and response type, and covering the feature with tests

New Features:
- Add find_duplicates and check_for_duplicates methods to PropertySelectValue manager for detecting similar select values
- Introduce checkPropertySelectValueForDuplicates GraphQL mutation and PropertySelectValueDuplicatesType for duplicate-check responses

Tests:
- Add tests for duplicate detection logic on PropertySelectValue via the new GraphQL mutation