### PR TITLE
Skip Amazon items lacking product data

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -604,6 +604,13 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
 
     def import_products_process(self):
         for product in self.get_products_data():
+            # Skip items that do not contain any useful information
+            if (
+                not getattr(product, "summaries", None)
+                and not getattr(product, "attributes", None)
+                and not getattr(product, "product_types", None)
+            ):
+                continue
             product_instance = None
             remote_product = AmazonProduct.objects.filter(
                 remote_sku=product.sku,
@@ -677,7 +684,6 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
                 }
                 self.broken_records.append(record)
                 continue
-
 
             self.update_remote_product(instance, product, view, is_variation)
             self.handle_ean_code(instance)


### PR DESCRIPTION
## Summary
- skip products lacking summaries, attributes and product types during Amazon import

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py`
- `coverage run --source='.' OneSila/manage.py test`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_688bc489c378832ea7ae8f20fd860f8d

## Summary by Sourcery

Enhancements:
- Skip items without summaries, attributes or product types to avoid creating incomplete records