### PR TITLE
Add translation filter options

### DIFF
--- a/OneSila/properties/schema/types/filters.py
+++ b/OneSila/properties/schema/types/filters.py
@@ -1,14 +1,19 @@
 from typing import Optional
 
 from core.schema.core.types.types import auto
-from core.schema.core.types.filters import filter, SearchFilterMixin, ExcluideDemoDataFilterMixin
+from core.schema.core.types.filters import (
+    filter,
+    SearchFilterMixin,
+    ExcluideDemoDataFilterMixin,
+)
 from media.schema.types.filters import ImageFilter
 from strawberry_django import filter_field as custom_filter
 from properties.models import Property, ProductProperty, \
     ProductProperty, PropertySelectValue, PropertyTranslation, ProductPropertyTextTranslation, PropertySelectValueTranslation, ProductPropertiesRule, \
     ProductPropertiesRuleItem
 from products.schema.types.filters import ProductFilter
-from django.db.models import Q
+from django.db.models import Q, F
+from core.managers import QuerySet
 from strawberry import UNSET
 
 
@@ -19,6 +24,58 @@ class PropertyFilter(SearchFilterMixin, ExcluideDemoDataFilterMixin):
     is_product_type: auto
     type: auto
     internal_name: auto
+    missing_main_translation: Optional[bool]
+    missing_translations: Optional[bool]
+
+    @custom_filter
+    def missing_main_translation(
+        self,
+        queryset: QuerySet,
+        value: bool,
+        prefix: str,
+    ) -> tuple[QuerySet, Q]:
+
+        if value not in (None, UNSET):
+            condition = Q(
+                propertytranslation__language=F("multi_tenant_company__language")
+            )
+            if value:
+                queryset = queryset.exclude(condition)
+            else:
+                queryset = queryset.filter(condition)
+
+            queryset = queryset.distinct()
+
+        return queryset, Q()
+
+    @custom_filter
+    def missing_translations(
+        self,
+        queryset: QuerySet,
+        value: bool,
+        prefix: str,
+    ) -> tuple[QuerySet, Q]:
+
+        if value not in (None, UNSET):
+            ids: list[int] = []
+
+            properties = queryset.select_related("multi_tenant_company").prefetch_related(
+                "propertytranslation_set"
+            )
+
+            for prop in properties:
+                required_languages = set(prop.multi_tenant_company.languages or [])
+                translation_languages = {
+                    pt.language for pt in prop.propertytranslation_set.all()
+                }
+                is_missing = not required_languages.issubset(translation_languages)
+
+                if (value and is_missing) or (not value and not is_missing):
+                    ids.append(prop.id)
+
+            queryset = queryset.filter(id__in=ids)
+
+        return queryset, Q()
 
 
 @filter(PropertySelectValue)
@@ -26,11 +83,65 @@ class PropertySelectValueFilter(SearchFilterMixin, ExcluideDemoDataFilterMixin):
     id: auto
     property: Optional[PropertyFilter]
     image: Optional[ImageFilter]
+    missing_main_translation: Optional[bool]
+    missing_translations: Optional[bool]
 
     @custom_filter
     def is_product_type(self, queryset, value: bool, prefix: str):
         if value not in (None, UNSET):
             queryset = queryset.filter(property__is_product_type=value)
+
+        return queryset, Q()
+
+    @custom_filter
+    def missing_main_translation(
+        self,
+        queryset: QuerySet,
+        value: bool,
+        prefix: str,
+    ) -> tuple[QuerySet, Q]:
+
+        if value not in (None, UNSET):
+            condition = Q(
+                propertyselectvaluetranslation__language=F(
+                    "multi_tenant_company__language"
+                )
+            )
+            if value:
+                queryset = queryset.exclude(condition)
+            else:
+                queryset = queryset.filter(condition)
+
+            queryset = queryset.distinct()
+
+        return queryset, Q()
+
+    @custom_filter
+    def missing_translations(
+        self,
+        queryset: QuerySet,
+        value: bool,
+        prefix: str,
+    ) -> tuple[QuerySet, Q]:
+
+        if value not in (None, UNSET):
+            ids: list[int] = []
+
+            values = queryset.select_related("multi_tenant_company").prefetch_related(
+                "propertyselectvaluetranslation_set"
+            )
+
+            for val in values:
+                required_languages = set(val.multi_tenant_company.languages or [])
+                translation_languages = {
+                    pt.language for pt in val.propertyselectvaluetranslation_set.all()
+                }
+                is_missing = not required_languages.issubset(translation_languages)
+
+                if (value and is_missing) or (not value and not is_missing):
+                    ids.append(val.id)
+
+            queryset = queryset.filter(id__in=ids)
 
         return queryset, Q()
 

