### PR TITLE
Add eBay pull factories

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/__init__.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/__init__.py
@@ -1,0 +1,15 @@
+from .sales_channels import (
+    GetEbayRedirectUrlFactory,
+    ValidateEbayAuthFactory,
+    EbayRemoteCurrencyPullFactory,
+    EbayRemoteLanguagePullFactory,
+    EbaySalesChannelViewPullFactory,
+)
+
+__all__ = [
+    'GetEbayRedirectUrlFactory',
+    'ValidateEbayAuthFactory',
+    'EbayRemoteCurrencyPullFactory',
+    'EbayRemoteLanguagePullFactory',
+    'EbaySalesChannelViewPullFactory',
+]

--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/__init__.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/__init__.py
@@ -1,0 +1,12 @@
+from .oauth import GetEbayRedirectUrlFactory, ValidateEbayAuthFactory
+from .currencies import EbayRemoteCurrencyPullFactory
+from .languages import EbayRemoteLanguagePullFactory
+from .views import EbaySalesChannelViewPullFactory
+
+__all__ = [
+    'GetEbayRedirectUrlFactory',
+    'ValidateEbayAuthFactory',
+    'EbayRemoteCurrencyPullFactory',
+    'EbayRemoteLanguagePullFactory',
+    'EbaySalesChannelViewPullFactory',
+]

--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/currencies.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/currencies.py
@@ -1,0 +1,59 @@
+from sales_channels.factories.mixins import PullRemoteInstanceMixin, LocalCurrencyMappingMixin
+from sales_channels.integrations.ebay.mixins import GetEbayAPIMixin
+from sales_channels.integrations.ebay.models import (
+    EbayCurrency,
+    EbaySalesChannelView,
+)
+
+
+class EbayRemoteCurrencyPullFactory(GetEbayAPIMixin, LocalCurrencyMappingMixin, PullRemoteInstanceMixin):
+    """Pull default currencies for each eBay marketplace."""
+
+    remote_model_class = EbayCurrency
+    field_mapping = {
+        'remote_code': 'code',
+    }
+    update_field_mapping = field_mapping
+    get_or_create_fields = ['remote_code', 'sales_channel_view']
+
+    allow_create = True
+    allow_update = True
+    allow_delete = False
+    is_model_response = False
+
+    def fetch_remote_instances(self):
+        self.remote_instances = []
+        marketplaces = self.get_marketplace_ids()
+        reference = self.marketplace_reference()
+
+        for marketplace_id in marketplaces:
+            currency = self.get_marketplace_currency(marketplace_id)
+            if not currency:
+                continue
+            info = reference.get(marketplace_id)
+            if not info:
+                continue
+            self.remote_instances.append({
+                "code": currency,
+                "view_remote_id": marketplace_id,
+            })
+
+        self.add_local_currency()
+
+    def update_get_or_create_lookup(self, lookup, remote_data):
+        view = EbaySalesChannelView.objects.filter(
+            remote_id=remote_data['view_remote_id'],
+            sales_channel=self.sales_channel,
+        ).first()
+        lookup['sales_channel_view'] = view
+        return lookup
+
+    def create_remote_instance_mirror(self, remote_data, remote_instance_mirror):
+        remote_instance_mirror.remote_code = remote_data['code']
+        remote_instance_mirror.sales_channel = self.sales_channel
+        remote_instance_mirror.multi_tenant_company = self.sales_channel.multi_tenant_company
+        remote_instance_mirror.sales_channel_view = EbaySalesChannelView.objects.filter(
+            remote_id=remote_data['view_remote_id'],
+            sales_channel=self.sales_channel,
+        ).first()
+        remote_instance_mirror.save()

