### PR TITLE
Add debug logs for Amazon attribute parsing

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -1,5 +1,6 @@
 import pprint
 from decimal import Decimal
+import logging
 
 from django.db import IntegrityError
 
@@ -34,6 +35,9 @@ from sales_channels.integrations.amazon.models.properties import AmazonPublicDef
 from sales_channels.models import SalesChannelViewAssign
 from dateutil.parser import parse
 import datetime
+
+
+logger = logging.getLogger(__name__)
 
 
 class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
@@ -186,6 +190,13 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
                         continue
 
                     value = extract_amazon_attribute_value({code: values[0]}, real_code)
+                    if value is None:
+                        logger.debug(
+                            "Could not extract value for attribute '%s' (real code '%s') with entry %s",
+                            code,
+                            real_code,
+                            values[0],
+                        )
                     if remote_property.type in [Property.TYPES.SELECT, Property.TYPES.MULTISELECT]:
                         select_value = AmazonPropertySelectValue.objects.filter(
                             amazon_property=remote_property,

--- a/OneSila/sales_channels/integrations/amazon/helpers.py
+++ b/OneSila/sales_channels/integrations/amazon/helpers.py
@@ -1,6 +1,11 @@
 """Utility helpers for Amazon integration."""
 
+import logging
+
 from products.product_types import CONFIGURABLE, SIMPLE
+
+
+logger = logging.getLogger(__name__)
 
 
 def infer_product_type(data) -> str:
@@ -33,16 +38,12 @@ def extract_description_and_bullets(attributes: dict) -> tuple[str | None, list[
 
     return description, bullets
 
+
 def extract_amazon_attribute_value(entry: dict, code: str) -> str | None:
-    """
-    Extracts a value from an Amazon attribute entry based on a possibly nested code.
-    Examples:
-        code: 'brand' -> entry: {'value': 'X'} → returns 'X'
-        code: 'item_package_dimensions__length' -> entry: {'length': {'value': '30.00'}} → returns '30.00'
-        code: 'outer__material' -> entry: {'material': [{'value': 'POLYESTER'}]} → returns 'POLYESTER'
-    """
+    """Extract a value from an Amazon attribute entry using a possibly nested code."""
     parts = code.split("__")
     current = entry
+    original_entry = entry
 
     for part in parts:
         if isinstance(current, list):
@@ -50,6 +51,12 @@ def extract_amazon_attribute_value(entry: dict, code: str) -> str | None:
         if isinstance(current, dict):
             current = current.get(part)
         else:
+            logger.debug(
+                "extract_amazon_attribute_value failed at part '%s' for code '%s' with entry %s",
+                part,
+                code,
+                original_entry,
+            )
             return None
 
     if isinstance(current, list):
@@ -59,6 +66,11 @@ def extract_amazon_attribute_value(entry: dict, code: str) -> str | None:
     if isinstance(current, str):
         return current
 
+    logger.debug(
+        "extract_amazon_attribute_value returned None for code '%s' with entry %s",
+        code,
+        original_entry,
+    )
     return None
 
 


### PR DESCRIPTION
## Summary
- add a module logger for Amazon helpers
- log failures inside `extract_amazon_attribute_value`
- add logging when attribute extraction returns `None` in product import
- keep processing when attribute extraction fails

## Testing
- `pycodestyle OneSila/sales_channels/integrations/amazon/helpers.py OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py`
- `python OneSila/manage.py test --keepdb`


------
https://chatgpt.com/codex/tasks/task_e_6887396fd6ec832ebc630d8746b3c1be