### PR TITLE
Add eBay property schema

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/mutations.py
@@ -4,10 +4,16 @@ from sales_channels.integrations.ebay.schema.types.input import (
     EbaySalesChannelInput,
     EbaySalesChannelPartialInput,
     EbayValidateAuthInput,
+    EbayPropertyPartialInput,
+    EbayPropertySelectValuePartialInput,
+    EbaySalesChannelViewPartialInput,
 )
 from sales_channels.integrations.ebay.schema.types.types import (
     EbaySalesChannelType,
     EbayRedirectUrlType,
+    EbayPropertyType,
+    EbayPropertySelectValueType,
+    EbaySalesChannelViewType,
 )
 from core.schema.core.mutations import create, type, List, update
 from strawberry import Info
@@ -23,6 +29,10 @@ class EbaySalesChannelMutation:
     create_ebay_sales_channels: List[EbaySalesChannelType] = create(EbaySalesChannelInput)
 
     update_ebay_sales_channel: EbaySalesChannelType = update(EbaySalesChannelPartialInput)
+
+    update_ebay_property: EbayPropertyType = update(EbayPropertyPartialInput)
+    update_ebay_property_select_value: EbayPropertySelectValueType = update(EbayPropertySelectValuePartialInput)
+    update_ebay_sales_channel_view: EbaySalesChannelViewType = update(EbaySalesChannelViewPartialInput)
 
     @strawberry_django.mutation(handle_django_errors=True, extensions=default_extensions)
     def get_ebay_redirect_url(self, instance: EbaySalesChannelPartialInput, info: Info) -> EbayRedirectUrlType:

--- a/OneSila/sales_channels/integrations/ebay/schema/queries.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/queries.py
@@ -1,8 +1,22 @@
 from core.schema.core.queries import node, connection, DjangoListConnection, type
-from sales_channels.integrations.ebay.schema.types.types import EbaySalesChannelType
+from sales_channels.integrations.ebay.schema.types.types import (
+    EbaySalesChannelType,
+    EbayPropertyType,
+    EbayPropertySelectValueType,
+    EbaySalesChannelViewType,
+)
 
 
 @type(name="Query")
 class EbaySalesChannelsQuery:
     ebay_channel: EbaySalesChannelType = node()
     ebay_channels: DjangoListConnection[EbaySalesChannelType] = connection()
+
+    ebay_property: EbayPropertyType = node()
+    ebay_properties: DjangoListConnection[EbayPropertyType] = connection()
+
+    ebay_property_select_value: EbayPropertySelectValueType = node()
+    ebay_property_select_values: DjangoListConnection[EbayPropertySelectValueType] = connection()
+
+    ebay_channel_view: EbaySalesChannelViewType = node()
+    ebay_channel_views: DjangoListConnection[EbaySalesChannelViewType] = connection()

--- a/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
@@ -1,9 +1,43 @@
+from typing import Optional
+
 from core.schema.core.types.filters import filter, SearchFilterMixin
 from core.schema.core.types.types import auto
-from sales_channels.integrations.ebay.models import EbaySalesChannel
+from sales_channels.integrations.ebay.models import (
+    EbaySalesChannel,
+    EbayProperty,
+    EbayPropertySelectValue,
+    EbaySalesChannelView,
+)
+from properties.schema.types.filters import PropertyFilter, PropertySelectValueFilter
+from sales_channels.schema.types.filters import SalesChannelFilter, SalesChannelViewFilter
 
 
 @filter(EbaySalesChannel)
 class EbaySalesChannelFilter(SearchFilterMixin):
     active: auto
     hostname: auto
+
+
+@filter(EbayProperty)
+class EbayPropertyFilter(SearchFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]
+    local_instance: Optional[PropertyFilter]
+    allow_multiple: auto
+    type: auto
+
+
+@filter(EbayPropertySelectValue)
+class EbayPropertySelectValueFilter(SearchFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]
+    ebay_property: Optional[EbayPropertyFilter]
+    local_instance: Optional[PropertySelectValueFilter]
+    marketplace: Optional[SalesChannelViewFilter]
+
+
+@filter(EbaySalesChannelView)
+class EbaySalesChannelViewFilter(SearchFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]
+    is_default: auto

--- a/OneSila/sales_channels/integrations/ebay/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/input.py
@@ -1,5 +1,10 @@
 from core.schema.core.types.input import NodeInput, input, partial, strawberry_input
-from sales_channels.integrations.ebay.models import EbaySalesChannel
+from sales_channels.integrations.ebay.models import (
+    EbaySalesChannel,
+    EbayProperty,
+    EbayPropertySelectValue,
+    EbaySalesChannelView,
+)
 
 
 @strawberry_input
@@ -15,4 +20,34 @@ class EbaySalesChannelInput:
 
 @partial(EbaySalesChannel, fields="__all__")
 class EbaySalesChannelPartialInput(NodeInput):
+    pass
+
+
+@input(EbayProperty, fields="__all__")
+class EbayPropertyInput:
+    pass
+
+
+@partial(EbayProperty, fields="__all__")
+class EbayPropertyPartialInput(NodeInput):
+    pass
+
+
+@input(EbayPropertySelectValue, fields="__all__")
+class EbayPropertySelectValueInput:
+    pass
+
+
+@partial(EbayPropertySelectValue, fields="__all__")
+class EbayPropertySelectValuePartialInput(NodeInput):
+    pass
+
+
+@input(EbaySalesChannelView, fields="__all__")
+class EbaySalesChannelViewInput:
+    pass
+
+
+@partial(EbaySalesChannelView, fields="__all__")
+class EbaySalesChannelViewPartialInput(NodeInput):
     pass

