### PR TITLE
Fix default marketplace import logic

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -206,10 +206,10 @@ class GetAmazonAPIMixin:
 
         listings_api = ListingsApi(self._get_client())
         seller_id = self.sales_channel.remote_id
-        marketplace_ids = list(
-            AmazonSalesChannelView.objects.filter(sales_channel=self.sales_channel)
-            .values_list("remote_id", flat=True)
-        )
+        views = AmazonSalesChannelView.objects.filter(
+            sales_channel=self.sales_channel
+        ).order_by("-is_default")
+        marketplace_ids = list(views.values_list("remote_id", flat=True))
 
         product_types = set()
 
@@ -235,10 +235,10 @@ class GetAmazonAPIMixin:
     def get_all_products(self):
         listings_api = ListingsApi(self._get_client())
         seller_id = self.sales_channel.remote_id
-        marketplace_ids = list(
-            AmazonSalesChannelView.objects.filter(sales_channel=self.sales_channel)
-            .values_list("remote_id", flat=True)
-        )
+        views = AmazonSalesChannelView.objects.filter(
+            sales_channel=self.sales_channel
+        ).order_by("-is_default")
+        marketplace_ids = list(views.values_list("remote_id", flat=True))
         issue_locale = self._get_issue_locale()
         import pprint
 

--- a/OneSila/sales_channels/integrations/amazon/migrations/0039_amazonsaleschannelview_is_default.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0039_amazonsaleschannelview_is_default.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0038_alter_amazonproducttype_unique_amazonproducttype_local_instance_sales_channel_not_null_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='amazonsaleschannelview',
+            name='is_default',
+            field=models.BooleanField(default=False, help_text='Marks the default marketplace for this Amazon store.'),
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/sales_channels.py
+++ b/OneSila/sales_channels/integrations/amazon/models/sales_channels.py
@@ -130,6 +130,10 @@ class AmazonSalesChannelView(SalesChannelView):
         null=True,
         blank=True,
     )
+    is_default = models.BooleanField(
+        default=False,
+        help_text="Marks the default marketplace for this Amazon store.",
+    )
 
     @property
     def language_tag(self) -> str | None:


### PR DESCRIPTION
## Summary
- add `is_default` flag to mark the primary marketplace
- order marketplace listing fetches by default first
- store remote SKU and variation flag via mirror defaults
- revert unnecessary constant support in mirror creation

## Testing
- `pre-commit run --files OneSila/imports_exports/factories/mixins.py OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py`
- `coverage run --source='.' OneSila/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6888f91c9d90832e8c2cd7e8b31c9329

## Summary by Sourcery

Add default marketplace support and streamline product import logic by prioritizing default views and reusing existing product records

New Features:
- Add is_default flag to AmazonSalesChannelView to mark the primary marketplace

Enhancements:
- Order marketplace listing fetches by is_default to prioritize the default marketplace
- Refactor product import logic to reuse existing AmazonProduct records for variation detection and local instance retrieval