### PR TITLE
Add GTIN exemption support to Amazon integration

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/constants.py
+++ b/OneSila/sales_channels/integrations/amazon/constants.py
@@ -85,7 +85,6 @@ AMAZON_INTERNAL_PROPERTIES = [
 
     # Auto-linking/ASIN suggestion
     'merchant_suggested_asin', 'externally_assigned_product_identifier',
-    'supplier_declared_has_product_identifier_exemption',
 
     # Amazon-only compliance metadata (for now)
     'compliance_media', 'gpsr_safety_attestation', 'gpsr_manufacturer_reference',

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
@@ -1,11 +1,20 @@
 import logging
 from imports_exports.factories.imports import ImportMixin
-from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin, EnsureMerchantSuggestedAsinMixin
+from sales_channels.integrations.amazon.factories.mixins import (
+    GetAmazonAPIMixin,
+    EnsureMerchantSuggestedAsinMixin,
+    EnsureGtinExemptionMixin,
+)
 from sales_channels.integrations.amazon.factories.sales_channels.full_schema import AmazonProductTypeRuleFactory
 logger = logging.getLogger(__name__)
 
 
-class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin, EnsureMerchantSuggestedAsinMixin):
+class AmazonSchemaImportProcessor(
+    ImportMixin,
+    GetAmazonAPIMixin,
+    EnsureMerchantSuggestedAsinMixin,
+    EnsureGtinExemptionMixin,
+):
     import_properties = False
     import_select_values = False
     import_rules = True
@@ -18,6 +27,7 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin, EnsureMerchant
         self.initial_sales_channel_status = sales_channel.active
         self.api = self.get_api()
         self.merchant_asin_property = self._ensure_merchant_suggested_asin()
+        self.gtin_exemption_property = self._ensure_gtin_exemption()
 
     def prepare_import_process(self):
         # during the import this needs to stay false to prevent trying to create the mirror models because
@@ -28,8 +38,6 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin, EnsureMerchant
 
     def get_total_instances(self):
         return 100
-
-
 
     def import_rules_process(self):
 
@@ -42,16 +50,14 @@ class AmazonSchemaImportProcessor(ImportMixin, GetAmazonAPIMixin, EnsureMerchant
                 product_type_code=product_type_code,
                 sales_channel=self.sales_channel,
                 merchant_asin_property=self.merchant_asin_property,
+                gtin_exemption_property=self.gtin_exemption_property,
                 api=self.api,
                 language=self.language,
             )
             product_type_fac.run()
             self.update_percentage()
 
-
     def process_completed(self):
         self.sales_channel.active = self.initial_sales_channel_status
         self.sales_channel.is_importing = False
         self.sales_channel.save()
-
-

--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -457,3 +457,35 @@ class EnsureMerchantSuggestedAsinMixin:
             local_property.save(update_fields=["non_deletable"])
 
         return remote_property
+
+
+class EnsureGtinExemptionMixin:
+    """Mixin ensuring the supplier_declared_has_product_identifier_exemption property exists."""
+
+    def _ensure_gtin_exemption(self):
+        remote_property, _ = AmazonProperty.objects.get_or_create(
+            allow_multiple=True,
+            multi_tenant_company=self.sales_channel.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            code="supplier_declared_has_product_identifier_exemption",
+            defaults={"type": Property.TYPES.BOOLEAN},
+        )
+
+        if not remote_property.local_instance:
+            local_property, _ = Property.objects.get_or_create(
+                internal_name="supplier_declared_has_product_identifier_exemption",
+                multi_tenant_company=self.sales_channel.multi_tenant_company,
+                defaults={"type": Property.TYPES.BOOLEAN},
+            )
+
+            PropertyTranslation.objects.get_or_create(
+                property=local_property,
+                language=self.sales_channel.multi_tenant_company.language,
+                multi_tenant_company=self.sales_channel.multi_tenant_company,
+                defaults={"name": "GTIN Exemption"},
+            )
+
+            remote_property.local_instance = local_property
+            remote_property.save()
+
+        return remote_property

--- a/OneSila/sales_channels/integrations/amazon/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/products.py
@@ -124,6 +124,17 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
     def _get_ean_for_payload(self) -> str | None:
         return self.remote_instance.ean_code or self.get_ean_code_value()
 
+    def _get_gtin_exemption(self) -> bool | None:
+        prop = Property.objects.filter(
+            internal_name="supplier_declared_has_product_identifier_exemption",
+            multi_tenant_company=self.sales_channel.multi_tenant_company,
+        ).first()
+        if not prop:
+            return None
+
+        pp = ProductProperty.objects.filter(product=self.local_instance, property=prop).first()
+        return pp.get_value() if pp else None
+
     def build_basic_attributes(self) -> Dict:
         self.set_sku()
 
@@ -133,17 +144,24 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
             attrs["merchant_suggested_asin"] = [{"value": asin}]
             self.force_listing_requirements = False
         else:
