### PR TITLE
feat: prevent variation SKU duplication

### DIFF
--- a/OneSila/sales_channels/exceptions.py
+++ b/OneSila/sales_channels/exceptions.py
@@ -22,3 +22,9 @@ class PreFlightCheckError(Exception):
     Exception raised when a pre-flight check fails.
     """
     pass
+
+
+class VariationAlreadyExistsOnWebsite(Exception):
+    """Raised when attempting to create a variation that already exists as a
+    standalone product on the remote sales channel."""
+    pass

--- a/OneSila/sales_channels/factories/products/products.py
+++ b/OneSila/sales_channels/factories/products/products.py
@@ -2,7 +2,12 @@ from integrations.models import IntegrationLog
 from media.models import MediaProductThrough, Media
 from products.models import Product
 from properties.models import ProductProperty
-from sales_channels.exceptions import SwitchedToSyncException, SwitchedToCreateException, ConfigurationMissingError
+from sales_channels.exceptions import (
+    SwitchedToSyncException,
+    SwitchedToCreateException,
+    ConfigurationMissingError,
+    VariationAlreadyExistsOnWebsite,
+)
 from sales_channels.factories.mixins import IntegrationInstanceOperationMixin, RemoteInstanceDeleteFactory, \
     EanCodeValueMixin, SyncProgressMixin
 import logging
@@ -33,6 +38,10 @@ class RemoteProductSyncFactory(IntegrationInstanceOperationMixin, EanCodeValueMi
     delete_product_factory = None
     add_variation_factory = None
     accepted_variation_already_exists_error = None
+
+    # Determines whether the sales channel allows duplicate SKUs across
+    # standalone products and variations.
+    sales_channel_allow_duplicate_sku = False
 
     field_mapping = {}  # Mapping of local fields to remote fields, should be overridden in subclasses
 
@@ -72,6 +81,32 @@ class RemoteProductSyncFactory(IntegrationInstanceOperationMixin, EanCodeValueMi
 
     def preflight_check(self):
         return True
+
+    def sanity_check(self):
+        """Run pre-sync validations."""
+
+        if (
+            not self.sales_channel_allow_duplicate_sku
+            and self.local_instance.is_configurable()
+        ):
+            variations = self.local_instance.get_configurable_variations(active_only=True)
+            variation_ids = [v.id for v in variations]
+            conflicted_ids = SalesChannelViewAssign.objects.filter(
+                product_id__in=variation_ids,
+                sales_channel=self.sales_channel,
+                remote_product__isnull=False,
+            ).values_list("product_id", flat=True)
+
+            if conflicted_ids:
+                sku_map = {v.id: v.sku for v in variations}
+                conflicted_skus = [sku_map[pid] for pid in conflicted_ids]
+                skus = ", ".join(conflicted_skus)
+                raise VariationAlreadyExistsOnWebsite(
+                    f"Variations with SKU(s) {skus} already exist on this sales channel. "
+                    "Remove them before syncing as a configurable product."
+                )
+
+        # Additional sanity checks can be added with new `if` blocks above.
 
     def add_field_in_payload(self, field_name, value):
         """
