### PR TITLE
Handle Amazon item serialization for async import

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -732,7 +732,6 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
         if not is_variation:
             self.handle_sales_channels_views(instance, structured, view)
 
-
     def import_products_process(self):
         for product in self.get_products_data():
             self.process_product_item(product)
@@ -758,7 +757,10 @@ class AmazonProductItemFactory(AmazonProductsImportProcessor):
 
     def run(self):
         try:
-            self.process_product_item(self.product_data)
+            client = self._get_client()
+            deser = getattr(client, "_ApiClient__deserialize")
+            product = deser(self.product_data, "ListingsItemSubmissionResponse")
+            self.process_product_item(product)
         except Exception as exc:  # capture unexpected errors
             self._add_broken_record(
                 code="UNKNOWN_ERROR",
@@ -800,6 +802,7 @@ class AmazonConfigurableVariationsFactory:
                     variation=child,
                     multi_tenant_company=mtc,
                 )
+
 
 class AmazonProductsAsyncImportProcessor(AsyncProductImportMixin, AmazonProductsImportProcessor):
     """Async variant of the Amazon product importer."""

--- a/OneSila/sales_channels/integrations/amazon/helpers.py
+++ b/OneSila/sales_channels/integrations/amazon/helpers.py
@@ -3,6 +3,7 @@
 import logging
 
 from products.product_types import CONFIGURABLE, SIMPLE
+from core.helpers import ensure_serializable
 
 
 logger = logging.getLogger(__name__)
@@ -97,3 +98,12 @@ def get_is_product_variation(data):
         return True, parent_skus
     else:
         return False, []
+
+
+def serialize_listing_item(item):
+    """Return a serializable dictionary representation of an SP-API listing item."""
+    if hasattr(item, "to_dict"):
+        return item.to_dict()
+    if hasattr(item, "__dict__"):
+        return ensure_serializable(item.__dict__)
+    return ensure_serializable(item)

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_tasks.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_tasks.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from core.tests import TestCase
+from imports_exports.factories.imports import AsyncProductImportMixin
+from imports_exports.models import Import
+from sales_channels.integrations.amazon.factories.imports.products_imports import (
+    AmazonProductItemFactory,
+)
+from sales_channels.integrations.amazon.helpers import serialize_listing_item
+from sales_channels.integrations.amazon.models.sales_channels import (
+    AmazonSalesChannel,
+)
+
+
+class SerializationHelpersTest(TestCase):
+    def test_serialize_listing_item(self):
+        item = SimpleNamespace(sku="SKU1", nested=SimpleNamespace(value=5))
+
+        data = serialize_listing_item(item)
+        self.assertEqual(data["sku"], "SKU1")
+        self.assertEqual(data["nested"]["value"], 5)
+
+
+class AsyncImportAndItemFactoryTest(TestCase):
+    def test_async_import_runs_and_item_factory_deserializes(self):
+        imp = Import.objects.create(multi_tenant_company=self.multi_tenant_company)
+        channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company, remote_id="SELLER"
+        )
+
+        captured = []
+
+        def fake_task(import_id, channel_id, product_data, is_last, updated_with):
+            captured.append(product_data)
+
+        class DummyImport(AsyncProductImportMixin):
+            async_task = staticmethod(fake_task)
+
+            def __init__(self, imp_process, sc, items):
+                self.import_process = imp_process
+                self.sales_channel = sc
+                self._items = items
+
+            def prepare_import_process(self):
+                pass
+
+            def strat_process(self):
+                pass
+
+            def process_completed(self):
+                pass
+
+            def get_total_instances(self):
+                return len(self._items)
+
+            def get_products_data(self):
+                return self._items
+
+        items = [SimpleNamespace(sku="X")]
+        importer = DummyImport(imp, channel, items)
+        importer.run()
+
+        self.assertEqual(len(captured), 1)
+        self.assertIsInstance(captured[0], dict)
+        self.assertEqual(captured[0]["sku"], "X")
+
+        processed = []
+
+        class DummyClient:
+            def __deserialize(self, data, klass):
+                return SimpleNamespace(**data)
+
+        with patch.object(
+            AmazonProductItemFactory,
+            "process_product_item",
+            lambda self, prod: processed.append(prod),
+        ), patch.object(
+            AmazonProductItemFactory,
+            "_get_client",
+            return_value=DummyClient(),
+        ):
+            fac = AmazonProductItemFactory(captured[0], imp, channel)
+            fac.run()
+
+        self.assertEqual(len(processed), 1)
+        self.assertIsInstance(processed[0], SimpleNamespace)
+        self.assertEqual(processed[0].sku, "X")


### PR DESCRIPTION
## Summary
- support serializing Amazon listing items with `serialize_listing_item`
- deserialize product items using the SP-API client's private deserializer
- update tests to mock the API client deserialization

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py OneSila/sales_channels/integrations/amazon/helpers.py OneSila/sales_channels/integrations/amazon/tests/tests_tasks.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_tasks` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688d12d6b64c832e967d9e8e44450637

## Summary by Sourcery

Enable serialization of Amazon SP-API listing items and deserialization of product data for asynchronous imports.

New Features:
- Add a serialize_listing_item helper to convert SP-API listing items into JSON-serializable dictionaries
- Use the SP-API client's private __deserialize method in AmazonProductItemFactory to transform raw product data before processing

Enhancements:
- Update AsyncProductImportMixin.run to serialize each item before dispatching async tasks

Tests:
- Add unit test for serialize_listing_item to verify nested attribute serialization
- Add integration-style test for AsyncProductImportMixin and AmazonProductItemFactory to mock deserialization and ensure correct processing