### PR TITLE
feat: support manual product sync signal

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/tests/helpers.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/helpers.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+
 class DisableWooCommerceSignalsMixin:
     """Mixin to disable WooCommerce receivers during Amazon tests."""
 
@@ -8,6 +9,7 @@ class DisableWooCommerceSignalsMixin:
         "delete_remote_product",
         "update_remote_product",
         "sync_remote_product",
+        "manual_sync_remote_product",
         "create_remote_product_property",
         "update_remote_product_property",
         "delete_remote_product_property",

--- a/OneSila/sales_channels/integrations/magento2/receivers.py
+++ b/OneSila/sales_channels/integrations/magento2/receivers.py
@@ -14,7 +14,7 @@ from sales_channels.signals import create_remote_property, update_remote_propert
     update_remote_product_content, add_remote_product_variation, remove_remote_product_variation, \
     create_remote_image_association, \
     update_remote_image_association, delete_remote_image_association, delete_remote_image, update_remote_product, \
-    sync_remote_product, \
+    sync_remote_product, manual_sync_remote_product, \
     sales_view_assign_updated, delete_remote_product, update_remote_product_eancode, update_remote_vat_rate, \
     create_remote_vat_rate
 
@@ -317,6 +317,7 @@ def sales_channels__magento__product__update(sender, instance, **kwargs):
 
 
 @receiver(sync_remote_product, sender='products.Product')
+@receiver(manual_sync_remote_product, sender='products.Product')
 def sales_channels__magento__product__sync(sender, instance, **kwargs):
     from .tasks import sync_magento_product_db_task
     from products.product_types import CONFIGURABLE
@@ -337,6 +338,8 @@ def sales_channels__magento__product__sync(sender, instance, **kwargs):
 
 @receiver(sync_remote_product, sender='sales_channels.RemoteProduct')
 @receiver(sync_remote_product, sender='magento2.MagentoProduct')
+@receiver(manual_sync_remote_product, sender='sales_channels.RemoteProduct')
+@receiver(manual_sync_remote_product, sender='magento2.MagentoProduct')
 def sales_channels__magento__product__sync(sender, instance, **kwargs):
     from .tasks import sync_magento_product_db_task
     from products.product_types import CONFIGURABLE

--- a/OneSila/sales_channels/integrations/shopify/receivers.py
+++ b/OneSila/sales_channels/integrations/shopify/receivers.py
@@ -15,6 +15,7 @@ from sales_channels.signals import (
     delete_remote_product,
     update_remote_product,
     sync_remote_product,
+    manual_sync_remote_product,
     create_remote_product_property,
     update_remote_product_property,
     delete_remote_product_property,
@@ -118,6 +119,7 @@ def shopify__product__delete_from_product(sender, instance, **kwargs):
 # 5) Sync product
 #
 @receiver(sync_remote_product, sender='products.Product')
+@receiver(manual_sync_remote_product, sender='products.Product')
 def shopify__product__sync_from_local(sender, instance, **kwargs):
     # number of calls = 1 + variations
     count = 1 + (instance.get_configurable_variations().count()
@@ -133,6 +135,7 @@ def shopify__product__sync_from_local(sender, instance, **kwargs):
 
 
 @receiver(sync_remote_product, sender='shopify.ShopifyProduct')
+@receiver(manual_sync_remote_product, sender='shopify.ShopifyProduct')
 def shopify__product__sync_from_remote(sender, instance, **kwargs):
     product = instance.local_instance
     count = 1 + (getattr(product, 'get_configurable_variations', lambda: [])().count())

--- a/OneSila/sales_channels/integrations/woocommerce/receivers.py
+++ b/OneSila/sales_channels/integrations/woocommerce/receivers.py
@@ -11,6 +11,7 @@ from sales_channels.signals import (
     delete_remote_product,
     update_remote_product,
     sync_remote_product,
+    manual_sync_remote_product,
     create_remote_product_property,
     update_remote_product_property,
     delete_remote_product_property,
@@ -121,6 +122,7 @@ def woocommerce__product__delete_from_product(sender, instance, **kwargs):
 # 5) Sync product
 #
 @receiver(sync_remote_product, sender='products.Product')
+@receiver(manual_sync_remote_product, sender='products.Product')
 def woocommerce__product__sync_from_local(sender, instance, **kwargs):
     # number of calls = 1 + variations
     count = 1 + (instance.get_configurable_variations().count()
@@ -136,6 +138,7 @@ def woocommerce__product__sync_from_local(sender, instance, **kwargs):
 
 
 @receiver(sync_remote_product, sender='woocommerce.WoocommerceProduct')
+@receiver(manual_sync_remote_product, sender='woocommerce.WoocommerceProduct')
 def woocommerce__product__sync_from_remote(sender, instance, **kwargs):
     product = instance.local_instance
     count = 1 + (getattr(product, 'get_configurable_variations', lambda: [])().count())

--- a/OneSila/sales_channels/schema/mutations/mutation_classes.py
+++ b/OneSila/sales_channels/schema/mutations/mutation_classes.py
@@ -3,7 +3,7 @@ from core.schema.core.mixins import GetCurrentUserMixin
 from core.schema.core.mutations import Info, Any
 from core.schema.core.mutations import UpdateMutation
 from sales_channels.models import SalesChannelViewAssign, SalesChannel
-from sales_channels.signals import sync_remote_product, refresh_website_pull_models
+from sales_channels.signals import manual_sync_remote_product, refresh_website_pull_models
 from django.utils.translation import gettext_lazy as _
 
 
@@ -13,7 +13,7 @@ class ResyncSalesChannelAssignMutation(UpdateMutation, GetCurrentUserMixin):
         if instance.remote_product.syncing_current_percentage != 100:
             raise ValidationError(_("You can't resync the product because is currently syncing."))
 
-        sync_remote_product.send(sender=instance.remote_product.__class__, instance=instance.remote_product)
+        manual_sync_remote_product.send(sender=instance.remote_product.__class__, instance=instance.remote_product)
 
         return instance
 

--- a/OneSila/sales_channels/signals.py
+++ b/OneSila/sales_channels/signals.py
@@ -32,6 +32,7 @@ sales_channel_created = ModelSignal(use_caching=True)
 create_remote_product = ModelSignal(use_caching=True)
 update_remote_product = ModelSignal(use_caching=True)
 sync_remote_product = ModelSignal(use_caching=True)
+manual_sync_remote_product = ModelSignal(use_caching=True)
 delete_remote_product = ModelSignal(use_caching=True)
 
 sales_view_assign_updated = ModelSignal(use_caching=True)


### PR DESCRIPTION
## Summary
- add manual_sync_remote_product signal and use it for user-triggered resync
- update Magento, WooCommerce, and Shopify receivers to handle manual sync
- patch test helpers for new signal

## Testing
- `pre-commit run --files OneSila/sales_channels/signals.py OneSila/sales_channels/schema/mutations/mutation_classes.py OneSila/sales_channels/integrations/magento2/receivers.py OneSila/sales_channels/integrations/woocommerce/receivers.py OneSila/sales_channels/integrations/shopify/receivers.py OneSila/sales_channels/integrations/amazon/tests/helpers.py`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68908b2599c4832ea82a48576e4649b1