### PR TITLE
Add task-based product variations generator

### DIFF
--- a/OneSila/products/schema/mutations/mutation_classes.py
+++ b/OneSila/products/schema/mutations/mutation_classes.py
@@ -1,5 +1,10 @@
 from typing import Any
+
 from strawberry import Info
+
+from strawberry_django.optimizer import DjangoOptimizerExtension
+
+from core.schema.core.mutations import CreateMutation
 from products.models import AliasProduct
 from translations.schema.mutations import TranslatableCreateMutation
 
@@ -27,3 +32,6 @@ class AliasProductCreateMutation(TranslatableCreateMutation):
 
         instance.refresh_from_db()
         return instance
+
+
+

--- a/OneSila/products/schema/mutations/mutation_type.py
+++ b/OneSila/products/schema/mutations/mutation_type.py
@@ -1,3 +1,5 @@
+from typing import Optional, List as TypingList
+
 from .fields import create_product
 from strawberry import Info
 import strawberry_django
@@ -13,6 +15,7 @@ from ..types.types import (
     ConfigurableVariationType,
     BundleVariationType,
     ProductTranslationBulletPointType,
+    ProductVariationsTaskResponse,
 )
 from ..types.input import (
     ProductInput,
@@ -31,6 +34,8 @@ from ..types.input import (
     BundleVariationPartialInput,
     ProductTranslationBulletPointInput,
     ProductTranslationBulletPointPartialInput,
+    ProductPropertiesRulePartialInput,
+    PropertySelectValuePartialInput,
 )
 from core.schema.core.mutations import create, update, delete, type, List
 
@@ -86,6 +91,47 @@ class ProductsMutation:
     delete_product_translation_bullet_points: List[ProductTranslationBulletPointType] = delete(is_bulk=True)
 
     @strawberry_django.mutation(handle_django_errors=False, extensions=default_extensions)
+    def generate_product_variations(
+        self,
+        info: Info,
+        rule: ProductPropertiesRulePartialInput,
+        config_product: ProductPartialInput,
+        select_values: TypingList[PropertySelectValuePartialInput],
+        language_code: str | None = None,
+    ) -> ProductVariationsTaskResponse:
+        from products.tasks import products__generate_variations_task
+        from products.models import Product
+        from properties.models import ProductPropertiesRule, PropertySelectValue
+
+        multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
+
+        rule_obj = ProductPropertiesRule.objects.get(
+            id=rule.id.node_id,
+            multi_tenant_company=multi_tenant_company,
+        )
+        config_product_obj = Product.objects.get(
+            id=config_product.id.node_id,
+            multi_tenant_company=multi_tenant_company,
+        )
+
+        value_ids = [sv.id.node_id for sv in select_values]
+        select_value_ids = list(
+            PropertySelectValue.objects.filter(
+                id__in=value_ids,
+                multi_tenant_company=multi_tenant_company,
+            ).values_list("id", flat=True)
+        )
+
+        products__generate_variations_task(
+            rule_id=rule_obj.id,
+            config_product_id=config_product_obj.id,
+            select_value_ids=select_value_ids,
+            language=language_code,
+        )
+
+        return ProductVariationsTaskResponse(success=True)
+
+    @strawberry_django.mutation(handle_django_errors=False, extensions=default_extensions)
     def duplicate_product(self, info: Info, product: ProductPartialInput, sku: str | None = None) -> ProductType:
         multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
         instance =  Product.objects.get(id=product.id.node_id)
@@ -93,3 +139,4 @@ class ProductsMutation:
             raise PermissionError("Invalid company")
         duplicated = Product.objects.duplicate_product(instance, sku=sku)
         return duplicated
+

--- a/OneSila/products/schema/types/input.py
+++ b/OneSila/products/schema/types/input.py
@@ -1,3 +1,7 @@
+from typing import List
+
+import strawberry
+
 from core.schema.core.types.input import NodeInput, input, partial
 from products.models import (
     Product,
@@ -8,6 +12,10 @@ from products.models import (
     ConfigurableVariation,
     BundleVariation,
     ProductTranslationBulletPoint,
+)
+from properties.schema.types.input import (
+    ProductPropertiesRulePartialInput,
+    PropertySelectValuePartialInput,
 )
 
 
@@ -91,3 +99,5 @@ class ProductTranslationBulletPointInput:
 @partial(ProductTranslationBulletPoint, fields="__all__")
 class ProductTranslationBulletPointPartialInput(NodeInput):
     pass
+
+

--- a/OneSila/products/schema/types/types.py
+++ b/OneSila/products/schema/types/types.py
@@ -194,3 +194,8 @@ class AliasProductType(relay.Node, GetQuerysetMultiTenantMixin):
 )
 class ProductTranslationBulletPointType(relay.Node, GetQuerysetMultiTenantMixin):
     product_translation: Optional[ProductTranslationType]
+
+
+@strawberry_type
+class ProductVariationsTaskResponse:
+    success: bool

--- a/OneSila/products/tasks.py
+++ b/OneSila/products/tasks.py
@@ -1,0 +1,30 @@
+from huey.contrib.djhuey import db_task
+from core.decorators import run_task_after_commit
+
+
+@run_task_after_commit
+@db_task()
+def products__generate_variations_task(
+    *,
+    rule_id: int | str,
+    config_product_id: int | str,
+    select_value_ids: list[int | str],
+    language: str | None = None,
+) -> None:
+    """Generate product variations asynchronously."""
+    from products.factories.generate_variations import GenerateProductVariations
+    from properties.models import ProductPropertiesRule, PropertySelectValue
+    from products.models import Product
+
+    rule = ProductPropertiesRule.objects.get(id=rule_id)
+    config_product = Product.objects.get(id=config_product_id)
+    select_values = PropertySelectValue.objects.filter(id__in=select_value_ids)
+
+    factory = GenerateProductVariations(
+        rule=rule,
+        config_product=config_product,
+        select_values=select_values,
+        language=language,
+    )
+    factory.run()
+


### PR DESCRIPTION
## Summary
- add Huey task for generating product variations
- implement custom `generate_product_variations` mutation
- return `ProductVariationsTaskResponse` with success status

## Testing
- `coverage run --source='.' OneSila/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687eb987bbf0832ea85fa23d5ebb238a

## Summary by Sourcery

Introduce a task-based product variations generator by adding a new GraphQL mutation and enqueuing a Huey background task for asynchronous variation generation.

New Features:
- Add generate_product_variations GraphQL mutation with rule, config product, and select values inputs
- Define ProductVariationsTaskResponse type to return task success status
- Implement products__generate_variations_task as a Huey db_task to run variation generation asynchronously via the GenerateProductVariations factory