@@ -864,6 +899,8 @@ class RemoteProductSyncFactory(IntegrationInstanceOperationMixin, EanCodeValueMi
         if self.create_product_factory is None:
             raise ValueError("create_product_factory must be specified in the RemoteProductSyncFactory.")
 
+        self.sanity_check()
+
         fac = self.create_product_factory(self.sales_channel, self.local_instance, api=self.api)
         fac.run()
         self.remote_instance = fac.remote_instance
@@ -894,6 +931,8 @@ class RemoteProductSyncFactory(IntegrationInstanceOperationMixin, EanCodeValueMi
 
             if self.local_type == Product.CONFIGURABLE:
                 self.get_variations()
+
+            self.sanity_check()
 
             self.precalculate_progress_step_increment(4)
             self.set_local_assigns()
@@ -964,6 +1003,7 @@ class RemoteProductUpdateFactory(RemoteProductSyncFactory, SyncProgressMixin):
         try:
             self.initialize_remote_product()
             self.set_remote_product_for_logging()
+            self.sanity_check()
             self.precalculate_progress_step_increment(2)
             self.set_rule()
             self.build_payload()

--- a/OneSila/sales_channels/integrations/magento2/models/sales_channels.py
+++ b/OneSila/sales_channels/integrations/magento2/models/sales_channels.py
@@ -3,6 +3,7 @@ from sales_channels.models.sales_channels import (
     SalesChannelView,
     RemoteLanguage
 )
+from sales_channels.exceptions import VariationAlreadyExistsOnWebsite
 
 from core import models
 from django.utils.translation import gettext_lazy as _
@@ -35,7 +36,7 @@ class MagentoSalesChannel(SalesChannel):
     class Meta:
         verbose_name = 'Magento Sales Channel'
         verbose_name_plural = 'Magento Sales Channels'
-        user_exceptions = ()
+        user_exceptions = (VariationAlreadyExistsOnWebsite,)
 
     def __str__(self):
         return f"Magento Sales Channel: {self.hostname}"

--- a/OneSila/sales_channels/integrations/shopify/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/shopify/factories/products/products.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 class ShopifyProductSyncFactory(GetShopifyApiMixin, RemoteProductSyncFactory):
     remote_model_class = ShopifyProduct
+    sales_channel_allow_duplicate_sku = True
 
     # Sub-factories for images, metafields, EAN, etc.
     remote_image_assign_create_factory = ShopifyMediaProductThroughCreateFactory

--- a/OneSila/sales_channels/integrations/woocommerce/models.py
+++ b/OneSila/sales_channels/integrations/woocommerce/models.py
@@ -7,6 +7,7 @@ from sales_channels.models.properties import RemoteProperty, \
     RemotePropertySelectValue, RemoteProductProperty
 from sales_channels.models.products import RemoteImageProductAssociation
 from django.utils.translation import gettext_lazy as _
+from sales_channels.exceptions import VariationAlreadyExistsOnWebsite
 
 
 class WoocommerceSalesChannel(SalesChannel):
@@ -37,6 +38,9 @@ class WoocommerceSalesChannel(SalesChannel):
                 raise Exception(
                     _("Could not connect to the Woocommerce server. Make sure all the details are correctly completed.")
                 )
+
+    class Meta:
+        user_exceptions = (VariationAlreadyExistsOnWebsite,)
 
 
 class WoocommerceSalesChannelView(SalesChannelView):


### PR DESCRIPTION
## Summary
- add VariationAlreadyExistsOnWebsite user exception
- add sanity check preventing duplicate SKUs on configurable sync
- allow Shopify to bypass duplicate SKU restriction
- optimize sanity check with single query and streamline exception handling

## Testing
- `pre-commit run --files OneSila/sales_channels/factories/products/products.py OneSila/sales_channels/integrations/magento2/models/sales_channels.py OneSila/sales_channels/integrations/woocommerce/models.py OneSila/sales_channels/exceptions.py OneSila/sales_channels/integrations/shopify/factories/products/products.py`
- `python OneSila/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68908e3627bc832e8587cdc194848ff3

## Summary by Sourcery

Prevent duplicate variation SKUs on configurable products by introducing a pre-sync sanity check and user-facing exception, while allowing Shopify to bypass this restriction.

New Features:
- Add VariationAlreadyExistsOnWebsite as a user exception for duplicate variation SKUs
- Introduce sales_channel_allow_duplicate_sku flag in RemoteProductSyncFactory and enable it for Shopify

Enhancements:
- Implement sanity_check in RemoteProductSyncFactory to detect and block duplicate variation SKUs with a single optimized query
- Invoke sanity_check at key points in the product sync flows