-            ean = self._get_ean_for_payload()
-            if ean:
-                attrs["externally_assigned_product_identifier"] = [
-                    {
-                        "type": "ean",
-                        "value": ean,
-                    }
+            exemption = self._get_gtin_exemption()
+            if exemption:
+                attrs["supplier_declared_has_product_identifier_exemption"] = [
+                    {"value": True}
                 ]
                 self.force_listing_requirements = True
             else:
-                self.force_listing_requirements = False
+                ean = self._get_ean_for_payload()
+                if ean:
+                    attrs["externally_assigned_product_identifier"] = [
+                        {
+                            "type": "ean",
+                            "value": ean,
+                        }
+                    ]
+                    self.force_listing_requirements = True
+                else:
+                    self.force_listing_requirements = False
         return attrs
 
     def build_content_attributes(self) -> Dict:
@@ -627,7 +645,6 @@ class AmazonProductCreateFactory(AmazonProductBaseFactory, RemoteProductCreateFa
 class AmazonProductSyncFactory(AmazonProductBaseFactory, RemoteProductSyncFactory):
     """Sync Amazon products using marketplace-specific create or update."""
     create_product_factory = AmazonProductCreateFactory
-
 
     def perform_remote_action(self):
 

--- a/OneSila/sales_channels/integrations/amazon/migrations/0040_gtin_exemption_property.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0040_gtin_exemption_property.py
@@ -1,0 +1,79 @@
+from django.db import migrations
+from django.db.models import Max
+
+
+def add_gtin_exemption(apps, schema_editor):
+    AmazonSalesChannel = apps.get_model('amazon', 'AmazonSalesChannel')
+    AmazonProperty = apps.get_model('amazon', 'AmazonProperty')
+    AmazonProductType = apps.get_model('amazon', 'AmazonProductType')
+    AmazonProductTypeItem = apps.get_model('amazon', 'AmazonProductTypeItem')
+    Property = apps.get_model('properties', 'Property')
+    PropertyTranslation = apps.get_model('properties', 'PropertyTranslation')
+    ProductPropertiesRuleItem = apps.get_model('properties', 'ProductPropertiesRuleItem')
+
+    for sc in AmazonSalesChannel.objects.all().iterator():
+        remote_prop, _ = AmazonProperty.objects.get_or_create(
+            allow_multiple=True,
+            sales_channel=sc,
+            multi_tenant_company=sc.multi_tenant_company,
+            code='supplier_declared_has_product_identifier_exemption',
+            defaults={'type': 'BOOLEAN'},
+        )
+
+        if not remote_prop.local_instance:
+            local_prop, _ = Property.objects.get_or_create(
+                internal_name='supplier_declared_has_product_identifier_exemption',
+                multi_tenant_company=sc.multi_tenant_company,
+                defaults={'type': 'BOOLEAN'},
+            )
+            PropertyTranslation.objects.get_or_create(
+                property=local_prop,
+                language=sc.multi_tenant_company.language,
+                multi_tenant_company=sc.multi_tenant_company,
+                defaults={'name': 'GTIN Exemption'},
+            )
+            remote_prop.local_instance = local_prop
+            remote_prop.save()
+        else:
+            local_prop = remote_prop.local_instance
+
+        for pt in AmazonProductType.objects.filter(sales_channel=sc):
+            item, created = AmazonProductTypeItem.objects.get_or_create(
+                multi_tenant_company=sc.multi_tenant_company,
+                sales_channel=sc,
+                amazon_rule=pt,
+                remote_property=remote_prop,
+                defaults={'remote_type': 'OPTIONAL'},
+            )
+            if created or item.remote_type != 'OPTIONAL':
+                item.remote_type = 'OPTIONAL'
+                item.save()
+
+            if pt.local_instance:
+                rule = pt.local_instance
+                max_sort = rule.items.aggregate(max_sort=Max('sort_order')).get('max_sort') or 0
+                rule_item, created_local = ProductPropertiesRuleItem.objects.get_or_create(
+                    multi_tenant_company=rule.multi_tenant_company,
+                    rule=rule,
+                    property=local_prop,
+                    defaults={'type': 'OPTIONAL', 'sort_order': max_sort + 1},
+                )
+                if not created_local and rule_item.type != 'OPTIONAL':
+                    rule_item.type = 'OPTIONAL'
+                    rule_item.save(update_fields=['type'])
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0039_amazonsaleschannelview_is_default'),
+        ('properties', '0012_alter_property_options_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_gtin_exemption, noop),
+    ]


### PR DESCRIPTION
## Summary
- support supplier_declared_has_product_identifier_exemption property for Amazon
- include GTIN exemption when building Amazon listing payloads
- sync GTIN exemption as optional in rule import
- keep merchant ASIN logic untouched
- create migration for GTIN exemption property
- test GTIN exemption when creating a product
- simplify ensure_gtin_exemption_item implementation

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/sales_channels/full_schema.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductFactoriesTest.test_create_product_with_gtin_exemption` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6889eebee83c832eb9f6dc837c862037

## Summary by Sourcery

Add end-to-end support for Amazon GTIN exemptions by defining the supplier_declared_has_product_identifier_exemption property, migrating existing channels, syncing it during schema imports, and including the exemption flag in listing payloads.

New Features:
- Introduce supplier_declared_has_product_identifier_exemption property across Amazon product types and imports
- Include GTIN exemption attribute in listings API payload when set instead of EAN
- Add database migration to backfill and link GTIN exemption property and mark it optional in existing rules

Enhancements:
- Add EnsureGtinExemptionMixin and simplify rule item creation for GTIN exemption
- Extend AmazonProductTypeRuleFactory and schema import processor to handle GTIN exemption

Tests:
- Add factory test to verify GTIN exemption handling in product creation payload