### PR TITLE
Handle WooCommerce unsupported product types

### DIFF
--- a/OneSila/sales_channels/integrations/woocommerce/exceptions.py
+++ b/OneSila/sales_channels/integrations/woocommerce/exceptions.py
@@ -215,3 +215,12 @@ class NoneValueNotAllowedError(Exception):
     Exception raised when a None value is not allowed.
     """
     pass
+
+
+class UnsupportedProductTypeError(Exception):
+    """Raised when a WooCommerce product type is not supported."""
+
+    def __init__(self, product_type: str):
+        self.product_type = product_type
+        message = f"Unsupported WooCommerce product type: {product_type}"
+        super().__init__(message)


### PR DESCRIPTION
## Summary
- introduce `UnsupportedProductTypeError`
- raise new error when encountering unknown WooCommerce product types
- skip unsupported product types during WooCommerce import

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/woocommerce/exceptions.py OneSila/sales_channels/integrations/woocommerce/factories/imports/product_imports.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_688b368dcc90832ebec9c25499ea428c

## Summary by Sourcery

Introduce a custom exception for unsupported WooCommerce product types and update the import flow to gracefully skip them

New Features:
- Add UnsupportedProductTypeError to signal unsupported WooCommerce product types

Enhancements:
- Replace NotImplementedError with UnsupportedProductTypeError when encountering unknown product types
- Catch and log UnsupportedProductTypeError in the product import loop to skip unsupported items