--- a/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
@@ -1,8 +1,28 @@
 from core.schema.core.types.ordering import order
 from core.schema.core.types.types import auto
-from sales_channels.integrations.ebay.models import EbaySalesChannel
+from sales_channels.integrations.ebay.models import (
+    EbaySalesChannel,
+    EbayProperty,
+    EbayPropertySelectValue,
+    EbaySalesChannelView,
+)
 
 
 @order(EbaySalesChannel)
 class EbaySalesChannelOrder:
+    id: auto
+
+
+@order(EbayProperty)
+class EbayPropertyOrder:
+    id: auto
+
+
+@order(EbayPropertySelectValue)
+class EbayPropertySelectValueOrder:
+    id: auto
+
+
+@order(EbaySalesChannelView)
+class EbaySalesChannelViewOrder:
     id: auto

--- a/OneSila/sales_channels/integrations/ebay/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/types.py
@@ -1,7 +1,31 @@
-from core.schema.core.types.types import relay, type, GetQuerysetMultiTenantMixin, strawberry_type, field
-from sales_channels.integrations.ebay.models import EbaySalesChannel
-from sales_channels.integrations.ebay.schema.types.filters import EbaySalesChannelFilter
-from sales_channels.integrations.ebay.schema.types.ordering import EbaySalesChannelOrder
+from typing import Annotated, Optional, List
+
+from core.schema.core.types.types import (
+    relay,
+    type,
+    GetQuerysetMultiTenantMixin,
+    strawberry_type,
+    field,
+    lazy,
+)
+from sales_channels.integrations.ebay.models import (
+    EbaySalesChannel,
+    EbayProperty,
+    EbayPropertySelectValue,
+    EbaySalesChannelView,
+)
+from sales_channels.integrations.ebay.schema.types.filters import (
+    EbaySalesChannelFilter,
+    EbayPropertyFilter,
+    EbayPropertySelectValueFilter,
+    EbaySalesChannelViewFilter,
+)
+from sales_channels.integrations.ebay.schema.types.ordering import (
+    EbaySalesChannelOrder,
+    EbayPropertyOrder,
+    EbayPropertySelectValueOrder,
+    EbaySalesChannelViewOrder,
+)
 
 
 @strawberry_type
@@ -19,3 +43,66 @@ class EbaySalesChannelType(relay.Node, GetQuerysetMultiTenantMixin):
     @field()
     def saleschannel_ptr(self, info) -> str:
         return self.saleschannel_ptr
+
+
+@type(
+    EbayProperty,
+    filters=EbayPropertyFilter,
+    order=EbayPropertyOrder,
+    pagination=True,
+    fields="__all__",
+)
+class EbayPropertyType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'EbaySalesChannelType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]
+    local_instance: Optional[Annotated[
+        'PropertyType',
+        lazy("properties.schema.types.types")
+    ]]
+    select_values: List[Annotated[
+        'EbayPropertySelectValueType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]]
+
+
+@type(
+    EbayPropertySelectValue,
+    filters=EbayPropertySelectValueFilter,
+    order=EbayPropertySelectValueOrder,
+    pagination=True,
+    fields="__all__",
+)
+class EbayPropertySelectValueType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'EbaySalesChannelType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]
+    ebay_property: EbayPropertyType
+    marketplace: Annotated[
+        'SalesChannelViewType',
+        lazy("sales_channels.schema.types.types")
+    ]
+    local_instance: Optional[Annotated[
+        'PropertySelectValueType',
+        lazy("properties.schema.types.types")
+    ]]
+
+
+@type(
+    EbaySalesChannelView,
+    filters=EbaySalesChannelViewFilter,
+    order=EbaySalesChannelViewOrder,
+    pagination=True,
+    fields="__all__",
+)
+class EbaySalesChannelViewType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'EbaySalesChannelType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]
+
+    @field()
+    def active(self, info) -> bool:
+        return self.sales_channel.active


### PR DESCRIPTION
## Summary
- add eBay property GraphQL types, filters and ordering
- expose eBay property queries and mutations

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/ebay/schema/mutations.py OneSila/sales_channels/integrations/ebay/schema/queries.py OneSila/sales_channels/integrations/ebay/schema/types/filters.py OneSila/sales_channels/integrations/ebay/schema/types/input.py OneSila/sales_channels/integrations/ebay/schema/types/ordering.py OneSila/sales_channels/integrations/ebay/schema/types/types.py`
- `pytest -q` *(fails: ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_688c78f29dbc832ea040ee6807fd6eaa

## Summary by Sourcery

Add GraphQL schema support for eBay property entities by defining types, filters, ordering, inputs, queries, and update mutations.

New Features:
- Introduce EbayPropertyType, EbayPropertySelectValueType, and EbaySalesChannelViewType GraphQL nodes with full fields, filtering, ordering, and pagination
- Add filter and ordering classes for EbayProperty, EbayPropertySelectValue, and EbaySalesChannelView models
- Define GraphQL input types and update mutations for EbayProperty, EbayPropertySelectValue, and EbaySalesChannelView
- Expose new query endpoints and list connections for ebay_property, ebay_properties, ebay_property_select_value, ebay_property_select_values, ebay_channel_view, and ebay_channel_views