### PR TITLE
Fix unique constraint when importing Amazon attributes

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -487,11 +487,19 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
                     sales_channel=self.sales_channel,
                     local_instance=product_property,
                     remote_product=remote_product,
-                    remote_property=remote_property,
                 )
+
+                updated = False
+
+                if remote_product_property.remote_property != remote_property:
+                    remote_product_property.remote_property = remote_property
+                    updated = True
 
                 if not remote_product_property.remote_value:
                     remote_product_property.remote_value = remote_value
+                    updated = True
+
+                if updated:
                     remote_product_property.save()
 
     def handle_translations(self, import_instance: ImportProductInstance):


### PR DESCRIPTION
## Summary
- avoid unique constraint violation for Amazon product properties
- update remote property/value only when necessary

## Testing
- `pip install -r requirements.txt` *(fails: output truncated)*
- `pytest -q` *(fails to configure Django settings)*

------
https://chatgpt.com/codex/tasks/task_e_688b816babb4832eb86f4257e9b49938

## Summary by Sourcery

Bug Fixes:
- Only update and save Amazon remote properties and values when they differ from existing ones to avoid unique constraint violations.