### PR TITLE
Add failing property internal_name test

### DIFF
--- a/OneSila/properties/tests/tests_models.py
+++ b/OneSila/properties/tests/tests_models.py
@@ -1,0 +1,29 @@
+from core.tests import TestCase
+from properties.models import Property
+
+
+class PropertyManagerGetOrCreateTestCase(TestCase):
+    def test_get_or_create_auto_increment_internal_name(self):
+        """Ensure a unique internal_name is generated for each call."""
+        # Existing property with internal_name "color"
+        Property.objects.create(
+            internal_name="color",
+            type=Property.TYPES.SELECT,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        prop1, created1 = Property.objects.get_or_create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.TEXT,
+            internal_name="color",
+        )
+        self.assertTrue(created1)
+        self.assertEqual(prop1.internal_name, "color_1")
+
+        prop2, created2 = Property.objects.get_or_create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.TEXT,
+            internal_name="color",
+        )
+        self.assertTrue(created2)
+        self.assertEqual(prop2.internal_name, "color_2")


### PR DESCRIPTION
## Summary
- add a unit test for `PropertyManager.get_or_create`

## Testing
- `python OneSila/manage.py test properties.tests.tests_models.PropertyManagerGetOrCreateTestCase --verbosity 2` *(fails: OperationalError, could not connect to PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_6880175a7f18832e8dedfa8154a47b35

## Summary by Sourcery

Tests:
- Add PropertyManagerGetOrCreateTestCase to test auto-incrementing internal_name when a name conflict occurs