### PR TITLE
Skip product type errors when configuring Amazon variations

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -564,12 +564,15 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
                 amazon_theme=theme,
             )
         else:
-            RemoteProductConfigurator.objects.create_from_remote_product(
-                remote_product=remote_product,
-                rule=import_instance.rule,
-                variations=None,
-                amazon_theme=theme,
-            )
+            try:
+                RemoteProductConfigurator.objects.create_from_remote_product(
+                    remote_product=remote_product,
+                    rule=import_instance.rule,
+                    variations=None,
+                    amazon_theme=theme,
+                )
+            except ValueError:
+                pass
 
     def handle_sales_channels_views(self, import_instance: ImportProductInstance, structured_data, view):
         if not view:


### PR DESCRIPTION
## Summary
- handle unmapped Amazon product types gracefully

## Testing
- `pip install -r requirements.txt` *(fails to fully set up environment)*
- `pytest -k amazon -q` *(fails: ImproperlyConfigured: settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_688c6a63607c832eb3758e8338b72675