--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/languages.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/languages.py
@@ -1,0 +1,56 @@
+from sales_channels.factories.mixins import PullRemoteInstanceMixin
+from sales_channels.integrations.ebay.mixins import GetEbayAPIMixin
+from sales_channels.integrations.ebay.models import (
+    EbayRemoteLanguage,
+    EbaySalesChannelView,
+)
+
+
+class EbayRemoteLanguagePullFactory(GetEbayAPIMixin, PullRemoteInstanceMixin):
+    """Pull default languages for each eBay marketplace."""
+
+    remote_model_class = EbayRemoteLanguage
+    field_mapping = {
+        'remote_code': 'code',
+    }
+    update_field_mapping = field_mapping
+    get_or_create_fields = ['remote_code', 'sales_channel_view']
+
+    allow_create = True
+    allow_update = True
+    allow_delete = False
+    is_model_response = False
+
+    def fetch_remote_instances(self):
+        self.remote_instances = []
+        marketplaces = self.get_marketplace_ids()
+        reference = self.marketplace_reference()
+
+        for marketplace_id in marketplaces:
+            info = reference.get(marketplace_id)
+            if not info:
+                continue
+            languages = info[1]
+            for lang in languages.keys():
+                self.remote_instances.append({
+                    "code": lang,
+                    "view_remote_id": marketplace_id,
+                })
+
+    def update_get_or_create_lookup(self, lookup, remote_data):
+        view = EbaySalesChannelView.objects.filter(
+            remote_id=remote_data['view_remote_id'],
+            sales_channel=self.sales_channel,
+        ).first()
+        lookup['sales_channel_view'] = view
+        return lookup
+
+    def create_remote_instance_mirror(self, remote_data, remote_instance_mirror):
+        remote_instance_mirror.remote_code = remote_data['code']
+        remote_instance_mirror.sales_channel = self.sales_channel
+        remote_instance_mirror.multi_tenant_company = self.sales_channel.multi_tenant_company
+        remote_instance_mirror.sales_channel_view = EbaySalesChannelView.objects.filter(
+            remote_id=remote_data['view_remote_id'],
+            sales_channel=self.sales_channel,
+        ).first()
+        remote_instance_mirror.save()

--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/views.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/views.py
@@ -1,0 +1,45 @@
+from sales_channels.factories.mixins import PullRemoteInstanceMixin
+from sales_channels.integrations.ebay.mixins import GetEbayAPIMixin
+from sales_channels.integrations.ebay.models import EbaySalesChannelView
+
+
+class EbaySalesChannelViewPullFactory(GetEbayAPIMixin, PullRemoteInstanceMixin):
+    """Pull eBay marketplaces as sales channel views."""
+
+    remote_model_class = EbaySalesChannelView
+    field_mapping = {
+        'remote_id': 'marketplace_id',
+        'name': 'name',
+        'url': 'url',
+        'is_default': 'is_default',
+    }
+    update_field_mapping = field_mapping
+    get_or_create_fields = ['remote_id']
+
+    allow_create = True
+    allow_update = True
+    allow_delete = False
+    is_model_response = False
+
+    def fetch_remote_instances(self):
+        self.remote_instances = []
+        marketplaces = self.get_marketplace_ids()
+        default_marketplace = self.get_default_marketplace_id()
+        reference = self.marketplace_reference()
+
+        for marketplace_id in marketplaces:
+            info = reference.get(marketplace_id)
+            if not info:
+                continue
+            name = info[0]
+            languages = info[1]
+            url = next(iter(languages.values()))[0] if languages else ""
+            self.remote_instances.append({
+                "marketplace_id": marketplace_id,
+                "name": name,
+                "url": url,
+                "is_default": marketplace_id == default_marketplace,
+            })
+
+    def serialize_response(self, response):
+        return response

