### PR TITLE
Fix build_content_attributes for Amazon products

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/products.py
@@ -4,7 +4,11 @@ from typing import Dict
 from datetime import timedelta
 
 from django.utils import timezone
-from products.models import Product
+from products.models import (
+    Product,
+    ProductTranslation,
+    ProductTranslationBulletPoint,
+)
 from properties.models import Property, ProductProperty
 from sales_channels.factories.products.products import (
     RemoteProductSyncFactory,
@@ -30,6 +34,7 @@ from sales_channels.integrations.amazon.factories.properties import (
 from sales_channels.integrations.amazon.factories.products.content import (
     AmazonProductContentUpdateFactory,
 )
+from sales_channels.integrations.amazon.helpers import is_safe_content
 from sales_channels.integrations.amazon.models.products import (
     AmazonProduct,
 )
@@ -189,17 +194,57 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
         return attrs
 
     def build_content_attributes(self) -> Dict:
-        fac = AmazonProductContentUpdateFactory(
-            sales_channel=self.sales_channel,
-            local_instance=self.local_instance,
-            remote_product=self.remote_instance,
-            view=self.view,
-            api=self.api,
-            skip_checks=True,
-            get_value_only=True,
+        lang = (
+            self.view.remote_languages.first().local_instance
+            if self.view.remote_languages.exists()
+            else self.sales_channel.multi_tenant_company.language
         )
-        fac.run()
-        return fac.value or {}
+
+        channel_translation = ProductTranslation.objects.filter(
+            product=self.local_instance,
+            language=lang,
+            sales_channel=self.sales_channel,
+        ).first()
+
+        default_translation = ProductTranslation.objects.filter(
+            product=self.local_instance,
+            language=lang,
+            sales_channel=None,
+        ).first()
+
+        item_name = None
+        product_description = None
+
+        if channel_translation:
+            item_name = channel_translation.name or None
+            product_description = channel_translation.description or None
+
+        if not item_name and default_translation:
+            item_name = default_translation.name
+
+        if not product_description and default_translation:
+            product_description = default_translation.description
+
+        bullet_points = []
+        if channel_translation:
+            bullet_points = list(
+                ProductTranslationBulletPoint.objects.filter(
+                    product_translation=channel_translation
+                )
+                .order_by("sort_order")
+                .values_list("text", flat=True)
+            )
+
+        attrs = {}
+        if item_name:
+            attrs["item_name"] = [{"value": item_name}]
+        if is_safe_content(product_description):
+            attrs["product_description"] = [{"value": product_description}]
+
+        if bullet_points:
+            attrs["bullet_point"] = [{"value": bp} for bp in bullet_points]
+
+        return {k: v for k, v in attrs.items() if v not in (None, "")}
 
     def build_price_attributes(self) -> Dict:
         attrs: Dict = {}


### PR DESCRIPTION
## Summary
- avoid requiring remote_instance when building Amazon product content

## Testing
- `pip install -r requirements.txt` *(fails: output truncated, success not fully verified)*
- `pytest OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py::AmazonProductContentUpdateFactoryTest::test_update_content_skips_empty_description -q` *(fails: django.core.exceptions.AppRegistryNotReady)*

------
https://chatgpt.com/codex/tasks/task_e_688a3e7c6614832eabc7ead8b3c11a07

## Summary by Sourcery

Revamp build_content_attributes to derive Amazon product content directly from local ProductTranslation models instead of relying on AmazonProductContentUpdateFactory and remote instances.

Bug Fixes:
- Remove dependency on AmazonProductContentUpdateFactory and remote_instance when building Amazon product content

Enhancements:
- Determine language context from view.remote_languages or fallback to channel’s default language
- Fetch channel-specific and default ProductTranslation records for item_name and description with fallback logic
- Assemble bullet_point attributes from ordered ProductTranslationBulletPoint records
- Validate product_description for safe content and filter out empty or null values