### PR TITLE
Add AmazonSalesChannelView GraphQL support

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -15,6 +15,7 @@ from sales_channels.integrations.amazon.schema.types.input import (
     AmazonSalesChannelImportInput,
     AmazonSalesChannelImportPartialInput,
     AmazonDefaultUnitConfiguratorPartialInput,
+    AmazonSalesChannelViewPartialInput,
     AmazonValidateAuthInput,
     BulkAmazonPropertySelectValueLocalInstanceInput,
 )
@@ -27,6 +28,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonRedirectUrlType,
     AmazonSalesChannelImportType,
     AmazonDefaultUnitConfiguratorType,
+    AmazonSalesChannelViewType,
     SuggestedAmazonProductType, SuggestedAmazonProductTypeEntry,
 )
 from sales_channels.schema.types.input import (
@@ -94,6 +96,8 @@ class AmazonSalesChannelMutation:
     update_amazon_product_type_item: AmazonProductTypeItemType = update(AmazonProductTypeItemPartialInput)
 
     update_amazon_default_unit_configurator: AmazonDefaultUnitConfiguratorType = update(AmazonDefaultUnitConfiguratorPartialInput)
+
+    update_amazon_sales_channel_view: AmazonSalesChannelViewType = update(AmazonSalesChannelViewPartialInput)
 
     create_amazon_import_process: AmazonSalesChannelImportType = create(AmazonSalesChannelImportInput)
     update_amazon_import_process: AmazonSalesChannelImportType = update(AmazonSalesChannelImportPartialInput)

--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -8,6 +8,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonSalesChannelImportType,
     AmazonDefaultUnitConfiguratorType,
     AmazonRemoteLogType,
+    AmazonSalesChannelViewType,
 )
 
 
@@ -36,3 +37,6 @@ class AmazonSalesChannelsQuery:
 
     amazon_remote_log: AmazonRemoteLogType = node()
     amazon_remote_logs: DjangoListConnection[AmazonRemoteLogType] = connection()
+
+    amazon_channel_view: AmazonSalesChannelViewType = node()
+    amazon_channel_views: DjangoListConnection[AmazonSalesChannelViewType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -27,6 +27,7 @@ from sales_channels.schema.types.filters import (
     SalesChannelViewFilter,
     RemoteProductFilter,
 )
+from sales_channels.integrations.amazon.models import AmazonSalesChannelView
 
 
 @filter(AmazonSalesChannel)
@@ -34,6 +35,13 @@ class AmazonSalesChannelFilter(SearchFilterMixin):
     id: auto
     active: auto
     hostname: auto
+
+
+@filter(AmazonSalesChannelView)
+class AmazonSalesChannelViewFilter(SearchFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]
+    is_default: auto
 
 
 @filter(AmazonProperty)

--- a/OneSila/sales_channels/integrations/amazon/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/input.py
@@ -7,6 +7,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProductTypeItem,
     AmazonSalesChannelImport,
     AmazonDefaultUnitConfigurator,
+    AmazonSalesChannelView,
 )
 from properties.schema.types.input import PropertySelectValuePartialInput
 from strawberry.relay import GlobalID
@@ -87,6 +88,16 @@ class AmazonDefaultUnitConfiguratorInput:
 
 @partial(AmazonDefaultUnitConfigurator, fields="__all__")
 class AmazonDefaultUnitConfiguratorPartialInput(NodeInput):
+    pass
+
+
+@input(AmazonSalesChannelView, fields="__all__")
+class AmazonSalesChannelViewInput:
+    pass
+
+
+@partial(AmazonSalesChannelView, fields="__all__")
+class AmazonSalesChannelViewPartialInput(NodeInput):
     pass
 
 

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -9,6 +9,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannelImport,
     AmazonDefaultUnitConfigurator,
     AmazonRemoteLog,
+    AmazonSalesChannelView,
 )
 
 
@@ -44,6 +45,11 @@ class AmazonSalesChannelImportOrder:
 
 @order(AmazonDefaultUnitConfigurator)
 class AmazonDefaultUnitConfiguratorOrder:
+    id: auto
+
+
+@order(AmazonSalesChannelView)
+class AmazonSalesChannelViewOrder:
     id: auto
 
 

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -19,6 +19,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannelImport,
     AmazonDefaultUnitConfigurator,
     AmazonRemoteLog,
+    AmazonSalesChannelView,
 )
 from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonSalesChannelFilter,
@@ -27,7 +28,7 @@ from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonProductTypeFilter,
     AmazonProductTypeItemFilter,
     AmazonSalesChannelImportFilter, AmazonDefaultUnitConfiguratorFilter,
-    AmazonRemoteLogFilter,
+    AmazonRemoteLogFilter, AmazonSalesChannelViewFilter,
 )
 from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonSalesChannelOrder,
@@ -37,7 +38,7 @@ from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonProductTypeItemOrder,
     AmazonSalesChannelImportOrder,
     AmazonDefaultUnitConfiguratorOrder,
-    AmazonRemoteLogOrder,
+    AmazonRemoteLogOrder, AmazonSalesChannelViewOrder,
 )
 from sales_channels.schema.types.types import FormattedIssueType
 
@@ -203,6 +204,24 @@ class AmazonDefaultUnitConfiguratorType(relay.Node, GetQuerysetMultiTenantMixin)
         'SalesChannelViewType',
         lazy("sales_channels.schema.types.types")
     ]
+
+
+@type(
+    AmazonSalesChannelView,
+    filters=AmazonSalesChannelViewFilter,
+    order=AmazonSalesChannelViewOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonSalesChannelViewType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'AmazonSalesChannelType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]
+
+    @field()
+    def active(self, info) -> bool:
+        return self.sales_channel.active
 
 
 @type(


### PR DESCRIPTION
## Summary
- allow querying and updating AmazonSalesChannelView
- expose AmazonSalesChannelViewType with `is_default`
- add filters, ordering and inputs for AmazonSalesChannelView

## Testing
- `coverage run --source='.' OneSila/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68890dcd9534832e96928f6419946b3a

## Summary by Sourcery

Add GraphQL support for AmazonSalesChannelView by registering its type, filters, ordering, inputs, queries, and mutation.

New Features:
- Register AmazonSalesChannelViewType in the GraphQL schema with full fields, pagination, filters (including is_default and sales_channel), ordering, and an active field
- Add GraphQL input and partial input types for creating and updating AmazonSalesChannelView
- Expose amazon_channel_view node query, amazon_channel_views list connection, and an update_amazon_sales_channel_view mutation