--- a/OneSila/properties/tests/tests_filters.py
+++ b/OneSila/properties/tests/tests_filters.py
@@ -1,0 +1,183 @@
+from core.tests import TestCase
+from properties.models import (
+    Property,
+    PropertyTranslation,
+    PropertySelectValue,
+    PropertySelectValueTranslation,
+)
+from properties.schema.types.filters import PropertyFilter, PropertySelectValueFilter
+
+
+class PropertyFilterTranslationTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.multi_tenant_company.language = "en"
+        self.multi_tenant_company.languages = ["en", "fr"]
+        self.multi_tenant_company.save()
+
+        self.p1 = Property.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.SELECT,
+        )
+        PropertyTranslation.objects.create(
+            property=self.p1,
+            language="en",
+            name="Color",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        self.p2 = Property.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.SELECT,
+        )
+        PropertyTranslation.objects.create(
+            property=self.p2,
+            language="en",
+            name="Size",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertyTranslation.objects.create(
+            property=self.p2,
+            language="fr",
+            name="Taille",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        self.p3 = Property.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.SELECT,
+        )
+        PropertyTranslation.objects.create(
+            property=self.p3,
+            language="fr",
+            name="Poids",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def test_missing_main_translation_true(self):
+        qs, _ = PropertyFilter().missing_main_translation(
+            Property.objects.filter(multi_tenant_company=self.multi_tenant_company),
+            True,
+            "",
+        )
+        self.assertSetEqual(set(qs), {self.p3})
+
+    def test_missing_main_translation_false(self):
+        qs, _ = PropertyFilter().missing_main_translation(
+            Property.objects.filter(multi_tenant_company=self.multi_tenant_company),
+            False,
+            "",
+        )
+        self.assertSetEqual(set(qs), {self.p1, self.p2})
+
+    def test_missing_translations_true(self):
+        qs, _ = PropertyFilter().missing_translations(
+            Property.objects.filter(multi_tenant_company=self.multi_tenant_company),
+            True,
+            "",
+        )
+        self.assertSetEqual(set(qs), {self.p1, self.p3})
+
+    def test_missing_translations_false(self):
+        qs, _ = PropertyFilter().missing_translations(
+            Property.objects.filter(multi_tenant_company=self.multi_tenant_company),
+            False,
+            "",
+        )
+        self.assertSetEqual(set(qs), {self.p2})
+
+
+class PropertySelectValueFilterTranslationTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.multi_tenant_company.language = "en"
+        self.multi_tenant_company.languages = ["en", "fr"]
+        self.multi_tenant_company.save()
+
+        self.property = Property.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.SELECT,
+        )
+        PropertyTranslation.objects.create(
+            property=self.property,
+            language="en",
+            name="Color",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertyTranslation.objects.create(
+            property=self.property,
+            language="fr",
+            name="Couleur",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        self.v1 = PropertySelectValue.objects.create(
+            property=self.property,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertySelectValueTranslation.objects.create(
+            propertyselectvalue=self.v1,
+            language="en",
+            value="Red",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        self.v2 = PropertySelectValue.objects.create(
+            property=self.property,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertySelectValueTranslation.objects.create(
+            propertyselectvalue=self.v2,
+            language="en",
+            value="Green",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertySelectValueTranslation.objects.create(
+            propertyselectvalue=self.v2,
+            language="fr",
+            value="Vert",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        self.v3 = PropertySelectValue.objects.create(
+            property=self.property,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertySelectValueTranslation.objects.create(
+            propertyselectvalue=self.v3,
+            language="fr",
+            value="Bleu",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def test_missing_main_translation_true(self):
+        qs, _ = PropertySelectValueFilter().missing_main_translation(
+            PropertySelectValue.objects.filter(multi_tenant_company=self.multi_tenant_company),
+            True,
+            "",
+        )
+        self.assertSetEqual(set(qs), {self.v3})
+
+    def test_missing_main_translation_false(self):
+        qs, _ = PropertySelectValueFilter().missing_main_translation(
+            PropertySelectValue.objects.filter(multi_tenant_company=self.multi_tenant_company),
+            False,
+            "",
+        )
+        self.assertSetEqual(set(qs), {self.v1, self.v2})
+
+    def test_missing_translations_true(self):
+        qs, _ = PropertySelectValueFilter().missing_translations(
+            PropertySelectValue.objects.filter(multi_tenant_company=self.multi_tenant_company),
+            True,
+            "",
+        )
+        self.assertSetEqual(set(qs), {self.v1, self.v3})
+
+    def test_missing_translations_false(self):
+        qs, _ = PropertySelectValueFilter().missing_translations(
+            PropertySelectValue.objects.filter(multi_tenant_company=self.multi_tenant_company),
+            False,
+            "",
+        )
+        self.assertSetEqual(set(qs), {self.v2})


### PR DESCRIPTION
## Summary
- extend property and property value filters
- add filters for missing translations
- test missing translation filters

## Testing
- `pre-commit run --files OneSila/properties/schema/types/filters.py OneSila/properties/tests/tests_filters.py`
- `pytest -q OneSila/properties/tests/tests_filters.py` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6882b27e21a0832ebba957339a5cbc86

## Summary by Sourcery

Introduce translation completeness filters on property and select value schemas and add corresponding unit tests to ensure correct inclusion and exclusion of objects based on missing translations

New Features:
- Add missing_main_translation and missing_translations filters to PropertyFilter
- Add missing_main_translation and missing_translations filters to PropertySelectValueFilter

Enhancements:
- Implement filter logic to include or exclude objects based on translation completeness against company languages

Tests:
- Add unit tests for missing_main_translation and missing_translations filters on properties and select values