### PR TITLE
Optimize Amazon async import client usage

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/tasks.py
+++ b/OneSila/sales_channels/integrations/amazon/tasks.py
@@ -25,7 +25,7 @@ def amazon_import_db_task(import_process, sales_channel):
 @remote_task(priority=LOW_PRIORITY)
 @db_task()
 def amazon_product_import_item_task(
-    import_process_id, sales_channel_id, product_data, is_last=False, updated_with=None
+    import_process_id, sales_channel_id, product_data, is_last=False, updated_with=None, client=None
 ):
     from sales_channels.integrations.amazon.factories.imports.products_imports import AmazonProductItemFactory
     from imports_exports.models import Import
@@ -39,6 +39,7 @@ def amazon_product_import_item_task(
         sales_channel=channel,
         is_last=is_last,
         updated_with=updated_with,
+        client=client,
     )
     fac.run()
 

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_tasks.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_tasks.py
@@ -40,3 +40,5 @@ class SerializationHelpersTest(TestCase):
         self.assertIsInstance(first, dict)
         self.assertEqual(first["sku"], "SKU1")
         self.assertEqual(first["product_tpe"], "CHAIR")
+
+


### PR DESCRIPTION
## Summary
- instantiate a single API client for `AmazonProductsAsyncImportProcessor`
- send the shared client via keyword args when dispatching tasks
- let `AmazonProductItemFactory` fall back to its own client when none provided
- drop temporary client test

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_tasks --noinput` *(fails: connection to server at "localhost" (::1), port 5432 failed)*


------
https://chatgpt.com/codex/tasks/task_e_688d2a5b1eb0832eab52a4a3e95062c2

## Summary by Sourcery

Share a single Amazon API client instance across the async product import workflow to reduce redundant client creations and streamline task execution.

Enhancements:
- Instantiate and store a single API client in AmazonProductsAsyncImportProcessor.
- Extend dispatch_task to forward the shared client to safe_run_task.
- Add optional client parameters to amazon_product_import_item_task and AmazonProductItemFactory, with fallback to internal client instantiation.
- Update factory run method to use the provided client or fall back to its own instance.