### PR TITLE
Fix eBay currency & language pulls

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/currencies.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/currencies.py
@@ -27,7 +27,13 @@ class EbayRemoteCurrencyPullFactory(GetEbayAPIMixin, LocalCurrencyMappingMixin, 
         reference = self.marketplace_reference()
 
         for marketplace_id in marketplaces:
-            currency = self.get_marketplace_currency(marketplace_id)
+            resp = self.get_marketplace_currencies(marketplace_id)
+            currency = None
+            if resp:
+                if hasattr(resp, "to_dict"):
+                    resp = resp.to_dict()
+                if isinstance(resp, dict):
+                    currency = resp.get("default_currency", {}).get("code")
             if not currency:
                 continue
             info = reference.get(marketplace_id)

--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/languages.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/languages.py
@@ -31,10 +31,12 @@ class EbayRemoteLanguagePullFactory(GetEbayAPIMixin, PullRemoteInstanceMixin):
             if not info:
                 continue
             languages = info[1]
-            for lang in languages.keys():
+            for code, data in languages.items():
+                url = data[0] if isinstance(data, (list, tuple)) and data else ""
                 self.remote_instances.append({
-                    "code": lang,
+                    "code": code,
                     "view_remote_id": marketplace_id,
+                    "url": url,
                 })
 
     def update_get_or_create_lookup(self, lookup, remote_data):


### PR DESCRIPTION
## Summary
- parse default currency from get_marketplace_currencies
- include language URLs when pulling languages

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/ebay/factories/sales_channels/languages.py OneSila/sales_channels/integrations/ebay/factories/sales_channels/currencies.py OneSila/sales_channels/integrations/ebay/factories/sales_channels/views.py`
- `coverage run --source='.' OneSila/manage.py test sales_channels.integrations.ebay.tests` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688c74b0b84c832e98dd384393861ef5