### PR TITLE
Fix Amazon description handling

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/helpers.py
+++ b/OneSila/sales_channels/integrations/amazon/helpers.py
@@ -39,6 +39,14 @@ def extract_description_and_bullets(attributes: dict) -> tuple[str | None, list[
     return description, bullets
 
 
+def is_safe_content(value: str | None) -> bool:
+    """Return True if the value is considered valid content."""
+    if value is None:
+        return False
+    value = str(value).strip()
+    return value not in ("", "<p><br></p>")
+
+
 def extract_amazon_attribute_value(entry: dict, code: str) -> str | None:
     """Extract a value from an Amazon attribute entry using a possibly nested code."""
     parts = code.split("__")


### PR DESCRIPTION
## Summary
- add `is_safe_content` helper for Amazon
- skip empty descriptions when building content attributes
- support `get_value_only` mode for AmazonProductContentUpdateFactory
- use AmazonProductContentUpdateFactory when building product content
- test that empty descriptions aren't sent to Amazon

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/products/products.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_content_factories.AmazonProductContentUpdateFactoryTest.test_update_content_skips_empty_description` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688a18c2a2e4832e8eea34a57ef4d6e6