### PR TITLE
Add Amazon patch skip keys constant

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/constants.py
+++ b/OneSila/sales_channels/integrations/amazon/constants.py
@@ -95,3 +95,10 @@ AMAZON_INTERNAL_PROPERTIES = [
     'fulfillment_availability', 'merchant_shipping_group', 'merchant_release_date',
     'skip_offer', 'supplemental_condition_information', 'uvp_list_price'
 ]
+
+# Attributes that should be ignored when generating update patches
+AMAZON_PATCH_SKIP_KEYS = {
+    'merchant_suggested_asin',
+    'externally_assigned_product_identifier',
+    'supplier_declared_has_product_identifier_exemption',
+}

--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -12,6 +12,7 @@ from deepdiff import DeepDiff
 
 
 from sales_channels.integrations.amazon.models.properties import AmazonProperty
+from sales_channels.integrations.amazon.constants import AMAZON_PATCH_SKIP_KEYS
 from properties.models import Property, PropertyTranslation
 
 
@@ -359,11 +360,7 @@ class GetAmazonAPIMixin:
         current_attributes = current_attributes or {}
         new_attributes = new_attributes or {}
 
-        skip_keys = {
-            "merchant_suggested_asin",
-            "externally_assigned_product_identifier",
-            "supplier_declared_has_product_identifier_exemption"
-        }
+        skip_keys = AMAZON_PATCH_SKIP_KEYS
 
         for key, new_value in new_attributes.items():
             if key in skip_keys:


### PR DESCRIPTION
## Summary
- centralize Amazon patch skip keys in constants
- reuse the constant in patch-building logic

## Testing
- `pre-commit run --files sales_channels/integrations/amazon/constants.py sales_channels/integrations/amazon/factories/mixins.py`
- `python OneSila/manage.py test` *(fails: Ran 0 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6889fed0a020832eb1dc2e343f3f6cb5