### PR TITLE
Map remote currencies to local instances

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/sales_channels/currencies.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sales_channels/currencies.py
@@ -1,4 +1,4 @@
-from sales_channels.factories.mixins import PullRemoteInstanceMixin
+from sales_channels.factories.mixins import PullRemoteInstanceMixin, LocalCurrencyMappingMixin
 from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin, PullAmazonMixin
 from sales_channels.integrations.amazon.models import (
     AmazonCurrency,
@@ -6,7 +6,7 @@ from sales_channels.integrations.amazon.models import (
 )
 
 
-class AmazonRemoteCurrencyPullFactory(GetAmazonAPIMixin, PullAmazonMixin, PullRemoteInstanceMixin):
+class AmazonRemoteCurrencyPullFactory(GetAmazonAPIMixin, PullAmazonMixin, LocalCurrencyMappingMixin, PullRemoteInstanceMixin):
     """Pull default currencies for each Amazon marketplace."""
 
     remote_model_class = AmazonCurrency
@@ -31,6 +31,7 @@ class AmazonRemoteCurrencyPullFactory(GetAmazonAPIMixin, PullAmazonMixin, PullRe
             for mp in marketplaces
             if mp.participation.is_participating and self.is_real_amazon_marketplace(mp.marketplace)
         ]
+        self.add_local_currency()
 
     def update_get_or_create_lookup(self, lookup, remote_data):
         view = AmazonSalesChannelView.objects.filter(

--- a/OneSila/sales_channels/integrations/shopify/factories/sales_channels/currencies.py
+++ b/OneSila/sales_channels/integrations/shopify/factories/sales_channels/currencies.py
@@ -1,12 +1,11 @@
 import json
 
-from sales_channels.factories.mixins import PullRemoteInstanceMixin
+from sales_channels.factories.mixins import PullRemoteInstanceMixin, LocalCurrencyMappingMixin
 from sales_channels.integrations.shopify.factories.mixins import GetShopifyApiMixin
 from sales_channels.integrations.shopify.models import ShopifyCurrency
-from currencies.models import Currency
 
 
-class ShopifyRemoteCurrencyPullFactory(GetShopifyApiMixin, PullRemoteInstanceMixin):
+class ShopifyRemoteCurrencyPullFactory(GetShopifyApiMixin, LocalCurrencyMappingMixin, PullRemoteInstanceMixin):
     """
     Pulls the primary and presentment currencies configured on a Shopify store.
     """
@@ -38,16 +37,11 @@ class ShopifyRemoteCurrencyPullFactory(GetShopifyApiMixin, PullRemoteInstanceMix
 
         primary = shop_data["currencyCode"]
 
-        local_currency = Currency.objects.filter(
-            iso_code=primary,
-            multi_tenant_company=self.sales_channel.multi_tenant_company,
-        ).first()
-
         self.remote_instances = [{
             'code': primary,
             'primary': True,
-            'local_currency': local_currency,
         }]
+        self.add_local_currency()
 
     def create_remote_instance_mirror(self, remote_data, remote_instance_mirror):
         super().create_remote_instance_mirror(remote_data, remote_instance_mirror)

--- a/OneSila/sales_channels/integrations/woocommerce/factories/pulling.py
+++ b/OneSila/sales_channels/integrations/woocommerce/factories/pulling.py
@@ -1,4 +1,4 @@
-from sales_channels.factories.mixins import PullRemoteInstanceMixin
+from sales_channels.factories.mixins import PullRemoteInstanceMixin, LocalCurrencyMappingMixin
 from sales_channels.integrations.woocommerce.mixins import GetWoocommerceAPIMixin
 from sales_channels.integrations.woocommerce.models import WoocommerceCurrency, \
     WoocommerceRemoteLanguage
@@ -9,7 +9,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class WoocommerceRemoteCurrencyPullFactory(GetWoocommerceAPIMixin, PullRemoteInstanceMixin):
+class WoocommerceRemoteCurrencyPullFactory(GetWoocommerceAPIMixin, LocalCurrencyMappingMixin, PullRemoteInstanceMixin):
     """
     Pulls the primary and presentment currencies configured on a Woocommerce store.
     """
@@ -28,6 +28,7 @@ class WoocommerceRemoteCurrencyPullFactory(GetWoocommerceAPIMixin, PullRemoteIns
     def fetch_remote_instances(self):
         currency = self.api.get_store_currency()
         self.remote_instances = [{'remote_code': currency, }]
+        self.add_local_currency()
 
 
 class WoocommerceLanguagePullFactory(GetWoocommerceAPIMixin, PullRemoteInstanceMixin):


### PR DESCRIPTION
## Summary
- add `LocalCurrencyMappingMixin` to automatically match remote currency codes with local `Currency` records
- use the new mixin in Shopify, Amazon and WooCommerce currency pull factories

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -k "RemoteCurrencyPullFactory" -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_687fabb4eca4832e86456b95ee8cfed9