### PR TITLE
Add admin for Amazon import relationships

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/admin.py
+++ b/OneSila/sales_channels/integrations/amazon/admin.py
@@ -20,6 +20,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonImageProductAssociation,
     AmazonTaxCode,
     AmazonDefaultUnitConfigurator,
+    AmazonImportRelationship,
 )
 from sales_channels.integrations.amazon.models.properties import AmazonPublicDefinition
 from sales_channels.models import SalesChannelViewAssign
@@ -126,6 +127,13 @@ class AmazonTaxCodeAdmin(SalesChannelRemoteAdmin):
 @admin.register(AmazonDefaultUnitConfigurator)
 class AmazonDefaultUnitConfiguratorAdmin(SalesChannelRemoteAdmin):
     pass
+
+
+@admin.register(AmazonImportRelationship)
+class AmazonImportRelationshipAdmin(admin.ModelAdmin):
+    list_display = ("import_process", "parent_sku", "child_sku")
+    search_fields = ("parent_sku", "child_sku")
+    raw_id_fields = ("import_process",)
 
 
 @admin.register(AmazonPublicDefinition)


### PR DESCRIPTION
## Summary
- register AmazonImportRelationship in admin
- enable list, search and raw ID access for import relationships

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/admin.py`
- `coverage run --source='.' OneSila/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6890eba6ae00832ea43c383481dc615f

## Summary by Sourcery

New Features:
- Register AmazonImportRelationship in Django admin with list display, search fields, and raw ID access