### PR TITLE
Refactor Amazon import to use dict access

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/helpers.py
+++ b/OneSila/sales_channels/integrations/amazon/helpers.py
@@ -11,11 +11,16 @@ logger = logging.getLogger(__name__)
 
 def infer_product_type(data) -> str:
     """Infer local product type from Amazon relationships data."""
-    relationships = data.relationships
+    if isinstance(data, dict):
+        relationships = data.get("relationships") or []
+    else:
+        relationships = getattr(data, "relationships", []) or []
 
     for relation in relationships:
-        for rel in relation.relationships:
-            if rel.child_skus:
+        rels = relation.get("relationships", []) if isinstance(relation, dict) else getattr(relation, "relationships", []) or []
+        for rel in rels:
+            child_skus = rel.get("child_skus") if isinstance(rel, dict) else getattr(rel, "child_skus", None)
+            if child_skus:
                 return CONFIGURABLE
 
     return SIMPLE
@@ -85,12 +90,16 @@ def extract_amazon_attribute_value(entry: dict, code: str) -> str | None:
 
 def get_is_product_variation(data):
     """Return whether the product is a variation and its parent SKUs if present."""
-    relationships = getattr(data, 'relationships', []) or []
+    if isinstance(data, dict):
+        relationships = data.get("relationships") or []
+    else:
+        relationships = getattr(data, "relationships", []) or []
     parent_skus = []
 
     for relation in relationships:
-        for rel in getattr(relation, 'relationships', []) or []:
-            parent_sku = getattr(rel, 'parent_sku', None)
+        rels = relation.get("relationships", []) if isinstance(relation, dict) else getattr(relation, "relationships", []) or []
+        for rel in rels:
+            parent_sku = rel.get("parent_sku") if isinstance(rel, dict) else getattr(rel, "parent_sku", None)
             if parent_sku:
                 parent_skus.append(parent_sku)
 


### PR DESCRIPTION
## Summary
- avoid attribute access on imported product data
- handle dictionary input in Amazon helper functions

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py OneSila/sales_channels/integrations/amazon/helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_688d3c9ab2b8832e925caf4a9a4ff52d

## Summary by Sourcery

Refactor Amazon product import pipeline and helper functions to use dictionary access for product data and support inputs as dicts

Enhancements:
- Replace attribute and getattr access on imported product data with dict.get calls across products_imports.py
- Add handling for dictionary inputs in infer_product_type and get_is_product_variation helper functions