### PR TITLE
Switch prints to debug logging in Amazon mixin

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -1,3 +1,6 @@
+from properties.models import Property, PropertyTranslation
+from sales_channels.integrations.amazon.constants import AMAZON_PATCH_SKIP_KEYS
+from sales_channels.integrations.amazon.models.properties import AmazonProperty
 import json
 
 from django.conf import settings
@@ -10,10 +13,8 @@ from sales_channels.models.logs import RemoteLog
 from core.helpers import ensure_serializable
 from deepdiff import DeepDiff
 
-
-from sales_channels.integrations.amazon.models.properties import AmazonProperty
-from sales_channels.integrations.amazon.constants import AMAZON_PATCH_SKIP_KEYS
-from properties.models import Property, PropertyTranslation
+import logging
+logger = logging.getLogger(__name__)
 
 
 class PullAmazonMixin:
@@ -265,7 +266,7 @@ class GetAmazonAPIMixin:
             last_created_date = None
             total_results = 0
 
-            print(f"[START CYCLE] created_after={created_after}")
+            logger.debug(f"[START CYCLE] created_after={created_after}")
 
             while True:
                 items, page_token, results_number = self._fetch_listing_items_page(
@@ -295,7 +296,9 @@ class GetAmazonAPIMixin:
                 if not page_token:
                     break
 
-            print(f"[END CYCLE] results_number={total_results} | last_created_date={last_created_date}")
+            logger.debug(
+                f"[END CYCLE] results_number={total_results} | last_created_date={last_created_date}"
+            )
 
             # amazon items results is limited at 1000
             if total_results < 1000:


### PR DESCRIPTION
## Summary
- set up module logger in Amazon factories mixin
- swap print statements for `logger.debug`

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/mixins.py`
- `pytest -q` *(fails: settings not configured)*

------
https://chatgpt.com/codex/tasks/task_e_688d12d993fc832e8c2d024f0e9f9c51

## Summary by Sourcery

Switch print statements to debug-level logging in the Amazon factories mixin

Enhancements:
- Initialize a module-level logger and replace print calls with logger.debug in get_all_products_by_marketplace
- Remove unused imports related to AmazonProperty, AMAZON_PATCH_SKIP_KEYS, and property models