### PR TITLE
Update eBay API mixin

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/mixins.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import requests
 from ebay_rest.reference import Reference
 from ebay_rest.api.sell_marketing.api_client import ApiClient
 from ebay_rest.api.sell_marketing.configuration import Configuration
@@ -28,11 +27,11 @@ class GetEbayAPIMixin:
             identity_host = "https://apiz.sandbox.ebay.com"
 
         configuration = Configuration()
-        configuration.host = ""
-        api_client = ApiClient(configuration)
+        configuration.host = host
         token = getattr(self.sales_channel, "access_token", None)
         if token:
-            api_client.default_headers.update({"Authorization": f"Bearer {token}"})
+            configuration.access_token = token
+        api_client = ApiClient(configuration)
         api_client.default_headers.update({"Content-Type": "application/json"})
 
         self.api_host = host


### PR DESCRIPTION
## Summary
- switch `GetEbayAPIMixin` to use ebay_rest ApiClient

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/ebay/factories/mixins.py`
- `pytest -q` *(fails: django not configured)*

------
https://chatgpt.com/codex/tasks/task_e_688bb4e59028832e91a48b7d735f3c42

## Summary by Sourcery

Switch GetEbayAPIMixin to use the official ebay_rest ApiClient instead of raw requests sessions

Enhancements:
- Migrate get_api to initialize and configure ApiClient with host, authorization, and content-type headers
- Refactor marketplace-related methods to invoke ApiClient.request and parse JSON from resp.data instead of using requests.Session