### PR TITLE
Fix eBay factories creating duplicate currencies and set languages

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/currencies.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/currencies.py
@@ -14,7 +14,10 @@ class EbayRemoteCurrencyPullFactory(GetEbayAPIMixin, LocalCurrencyMappingMixin, 
         'remote_code': 'code',
     }
     update_field_mapping = field_mapping
-    get_or_create_fields = ['remote_code', 'sales_channel_view']
+    # Only create a single currency per code. Previously the ``sales_channel_view``
+    # was included which resulted in the same currency (e.g. EUR) being created
+    # multiple times when it was present on different marketplaces.
+    get_or_create_fields = ['remote_code']
 
     allow_create = True
     allow_update = True
@@ -51,6 +54,7 @@ class EbayRemoteCurrencyPullFactory(GetEbayAPIMixin, LocalCurrencyMappingMixin, 
         self.add_local_currency()
 
     def update_get_or_create_lookup(self, lookup, remote_data):
+        """Attach the marketplace view but don't use it for lookups."""
         view = EbaySalesChannelView.objects.filter(
             remote_id=remote_data['view_remote_id'],
             sales_channel=self.sales_channel,

--- a/OneSila/sales_channels/integrations/ebay/tests/tests_factories/tests_pull.py
+++ b/OneSila/sales_channels/integrations/ebay/tests/tests_factories/tests_pull.py
@@ -10,7 +10,10 @@ class TestEbayPullFactories(TestCaseEbayMixin):
     def test_pull_currency(self):
         factory = EbayRemoteCurrencyPullFactory(sales_channel=self.sales_channel)
         factory.run()
-        self.assertTrue(factory.remote_model_class.objects.filter(sales_channel=self.sales_channel).exists())
+        currencies = factory.remote_model_class.objects.filter(sales_channel=self.sales_channel)
+        self.assertTrue(currencies.exists())
+        codes = {c.remote_code for c in currencies}
+        self.assertEqual(len(codes), currencies.count())
 
     def test_pull_view(self):
         factory = EbaySalesChannelViewPullFactory(sales_channel=self.sales_channel)
@@ -20,4 +23,8 @@ class TestEbayPullFactories(TestCaseEbayMixin):
     def test_pull_language(self):
         factory = EbayRemoteLanguagePullFactory(sales_channel=self.sales_channel)
         factory.run()
-        self.assertTrue(factory.remote_model_class.objects.filter(sales_channel=self.sales_channel).exists())
+        languages = factory.remote_model_class.objects.filter(sales_channel=self.sales_channel)
+        self.assertTrue(languages.exists())
+        from sales_channels.integrations.ebay.factories.sales_channels.languages import _map_local_language
+        for lang in languages:
+            self.assertEqual(lang.local_instance, _map_local_language(lang.remote_code))


### PR DESCRIPTION
## Summary
- ensure eBay currency pull only creates one currency per code
- ensure eBay language pull only creates one language per code and map to local language
- test that currencies are unique and languages use mapped locales

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/ebay/factories/sales_channels/currencies.py OneSila/sales_channels/integrations/ebay/factories/sales_channels/languages.py OneSila/sales_channels/integrations/ebay/tests/tests_factories/tests_pull.py`
- `./OneSila/manage.py test sales_channels.integrations.ebay.tests.tests_factories.tests_pull.TestEbayPullFactories` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688c803e9a2c832e9ef65bee622f5608

## Summary by Sourcery

Fix duplication in eBay currency and language pull factories by limiting uniqueness to remote_code, add mapping of eBay language codes to local locales, and enhance tests to assert uniqueness and correct locale assignment.

Bug Fixes:
- Prevent duplication of currencies by using only remote_code in currency pull factory
- Prevent duplication of languages by using only remote_code in language pull factory

Enhancements:
- Introduce _map_local_language function to normalize and fallback eBay language codes
- Assign local_instance in language factory based on mapped locale
- Attach sales_channel_view in currency lookup without affecting uniqueness

Tests:
- Verify currencies are unique by comparing remote_code counts
- Verify languages local_instance matches mapped code for each remote language