--- a/OneSila/sales_channels/integrations/ebay/migrations/0004_marketplace_fields.py
+++ b/OneSila/sales_channels/integrations/ebay/migrations/0004_marketplace_fields.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ebay', '0003_alter_ebaysaleschannel_access_token'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ebaysaleschannelview',
+            name='is_default',
+            field=models.BooleanField(default=False, help_text='Marks the default marketplace for this eBay store.'),
+        ),
+        migrations.AddField(
+            model_name='ebaycurrency',
+            name='sales_channel_view',
+            field=models.ForeignKey(blank=True, help_text='The marketplace associated with this remote currency.', null=True, on_delete=models.CASCADE, related_name='remote_currencies', to='ebay.ebaysaleschannelview'),
+        ),
+        migrations.AddField(
+            model_name='ebayremotelanguage',
+            name='sales_channel_view',
+            field=models.ForeignKey(blank=True, help_text='The marketplace associated with this remote language.', null=True, on_delete=models.CASCADE, related_name='remote_languages', to='ebay.ebaysaleschannelview'),
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/ebay/mixins.py
+++ b/OneSila/sales_channels/integrations/ebay/mixins.py
@@ -1,0 +1,62 @@
+"""Utility mixins for eBay API access."""
+
+from __future__ import annotations
+
+import requests
+from ebay_rest.reference import Reference
+
+from .models.sales_channels import EbaySalesChannel
+
+
+class GetEbayAPIMixin:
+    """Mixin providing a simple authenticated requests session for eBay."""
+
+    api: requests.Session
+    api_host: str
+    identity_host: str
+
+    def get_api(self) -> requests.Session:
+        """Return an authenticated :class:`requests.Session` for eBay APIs."""
+
+        host = "https://api.ebay.com"
+        identity_host = "https://apiz.ebay.com"
+        if getattr(self.sales_channel, "environment", EbaySalesChannel.PRODUCTION) == EbaySalesChannel.SANDBOX:
+            host = "https://api.sandbox.ebay.com"
+            identity_host = "https://apiz.sandbox.ebay.com"
+
+        session = requests.Session()
+        if getattr(self.sales_channel, "access_token", None):
+            session.headers.update({"Authorization": f"Bearer {self.sales_channel.access_token}"})
+        session.headers.update({"Content-Type": "application/json"})
+
+        self.api_host = host
+        self.identity_host = identity_host
+        self.api = session
+        return session
+
+    def get_marketplace_ids(self) -> list[str]:
+        """Return list of marketplace IDs the account is subscribed to."""
+        resp = self.api.get(f"{self.api_host}/sell/account/v1/subscription")
+        if resp.ok:
+            return [s.get("marketplaceId") for s in resp.json().get("subscriptions", [])]
+        return []
+
+    def get_default_marketplace_id(self) -> str | None:
+        """Return the default marketplace ID for the account."""
+        resp = self.api.get(f"{self.identity_host}/commerce/identity/v1/user")
+        if resp.ok:
+            return resp.json().get("registrationMarketplaceId")
+        return None
+
+    def get_marketplace_currency(self, marketplace_id: str) -> str | None:
+        """Return the default currency code for a marketplace."""
+        url = f"{self.api_host}/sell/metadata/v1/marketplace/{marketplace_id}/get_currencies"
+        resp = self.api.get(url)
+        if resp.ok:
+            return resp.json().get("defaultCurrency", {}).get("code")
+        return None
+
+    @staticmethod
+    def marketplace_reference() -> dict:
+        """Return mapping from marketplace id to reference info."""
+        return Reference.get_marketplace_id_values()

--- a/OneSila/sales_channels/integrations/ebay/models/sales_channels.py
+++ b/OneSila/sales_channels/integrations/ebay/models/sales_channels.py
@@ -81,9 +81,19 @@ class EbaySalesChannel(SalesChannel):
 
 class EbaySalesChannelView(SalesChannelView):
     """eBay marketplace or site representation."""
-    pass
+    is_default = models.BooleanField(
+        default=False,
+        help_text="Marks the default marketplace for this eBay store.",
+    )
 
 
 class EbayRemoteLanguage(RemoteLanguage):
     """eBay remote language model."""
-    pass
+    sales_channel_view = models.ForeignKey(
+        EbaySalesChannelView,
+        on_delete=models.CASCADE,
+        related_name='remote_languages',
+        null=True,
+        blank=True,
+        help_text="The marketplace associated with this remote language.",
+    )

--- a/OneSila/sales_channels/integrations/ebay/models/taxes.py
+++ b/OneSila/sales_channels/integrations/ebay/models/taxes.py
@@ -1,9 +1,20 @@
 from sales_channels.models.taxes import RemoteCurrency
+from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 
 class EbayCurrency(RemoteCurrency):
     """eBay currency model."""
 
+    sales_channel_view = models.ForeignKey(
+        'ebay.EbaySalesChannelView',
+        on_delete=models.CASCADE,
+        related_name='remote_currencies',
+        null=True,
+        blank=True,
+        help_text="The marketplace associated with this remote currency.",
+    )
+
     class Meta:
         verbose_name_plural = _("eBay Currencies")
+

--- a/OneSila/sales_channels/integrations/ebay/receivers.py
+++ b/OneSila/sales_channels/integrations/ebay/receivers.py
@@ -1,6 +1,29 @@
 from core.receivers import receiver
-from core.signals import post_create, post_update
+from sales_channels.signals import refresh_website_pull_models, sales_channel_created
+from sales_channels.integrations.ebay.models import EbaySalesChannel
 
 # @receiver(post_update, sender='app_name.Model')
 # def app_name__model__action__example(sender, instance, **kwargs):
 #     do_something()
+@receiver(refresh_website_pull_models, sender='sales_channels.SalesChannel')
+@receiver(refresh_website_pull_models, sender='ebay.EbaySalesChannel')
+@receiver(sales_channel_created, sender='sales_channels.SalesChannel')
+@receiver(sales_channel_created, sender='ebay.EbaySalesChannel')
+def sales_channels__ebay__handle_pull(sender, instance, **kwargs):
+    from sales_channels.integrations.ebay.factories.sales_channels import (
+        EbaySalesChannelViewPullFactory,
+        EbayRemoteLanguagePullFactory,
+        EbayRemoteCurrencyPullFactory,
+    )
+
+    if not isinstance(instance.get_real_instance(), EbaySalesChannel):
+        return
+
+    views_factory = EbaySalesChannelViewPullFactory(sales_channel=instance)
+    views_factory.run()
+
+    languages_factory = EbayRemoteLanguagePullFactory(sales_channel=instance)
+    languages_factory.run()
+
+    currencies_factory = EbayRemoteCurrencyPullFactory(sales_channel=instance)
+    currencies_factory.run()

--- a/OneSila/sales_channels/integrations/ebay/tests/tests_factories/__init__.py
+++ b/OneSila/sales_channels/integrations/ebay/tests/tests_factories/__init__.py
@@ -1,0 +1,1 @@
+# Tests for eBay factories

--- a/OneSila/sales_channels/integrations/ebay/tests/tests_factories/mixins.py
+++ b/OneSila/sales_channels/integrations/ebay/tests/tests_factories/mixins.py
@@ -1,0 +1,13 @@
+from core.tests import TransactionTestCase
+from sales_channels.integrations.ebay.models import EbaySalesChannel
+
+
+class TestCaseEbayMixin(TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = EbaySalesChannel.objects.create(
+            hostname='test.ebay',
+            environment=EbaySalesChannel.PRODUCTION,
+            active=True,
+            multi_tenant_company=self.multi_tenant_company,
+        )

--- a/OneSila/sales_channels/integrations/ebay/tests/tests_factories/tests_pull.py
+++ b/OneSila/sales_channels/integrations/ebay/tests/tests_factories/tests_pull.py
@@ -1,0 +1,23 @@
+from .mixins import TestCaseEbayMixin
+from sales_channels.integrations.ebay.factories.sales_channels import (
+    EbayRemoteCurrencyPullFactory,
+    EbayRemoteLanguagePullFactory,
+    EbaySalesChannelViewPullFactory,
+)
+
+
+class TestEbayPullFactories(TestCaseEbayMixin):
+    def test_pull_currency(self):
+        factory = EbayRemoteCurrencyPullFactory(sales_channel=self.sales_channel)
+        factory.run()
+        self.assertTrue(factory.remote_model_class.objects.filter(sales_channel=self.sales_channel).exists())
+
+    def test_pull_view(self):
+        factory = EbaySalesChannelViewPullFactory(sales_channel=self.sales_channel)
+        factory.run()
+        self.assertTrue(factory.remote_model_class.objects.filter(sales_channel=self.sales_channel).exists())
+
+    def test_pull_language(self):
+        factory = EbayRemoteLanguagePullFactory(sales_channel=self.sales_channel)
+        factory.run()
+        self.assertTrue(factory.remote_model_class.objects.filter(sales_channel=self.sales_channel).exists())


### PR DESCRIPTION
## Summary
- add API mixin that uses requests and reference data
- dynamically fetch eBay marketplaces, currencies, and languages via API calls
- remove placeholder defaults

## Testing
- `coverage run ./OneSila/manage.py test sales_channels.integrations.ebay.tests.tests_factories.tests_pull -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed)*


------
https://chatgpt.com/codex/tasks/task_e_688b8e15af20832e9359e7bbd3fda0a7

## Summary by Sourcery

Introduce eBay pull factories and API mixin to dynamically fetch and store marketplaces, languages, and currencies, integrate them with signals, update model schema, and cover with tests

New Features:
- Add GetEbayAPIMixin for authenticated eBay API requests and reference lookups
- Implement pull factories for eBay marketplaces, languages, and currencies

Enhancements:
- Add signal receiver to trigger eBay pull factories on channel refresh and creation
- Add is_default flag to EbaySalesChannelView and link remote currencies/languages to their marketplace view
- Add migration to update eBay models with new fields

Tests:
- Add unit tests for eBay pull factories for views, languages, and currencies