### PR TITLE
Fix SalesChannel issue serialization

### DIFF
--- a/OneSila/core/helpers.py
+++ b/OneSila/core/helpers.py
@@ -3,6 +3,7 @@ import json
 from django.conf import settings
 from django.http import HttpResponse
 import os
+import datetime
 from get_absolute_url.helpers import reverse_lazy
 from io import BytesIO
 import zipfile
@@ -130,6 +131,17 @@ def is_json_serializable(value):
         return True
     except (TypeError, OverflowError):
         return False
+
+
+def ensure_serializable(value):
+    """Recursively converts common non-serializable objects to JSON-friendly types."""
+    if isinstance(value, (datetime.datetime, datetime.date)):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {k: ensure_serializable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [ensure_serializable(v) for v in value]
+    return value
 
 
 def safe_run_task(task_func, *args, **kwargs):

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -33,6 +33,7 @@ from sales_channels.integrations.amazon.models import (
 from sales_channels.integrations.amazon.constants import AMAZON_INTERNAL_PROPERTIES
 from sales_channels.integrations.amazon.models.properties import AmazonPublicDefinition
 from sales_channels.models import SalesChannelViewAssign
+from core.helpers import ensure_serializable
 from dateutil.parser import parse
 import datetime
 
@@ -579,7 +580,9 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
 
         issues = structured_data.get("__issues") or []
         assign.issues = [
-            issue.to_dict() if hasattr(issue, "to_dict") else issue.__dict__
+            ensure_serializable(
+                issue.to_dict() if hasattr(issue, "to_dict") else issue.__dict__
+            )
             for issue in issues
         ]
         assign.save()

--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -7,6 +7,7 @@ from sales_channels.integrations.amazon.decorators import throttle_safe
 from sales_channels.integrations.amazon.models import AmazonSalesChannelView
 from sales_channels.models import SalesChannelViewAssign
 from sales_channels.models.logs import RemoteLog
+from core.helpers import ensure_serializable
 from deepdiff import DeepDiff
 
 
@@ -54,13 +55,15 @@ class GetAmazonAPIMixin:
 
         # Ensure each existing issue is a dictionary
         existing_issues_dicts = [
-            issue.to_dict() if hasattr(issue, "to_dict") else issue
+            ensure_serializable(issue.to_dict() if hasattr(issue, "to_dict") else issue)
             for issue in existing_issues
         ]
 
         new_issues = []
         for issue in issues or []:
-            issue_dict = issue.to_dict() if hasattr(issue, "to_dict") else issue
+            issue_dict = ensure_serializable(
+                issue.to_dict() if hasattr(issue, "to_dict") else issue
+            )
             issue_dict["validation_issue"] = True
 
             if issue_dict not in existing_issues_dicts:

--- a/OneSila/sales_channels/integrations/amazon/factories/sales_channels/issues.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sales_channels/issues.py
@@ -1,5 +1,6 @@
 from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
 from sales_channels.models import SalesChannelViewAssign
+from core.helpers import ensure_serializable
 
 
 class RefreshLatestIssuesFactory(GetAmazonAPIMixin):
@@ -22,7 +23,9 @@ class RefreshLatestIssuesFactory(GetAmazonAPIMixin):
         )
         issues = getattr(response, "issues", []) or []
         self.assign.issues = [
-            issue.to_dict() if hasattr(issue, "to_dict") else issue
+            ensure_serializable(
+                issue.to_dict() if hasattr(issue, "to_dict") else issue
+            )
             for issue in issues
         ]
         self.assign.save()


### PR DESCRIPTION
## Summary
- add `ensure_serializable` helper to convert datetimes and nested structures
- use `ensure_serializable` when persisting SalesChannel issues

## Testing
- `pre-commit run --files OneSila/core/helpers.py OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py OneSila/sales_channels/integrations/amazon/factories/mixins.py OneSila/sales_channels/integrations/amazon/factories/sales_channels/issues.py`
- `pytest -k "SalesChannelViewAssign" -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6887457be004832eb759fcb0f11f3dae