### PR TITLE
Skip Amazon ASIN and EAN patches

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -359,7 +359,14 @@ class GetAmazonAPIMixin:
         current_attributes = current_attributes or {}
         new_attributes = new_attributes or {}
 
+        skip_keys = {
+            "merchant_suggested_asin",
+            "externally_assigned_product_identifier",
+        }
+
         for key, new_value in new_attributes.items():
+            if key in skip_keys:
+                continue
             new_value = clean(new_value)
             current_value = current_attributes.get(key)
             path = f"/attributes/{key}"


### PR DESCRIPTION
## Summary
- ignore merchant_suggested_asin and external identifier fields when building Amazon product patches
- test that update payload omits these fields

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/mixins.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py`
- `python manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductFactoriesTest.test_update_product_skips_merchant_asin_patch sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductFactoriesTest.test_update_product_skips_external_id_patch` *(fails: ModuleNotFoundError: No module named 'imagekit')*

------
https://chatgpt.com/codex/tasks/task_e_6889ed539168832eb5691a0918164240