### PR TITLE
Refactor property filter tests to use GraphQL

### DIFF
--- a/OneSila/properties/tests/tests_filters.py
+++ b/OneSila/properties/tests/tests_filters.py
@@ -1,183 +1,190 @@
-from core.tests import TestCase
+from django.test import TransactionTestCase
+from core.tests.tests_schemas.tests_queries import TransactionTestCaseMixin
 from properties.models import (
     Property,
     PropertyTranslation,
     PropertySelectValue,
     PropertySelectValueTranslation,
 )
-from properties.schema.types.filters import PropertyFilter, PropertySelectValueFilter
+from .tests_schemas.queries import (
+    PROPERTIES_MISSING_MAIN_TRANSLATION_QUERY,
+    PROPERTIES_MISSING_TRANSLATIONS_QUERY,
+    PROPERTY_SELECT_VALUES_MISSING_MAIN_TRANSLATION_QUERY,
+    PROPERTY_SELECT_VALUES_MISSING_TRANSLATIONS_QUERY,
+)
 
 
-# class PropertyFilterTranslationTestCase(TestCase):
-#     def setUp(self):
-#         super().setUp()
-#         self.multi_tenant_company.language = "en"
-#         self.multi_tenant_company.languages = ["en", "fr"]
-#         self.multi_tenant_company.save()
-#
-#         self.p1 = Property.objects.create(
-#             multi_tenant_company=self.multi_tenant_company,
-#             type=Property.TYPES.SELECT,
-#         )
-#         PropertyTranslation.objects.create(
-#             property=self.p1,
-#             language="en",
-#             name="Color",
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#
-#         self.p2 = Property.objects.create(
-#             multi_tenant_company=self.multi_tenant_company,
-#             type=Property.TYPES.SELECT,
-#         )
-#         PropertyTranslation.objects.create(
-#             property=self.p2,
-#             language="en",
-#             name="Size",
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#         PropertyTranslation.objects.create(
-#             property=self.p2,
-#             language="fr",
-#             name="Taille",
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#
-#         self.p3 = Property.objects.create(
-#             multi_tenant_company=self.multi_tenant_company,
-#             type=Property.TYPES.SELECT,
-#         )
-#         PropertyTranslation.objects.create(
-#             property=self.p3,
-#             language="fr",
-#             name="Poids",
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#
-#     def test_missing_main_translation_true(self):
-#         qs, _ = PropertyFilter().missing_main_translation(
-#             Property.objects.filter(multi_tenant_company=self.multi_tenant_company),
-#             True,
-#             "",
-#         )
-#         self.assertSetEqual(set(qs), {self.p3})
-#
-#     def test_missing_main_translation_false(self):
-#         qs, _ = PropertyFilter().missing_main_translation(
-#             Property.objects.filter(multi_tenant_company=self.multi_tenant_company),
-#             False,
-#             "",
-#         )
-#         self.assertSetEqual(set(qs), {self.p1, self.p2})
-#
-#     def test_missing_translations_true(self):
-#         qs, _ = PropertyFilter().missing_translations(
-#             Property.objects.filter(multi_tenant_company=self.multi_tenant_company),
-#             True,
-#             "",
-#         )
-#         self.assertSetEqual(set(qs), {self.p1, self.p3})
-#
-#     def test_missing_translations_false(self):
-#         qs, _ = PropertyFilter().missing_translations(
-#             Property.objects.filter(multi_tenant_company=self.multi_tenant_company),
-#             False,
-#             "",
-#         )
-#         self.assertSetEqual(set(qs), {self.p2})
-#
-#
-# class PropertySelectValueFilterTranslationTestCase(TestCase):
-#     def setUp(self):
-#         super().setUp()
-#         self.multi_tenant_company.language = "en"
-#         self.multi_tenant_company.languages = ["en", "fr"]
-#         self.multi_tenant_company.save()
-#
-#         self.property = Property.objects.create(
-#             multi_tenant_company=self.multi_tenant_company,
-#             type=Property.TYPES.SELECT,
-#         )
-#         PropertyTranslation.objects.create(
-#             property=self.property,
-#             language="en",
-#             name="Color",
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#         PropertyTranslation.objects.create(
-#             property=self.property,
-#             language="fr",
-#             name="Couleur",
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#
-#         self.v1 = PropertySelectValue.objects.create(
-#             property=self.property,
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#         PropertySelectValueTranslation.objects.create(
-#             propertyselectvalue=self.v1,
-#             language="en",
-#             value="Red",
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#
-#         self.v2 = PropertySelectValue.objects.create(
-#             property=self.property,
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#         PropertySelectValueTranslation.objects.create(
-#             propertyselectvalue=self.v2,
-#             language="en",
-#             value="Green",
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#         PropertySelectValueTranslation.objects.create(
-#             propertyselectvalue=self.v2,
-#             language="fr",
-#             value="Vert",
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#
-#         self.v3 = PropertySelectValue.objects.create(
-#             property=self.property,
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#         PropertySelectValueTranslation.objects.create(
-#             propertyselectvalue=self.v3,
-#             language="fr",
-#             value="Bleu",
-#             multi_tenant_company=self.multi_tenant_company,
-#         )
-#
-#     def test_missing_main_translation_true(self):
-#         qs, _ = PropertySelectValueFilter().missing_main_translation(
-#             PropertySelectValue.objects.filter(multi_tenant_company=self.multi_tenant_company),
-#             True,
-#             "",
-#         )
-#         self.assertSetEqual(set(qs), {self.v3})
-#
-#     def test_missing_main_translation_false(self):
-#         qs, _ = PropertySelectValueFilter().missing_main_translation(
-#             PropertySelectValue.objects.filter(multi_tenant_company=self.multi_tenant_company),
-#             False,
-#             "",
-#         )
-#         self.assertSetEqual(set(qs), {self.v1, self.v2})
-#
-#     def test_missing_translations_true(self):
-#         qs, _ = PropertySelectValueFilter().missing_translations(
-#             PropertySelectValue.objects.filter(multi_tenant_company=self.multi_tenant_company),
-#             True,
-#             "",
-#         )
-#         self.assertSetEqual(set(qs), {self.v1, self.v3})
-#
-#     def test_missing_translations_false(self):
-#         qs, _ = PropertySelectValueFilter().missing_translations(
-#             PropertySelectValue.objects.filter(multi_tenant_company=self.multi_tenant_company),
-#             False,
-#             "",
-#         )
-#         self.assertSetEqual(set(qs), {self.v2})
+class PropertyFilterTranslationTestCase(TransactionTestCaseMixin, TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.multi_tenant_company.language = "en"
+        self.multi_tenant_company.languages = ["en", "fr"]
+        self.multi_tenant_company.save()
+        self.p1 = Property.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.SELECT,
+        )
+        PropertyTranslation.objects.create(
+            property=self.p1,
+            language="en",
+            name="Color",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.p2 = Property.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.SELECT,
+        )
+        PropertyTranslation.objects.create(
+            property=self.p2,
+            language="en",
+            name="Size",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertyTranslation.objects.create(
+            property=self.p2,
+            language="fr",
+            name="Taille",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.p3 = Property.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.SELECT,
+        )
+        PropertyTranslation.objects.create(
+            property=self.p3,
+            language="fr",
+            name="Poids",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def _query_ids(self, query, variables):
+        resp = self.strawberry_test_client(query=query, variables=variables)
+        self.assertIsNone(resp.errors)
+        return {
+            int(self.from_global_id(edge["node"]["id"])[1])
+            for edge in resp.data["properties"]["edges"]
+        }
+
+    def test_missing_main_translation_true(self):
+        ids = self._query_ids(
+            PROPERTIES_MISSING_MAIN_TRANSLATION_QUERY,
+            {"missingMainTranslation": True},
+        )
+        self.assertSetEqual(ids, {self.p3.id})
+
+    def test_missing_main_translation_false(self):
+        ids = self._query_ids(
+            PROPERTIES_MISSING_MAIN_TRANSLATION_QUERY,
+            {"missingMainTranslation": False},
+        )
+        self.assertSetEqual(ids, {self.p1.id, self.p2.id})
+
+    def test_missing_translations_true(self):
+        ids = self._query_ids(
+            PROPERTIES_MISSING_TRANSLATIONS_QUERY,
+            {"missingTranslations": True},
+        )
+        self.assertSetEqual(ids, {self.p1.id, self.p3.id})
+
+    def test_missing_translations_false(self):
+        ids = self._query_ids(
+            PROPERTIES_MISSING_TRANSLATIONS_QUERY,
+            {"missingTranslations": False},
+        )
+        self.assertSetEqual(ids, {self.p2.id})
+
+
+class PropertySelectValueFilterTranslationTestCase(TransactionTestCaseMixin, TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.multi_tenant_company.language = "en"
+        self.multi_tenant_company.languages = ["en", "fr"]
+        self.multi_tenant_company.save()
+        self.property = Property.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.SELECT,
+        )
+        PropertyTranslation.objects.create(
+            property=self.property,
+            language="en",
+            name="Color",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertyTranslation.objects.create(
+            property=self.property,
+            language="fr",
+            name="Couleur",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.v1 = PropertySelectValue.objects.create(
+            property=self.property,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertySelectValueTranslation.objects.create(
+            propertyselectvalue=self.v1,
+            language="en",
+            value="Red",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.v2 = PropertySelectValue.objects.create(
+            property=self.property,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertySelectValueTranslation.objects.create(
+            propertyselectvalue=self.v2,
+            language="en",
+            value="Green",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertySelectValueTranslation.objects.create(
+            propertyselectvalue=self.v2,
+            language="fr",
+            value="Vert",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.v3 = PropertySelectValue.objects.create(
+            property=self.property,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertySelectValueTranslation.objects.create(
+            propertyselectvalue=self.v3,
+            language="fr",
+            value="Bleu",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def _query_ids(self, query, variables):
+        resp = self.strawberry_test_client(query=query, variables=variables)
+        self.assertIsNone(resp.errors)
+        return {
+            int(self.from_global_id(edge["node"]["id"])[1])
+            for edge in resp.data["propertySelectValues"]["edges"]
+        }
+
+    def test_missing_main_translation_true(self):
+        ids = self._query_ids(
+            PROPERTY_SELECT_VALUES_MISSING_MAIN_TRANSLATION_QUERY,
+            {"missingMainTranslation": True},
+        )
+        self.assertSetEqual(ids, {self.v3.id})
+
+    def test_missing_main_translation_false(self):
+        ids = self._query_ids(
+            PROPERTY_SELECT_VALUES_MISSING_MAIN_TRANSLATION_QUERY,
+            {"missingMainTranslation": False},
+        )
+        self.assertSetEqual(ids, {self.v1.id, self.v2.id})
+
+    def test_missing_translations_true(self):
+        ids = self._query_ids(
+            PROPERTY_SELECT_VALUES_MISSING_TRANSLATIONS_QUERY,
+            {"missingTranslations": True},
+        )
+        self.assertSetEqual(ids, {self.v1.id, self.v3.id})
+
+    def test_missing_translations_false(self):
+        ids = self._query_ids(
+            PROPERTY_SELECT_VALUES_MISSING_TRANSLATIONS_QUERY,
+            {"missingTranslations": False},
+        )
+        self.assertSetEqual(ids, {self.v2.id})

--- a/OneSila/properties/tests/tests_schemas/queries.py
+++ b/OneSila/properties/tests/tests_schemas/queries.py
@@ -1,0 +1,31 @@
+PROPERTIES_MISSING_MAIN_TRANSLATION_QUERY = """
+query Properties($missingMainTranslation: Boolean!) {
+  properties(filters: {missingMainTranslation: $missingMainTranslation}) {
+    edges { node { id } }
+  }
+}
+"""
+
+PROPERTIES_MISSING_TRANSLATIONS_QUERY = """
+query Properties($missingTranslations: Boolean!) {
+  properties(filters: {missingTranslations: $missingTranslations}) {
+    edges { node { id } }
+  }
+}
+"""
+
+PROPERTY_SELECT_VALUES_MISSING_MAIN_TRANSLATION_QUERY = """
+query PropertySelectValues($missingMainTranslation: Boolean!) {
+  propertySelectValues(filters: {missingMainTranslation: $missingMainTranslation}) {
+    edges { node { id } }
+  }
+}
+"""
+
+PROPERTY_SELECT_VALUES_MISSING_TRANSLATIONS_QUERY = """
+query PropertySelectValues($missingTranslations: Boolean!) {
+  propertySelectValues(filters: {missingTranslations: $missingTranslations}) {
+    edges { node { id } }
+  }
+}
+"""


### PR DESCRIPTION
## Summary
- add GraphQL queries for property filter tests
- rewrite property filter tests to execute GraphQL queries

## Testing
- `pre-commit run --files OneSila/properties/tests/tests_filters.py OneSila/properties/tests/tests_schemas/queries.py`
- `python OneSila/manage.py test` *(0 tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6882b93af310832e969b166200333a0d