### PR TITLE
feat: add GraphQL support for Amazon product issues

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -9,6 +9,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonDefaultUnitConfiguratorType,
     AmazonRemoteLogType,
     AmazonSalesChannelViewType,
+    AmazonProductIssueType,
 )
 
 
@@ -37,6 +38,9 @@ class AmazonSalesChannelsQuery:
 
     amazon_remote_log: AmazonRemoteLogType = node()
     amazon_remote_logs: DjangoListConnection[AmazonRemoteLogType] = connection()
+
+    amazon_product_issue: AmazonProductIssueType = node()
+    amazon_product_issues: DjangoListConnection[AmazonProductIssueType] = connection()
 
     amazon_channel_view: AmazonSalesChannelViewType = node()
     amazon_channel_views: DjangoListConnection[AmazonSalesChannelViewType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -15,6 +15,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannelImport, AmazonProductTypeItem,
     AmazonDefaultUnitConfigurator,
     AmazonRemoteLog,
+    AmazonProductIssue,
 )
 from properties.schema.types.filters import (
     PropertyFilter,
@@ -146,4 +147,11 @@ class AmazonDefaultUnitConfiguratorFilter(SearchFilterMixin):
 @filter(AmazonRemoteLog)
 class AmazonRemoteLogFilter(SearchFilterMixin):
     id: auto
+    remote_product: Optional[RemoteProductFilter]
+
+
+@filter(AmazonProductIssue)
+class AmazonProductIssueFilter(SearchFilterMixin):
+    id: auto
+    view: Optional[SalesChannelViewFilter]
     remote_product: Optional[RemoteProductFilter]

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -10,6 +10,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonDefaultUnitConfigurator,
     AmazonRemoteLog,
     AmazonSalesChannelView,
+    AmazonProductIssue,
 )
 
 
@@ -55,4 +56,9 @@ class AmazonSalesChannelViewOrder:
 
 @order(AmazonRemoteLog)
 class AmazonRemoteLogOrder:
+    id: auto
+
+
+@order(AmazonProductIssue)
+class AmazonProductIssueOrder:
     id: auto

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -20,6 +20,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonDefaultUnitConfigurator,
     AmazonRemoteLog,
     AmazonSalesChannelView,
+    AmazonProductIssue,
 )
 from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonSalesChannelFilter,
@@ -28,7 +29,7 @@ from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonProductTypeFilter,
     AmazonProductTypeItemFilter,
     AmazonSalesChannelImportFilter, AmazonDefaultUnitConfiguratorFilter,
-    AmazonRemoteLogFilter, AmazonSalesChannelViewFilter,
+    AmazonRemoteLogFilter, AmazonSalesChannelViewFilter, AmazonProductIssueFilter,
 )
 from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonSalesChannelOrder,
@@ -38,7 +39,7 @@ from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonProductTypeItemOrder,
     AmazonSalesChannelImportOrder,
     AmazonDefaultUnitConfiguratorOrder,
-    AmazonRemoteLogOrder, AmazonSalesChannelViewOrder,
+    AmazonRemoteLogOrder, AmazonSalesChannelViewOrder, AmazonProductIssueOrder,
 )
 from sales_channels.schema.types.types import FormattedIssueType
 
@@ -268,6 +269,24 @@ class AmazonRemoteLogType(relay.Node, GetQuerysetMultiTenantMixin):
             )
 
         return formatted
+
+
+@type(
+    AmazonProductIssue,
+    filters=AmazonProductIssueFilter,
+    order=AmazonProductIssueOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonProductIssueType(relay.Node, GetQuerysetMultiTenantMixin):
+    remote_product: Annotated[
+        'RemoteProductType',
+        lazy("sales_channels.schema.types.types")
+    ]
+    view: Annotated[
+        'AmazonSalesChannelViewType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]
 
 
 @strawberry_type


### PR DESCRIPTION
## Summary
- add `AmazonProductIssue` GraphQL type with filter and ordering
- expose product issue queries for Amazon integration

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/schema/queries.py OneSila/sales_channels/integrations/amazon/schema/types/filters.py OneSila/sales_channels/integrations/amazon/schema/types/ordering.py OneSila/sales_channels/integrations/amazon/schema/types/types.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689144076290832eaa944f204847a8fe

## Summary by Sourcery

Add comprehensive GraphQL support for Amazon product issues by defining the issue type, filters, ordering, and exposing related queries.

New Features:
- Define AmazonProductIssueType GraphQL node with all fields, filtering, ordering, and pagination
- Implement AmazonProductIssueFilter and AmazonProductIssueOrder to enable filtering and sorting of product issues
- Expose amazonProductIssue and amazonProductIssues queries in the AmazonSalesChannelsQuery schema