### PR TITLE
Introduce DB-backed async variation mapping

### DIFF
--- a/OneSila/imports_exports/helpers.py
+++ b/OneSila/imports_exports/helpers.py
@@ -1,0 +1,25 @@
+import math
+from django.db import transaction
+from django.db.models import F
+
+from .models import Import
+
+
+def increment_processed_records(process_id: int, delta: int = 1) -> None:
+    """Safely increment the processed counter and update percentage."""
+    Import.objects.filter(pk=process_id).update(processed_records=F('processed_records') + delta)
+    imp = Import.objects.get(pk=process_id)
+    if imp.total_records:
+        percent = math.floor((imp.processed_records / imp.total_records) * 100)
+        Import.objects.filter(pk=process_id).update(percentage=percent)
+
+
+def append_broken_record(process_id: int, record: dict) -> None:
+    """Safely append a broken record to the import process."""
+    with transaction.atomic():
+        imp = Import.objects.select_for_update().get(pk=process_id)
+        data = imp.broken_records or []
+        data.append(record)
+        imp.broken_records = data
+        imp.save(update_fields=['broken_records'])
+

--- a/OneSila/imports_exports/migrations/0013_import_async_fields.py
+++ b/OneSila/imports_exports/migrations/0013_import_async_fields.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('imports_exports', '0012_importreport'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='import',
+            name='total_records',
+            field=models.PositiveIntegerField(default=0, help_text='Total number of items that this import will process.'),
+        ),
+        migrations.AddField(
+            model_name='import',
+            name='processed_records',
+            field=models.PositiveIntegerField(default=0, help_text='How many items have been processed so far in async imports.'),
+        ),
+    ]

--- a/OneSila/imports_exports/models.py
+++ b/OneSila/imports_exports/models.py
@@ -60,6 +60,15 @@ class Import(PolymorphicModel, models.Model):
         help_text="JSON array storing details of records that failed during import."
     )
 
+    total_records = models.PositiveIntegerField(
+        default=0,
+        help_text="Total number of items that this import will process.",
+    )
+    processed_records = models.PositiveIntegerField(
+        default=0,
+        help_text="How many items have been processed so far in async imports.",
+    )
+
     def get_cleaned_errors_from_broken_records(self):
         import re
         from django.core.exceptions import ObjectDoesNotExist

--- a/OneSila/imports_exports/signals.py
+++ b/OneSila/imports_exports/signals.py
@@ -1,3 +1,4 @@
 from core.signals import ModelSignal
 
-# signal_name = ModelSignal(use_caching=True)
+# Emitted when an import process completes successfully
+import_success = ModelSignal(use_caching=True)

--- a/OneSila/sales_channels/integrations/amazon/migrations/0041_amazonimportrelationship.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0041_amazonimportrelationship.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0040_gtin_exemption_property'),
+        ('imports_exports', '0013_import_async_fields'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AmazonImportRelationship',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('parent_sku', models.CharField(max_length=255)),
+                ('child_sku', models.CharField(max_length=255)),
+                ('import_process', models.ForeignKey(on_delete=models.deletion.CASCADE, related_name='amazon_relationships', to='imports_exports.import')),
+            ],
+            options={
+                'verbose_name': 'Amazon Import Relationship',
+                'verbose_name_plural': 'Amazon Import Relationships',
+                'unique_together': {('import_process', 'parent_sku', 'child_sku')},
+            },
+        ),
+    ]
+

--- a/OneSila/sales_channels/integrations/amazon/models/imports.py
+++ b/OneSila/sales_channels/integrations/amazon/models/imports.py
@@ -18,3 +18,16 @@ class AmazonSalesChannelImport(SalesChannelImport):
     class Meta:
         verbose_name = "Amazon Sales Channel Import"
         verbose_name_plural = "Amazon Sales Channel Imports"
+
+
+class AmazonImportRelationship(models.Model):
+    """Store parent-child SKU pairs during async product import."""
+
+    import_process = models.ForeignKey('imports_exports.Import', on_delete=models.CASCADE, related_name='amazon_relationships')
+    parent_sku = models.CharField(max_length=255)
+    child_sku = models.CharField(max_length=255)
+
+    class Meta:
+        unique_together = ("import_process", "parent_sku", "child_sku")
+        verbose_name = "Amazon Import Relationship"
+        verbose_name_plural = "Amazon Import Relationships"

--- a/OneSila/sales_channels/integrations/amazon/receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/receivers.py
@@ -14,6 +14,8 @@ from sales_channels.integrations.amazon.factories.sync.select_value_sync import 
     AmazonPropertySelectValuesSyncFactory,
 )
 from sales_channels.integrations.amazon.tasks import create_amazon_product_type_rule_task
+from imports_exports.signals import import_success
+from sales_channels.integrations.amazon.factories.imports.products_imports import AmazonConfigurableVariationsFactory
 
 
 @receiver(refresh_website_pull_models, sender='sales_channels.SalesChannel')
@@ -92,3 +94,11 @@ def sales_channels__amazon_product_type__imported_rule(sender, instance, **kwarg
             product_type_code=instance.product_type_code,
             sales_channel_id=instance.sales_channel_id,
         )
+
+
+@receiver(import_success, sender='amazon.AmazonSalesChannelImport')
+def sales_channels__amazon_import_completed(sender, instance, **kwargs):
+    if instance.type != instance.TYPE_PRODUCTS:
+        return
+    factory = AmazonConfigurableVariationsFactory(import_process=instance)
+    factory.run()


### PR DESCRIPTION
## Summary
- create `AmazonImportRelationship` model for parent-child SKU links
- track import completion via `import_success` signal
- dispatch async imports through new `AsyncProductImportMixin`
- build variations after import using `AmazonConfigurableVariationsFactory`
- handle unknown errors per item and store broken records safely

## Testing
- `pip install --break-system-packages -q --no-deps -r requirements.txt` *(failed: warnings, no packages installed)*
- `pytest -q` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ce40240f8832ebd626164cc303446

## Summary by Sourcery

Enable fully asynchronous Amazon product imports by dispatching each item to a DB-backed task, persisting parent-child SKU relationships for configurable products, and building variations after import completion

New Features:
- Introduce AsyncProductImportMixin with remote_tasks for per-item async product imports
- Add AmazonImportRelationship model to persist parent-child SKU mappings
- Implement AmazonProductItemFactory and AmazonProductsAsyncImportProcessor for asynchronous import flows
- Introduce AmazonConfigurableVariationsFactory and import_success signal to build configurable variations post-import

Enhancements:
- Track import progress in Import model with total_records and processed_records fields
- Safely append broken records and increment processed count via transactional helpers
- Refactor import processor to isolate product processing logic in process_product_item