### PR TITLE
Optimize import progress updates

### DIFF
--- a/OneSila/imports_exports/helpers.py
+++ b/OneSila/imports_exports/helpers.py
@@ -1,17 +1,26 @@
 import math
 from django.db import transaction
-from django.db.models import F
+from django.db.models import F, Case, When, IntegerField
+from django.db.models.functions import Cast
 
 from .models import Import
 
 
 def increment_processed_records(process_id: int, delta: int = 1) -> None:
     """Safely increment the processed counter and update percentage."""
-    Import.objects.filter(pk=process_id).update(processed_records=F('processed_records') + delta)
-    imp = Import.objects.get(pk=process_id)
-    if imp.total_records:
-        percent = math.floor((imp.processed_records / imp.total_records) * 100)
-        Import.objects.filter(pk=process_id).update(percentage=percent)
+    Import.objects.filter(pk=process_id).update(
+        processed_records=F("processed_records") + delta,
+        percentage=Case(
+            When(
+                total_records__gt=0,
+                then=Cast(
+                    ((F("processed_records") + delta) * 100) / F("total_records"),
+                    IntegerField(),
+                ),
+            ),
+            default=F("percentage"),
+        ),
+    )
 
 
 def append_broken_record(process_id: int, record: dict) -> None:

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -742,10 +742,19 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
 class AmazonProductItemFactory(AmazonProductsImportProcessor):
     """Process a single product in an async task."""
 
-    def __init__(self, product_data, import_process, sales_channel, is_last=False, language=None):
+    def __init__(
+        self,
+        product_data,
+        import_process,
+        sales_channel,
+        is_last=False,
+        updated_with=None,
+        language=None,
+    ):
         super().__init__(import_process=import_process, sales_channel=sales_channel, language=language)
         self.product_data = product_data
         self.is_last = is_last
+        self.updated_with = updated_with
 
     def run(self):
         try:
@@ -758,7 +767,8 @@ class AmazonProductItemFactory(AmazonProductsImportProcessor):
                 exc=exc,
             )
 
-        increment_processed_records(self.import_process.id)
+        if self.updated_with:
+            increment_processed_records(self.import_process.id, delta=self.updated_with)
         if self.is_last:
             self.mark_success()
             self.process_completed()

--- a/OneSila/sales_channels/integrations/amazon/tasks.py
+++ b/OneSila/sales_channels/integrations/amazon/tasks.py
@@ -21,14 +21,22 @@ def amazon_import_db_task(import_process, sales_channel):
 
 @remote_task(priority=LOW_PRIORITY)
 @db_task()
-def amazon_product_import_item_task(import_process_id, sales_channel_id, product_data, is_last=False):
+def amazon_product_import_item_task(
+    import_process_id, sales_channel_id, product_data, is_last=False, updated_with=None
+):
     from sales_channels.integrations.amazon.factories.imports.products_imports import AmazonProductItemFactory
     from imports_exports.models import Import
     from sales_channels.integrations.amazon.models import AmazonSalesChannel
 
     process = Import.objects.get(id=import_process_id)
     channel = AmazonSalesChannel.objects.get(id=sales_channel_id)
-    fac = AmazonProductItemFactory(product_data=product_data, import_process=process, sales_channel=channel, is_last=is_last)
+    fac = AmazonProductItemFactory(
+        product_data=product_data,
+        import_process=process,
+        sales_channel=channel,
+        is_last=is_last,
+        updated_with=updated_with,
+    )
     fac.run()
 
 


### PR DESCRIPTION
## Summary
- improve `increment_processed_records` to do a single DB update
- throttle async import progress updates with `_threshold_chunk`
- pass update delta to amazon item task
- store delta in `AmazonProductItemFactory`

## Testing
- `python OneSila/manage.py test imports_exports` *(fails: connection refused)*
- `pycodestyle .`

------
https://chatgpt.com/codex/tasks/task_e_688d0555c090832ea2a0731aaaa39115

## Summary by Sourcery

Optimize import progress tracking by batching progress counter updates into a single query and emitting asynchronous updates only at threshold intervals, carrying the update delta through tasks

New Features:
- Throttle asynchronous import progress updates using a configurable threshold chunk
- Add updated_with parameter to dispatch_task and Amazon import tasks to propagate update delta

Enhancements:
- Combine processed_records increment and percentage calculation into a single database update in increment_processed_records