### PR TITLE
Add product duplication support

### DIFF
--- a/OneSila/products/tests/tests_models.py
+++ b/OneSila/products/tests/tests_models.py
@@ -2,9 +2,17 @@ from django.db import IntegrityError
 
 from contacts.models import Supplier
 from core.tests import TestCase
-from products.models import ConfigurableProduct, \
-    SimpleProduct, BundleProduct, BundleVariation, \
-    AliasProduct
+from products.models import (
+    ConfigurableProduct,
+    SimpleProduct,
+    BundleProduct,
+    BundleVariation,
+    AliasProduct,
+    ProductTranslation,
+)
+from media.models import Media, MediaProductThrough
+from properties.models import Property, PropertyTranslation, ProductProperty, ProductPropertyTextTranslation
+from sales_prices.models import SalesPrice
 
 
 class AlasProductTestCase(TestCase):
@@ -69,3 +77,61 @@ class ProductModelTest(TestCase):
             quantity=1)
         self.assertTrue(bundle_product.id in bundle_product.get_parent_products(ids_only=True))
         self.assertTrue(bundle_product_two.id in bundle_product.get_parent_products(ids_only=True))
+
+
+class DuplicateProductTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.product = SimpleProduct.objects.create(multi_tenant_company=self.multi_tenant_company)
+        ProductTranslation.objects.create(
+            product=self.product,
+            language=self.multi_tenant_company.language,
+            name="Original",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        media = Media.objects.create(type=Media.IMAGE, multi_tenant_company=self.multi_tenant_company)
+        MediaProductThrough.objects.create(
+            product=self.product,
+            media=media,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        prop = Property.objects.create(type=Property.TYPES.TEXT, multi_tenant_company=self.multi_tenant_company)
+        PropertyTranslation.objects.create(
+            property=prop,
+            language=self.multi_tenant_company.language,
+            name="Prop",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        pp = ProductProperty.objects.create(
+            product=self.product,
+            property=prop,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        ProductPropertyTextTranslation.objects.create(
+            product_property=pp,
+            language=self.multi_tenant_company.language,
+            value_text="Value",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        SalesPrice.objects.create(
+            product=self.product,
+            currency=self.currency,
+            rrp=10,
+            price=8,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def test_duplicate_product_manager(self):
+        duplicate = SimpleProduct.objects.duplicate_product(self.product)
+        self.assertNotEqual(duplicate.id, self.product.id)
+        self.assertEqual(duplicate.translations.count(), self.product.translations.count())
+        self.assertEqual(duplicate.mediaproductthrough_set.count(), self.product.mediaproductthrough_set.count())
+        self.assertEqual(duplicate.productproperty_set.count(), self.product.productproperty_set.count())
+        self.assertEqual(duplicate.salesprice_set.count(), self.product.salesprice_set.count())
+
+    def test_duplicate_product_existing_sku_error(self):
+        with self.assertRaises(Exception):
+            SimpleProduct.objects.duplicate_product(self.product, sku=self.product.sku)

--- a/OneSila/products/tests/tests_schemas/tests_mutations.py
+++ b/OneSila/products/tests/tests_schemas/tests_mutations.py
@@ -1,0 +1,46 @@
+from django.test import TransactionTestCase
+from model_bakery import baker
+
+from core.tests.tests_schemas.tests_queries import TransactionTestCaseMixin
+from products.models import SimpleProduct, ProductTranslation
+
+
+DUPLICATE_PRODUCT_MUTATION = """
+    mutation($product: GlobalID!, $sku: String) {
+      duplicateProduct(product: $product, sku: $sku) {
+        id
+        sku
+      }
+    }
+"""
+
+
+class DuplicateProductMutationTestCase(TransactionTestCaseMixin, TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.product = SimpleProduct.objects.create(multi_tenant_company=self.multi_tenant_company)
+        ProductTranslation.objects.create(
+            product=self.product,
+            language=self.multi_tenant_company.language,
+            name="Original",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def test_duplicate_product_mutation(self):
+        resp = self.strawberry_test_client(
+            query=DUPLICATE_PRODUCT_MUTATION,
+            variables={"product": self.to_global_id(self.product), "sku": None},
+        )
+
+        self.assertIsNone(resp.errors)
+        data = resp.data["duplicateProduct"]
+        self.assertIsNotNone(data["id"])
+
+    def test_duplicate_product_mutation_existing_sku(self):
+        resp = self.strawberry_test_client(
+            query=DUPLICATE_PRODUCT_MUTATION,
+            variables={"product": self.to_global_id(self.product), "sku": self.product.sku},
+            asserts_errors=False,
+        )
+
+        self.assertTrue(resp.errors is not None)


### PR DESCRIPTION
## Summary
- add `duplicate_product` method to `ProductQuerySet` and manager
- implement `duplicateProduct` GraphQL mutation
- cover duplication with tests

## Testing
- `python OneSila/manage.py test OneSila/products/tests --verbosity 2` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687e90a0f174832eb859805ca43cc45b