### PR TITLE
feat(amazon): allow validation-only listing updates

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -369,7 +369,9 @@ class GetAmazonAPIMixin:
         }
 
     @throttle_safe(max_retries=5, base_delay=1)
-    def create_product(self, sku, marketplace_id, product_type, attributes):
+    def create_product(
+        self, sku, marketplace_id, product_type, attributes, force_validation_only: bool = False
+    ):
         body = self._build_common_body(product_type, attributes)
         listings = ListingsApi(self._get_client())
 
@@ -387,7 +389,7 @@ class GetAmazonAPIMixin:
             marketplace_ids=[marketplace_id],
             body=body,
             issue_locale=self._get_issue_locale(),
-            mode="VALIDATION_PREVIEW" if settings.DEBUG else None,
+            mode="VALIDATION_PREVIEW" if settings.DEBUG or force_validation_only else None,
         )
 
         submission_id = getattr(response, "submission_id", None)
@@ -448,6 +450,7 @@ class GetAmazonAPIMixin:
         product_type,
         new_attributes,
         current_attributes=None,
+        force_validation_only: bool = False,
     ):
         if current_attributes is None or current_attributes == {}:
             current_attributes = self.get_listing_attributes(sku, marketplace_id)
@@ -465,7 +468,7 @@ class GetAmazonAPIMixin:
             marketplace_ids=[marketplace_id],
             body=body,
             issue_locale=self._get_issue_locale(),
-            mode="VALIDATION_PREVIEW" if settings.DEBUG else None,
+            mode="VALIDATION_PREVIEW" if settings.DEBUG or force_validation_only else None,
         )
         submission_id = getattr(response, "submission_id", None)
         processing_status = getattr(response, "status", None)

--- a/OneSila/sales_channels/integrations/amazon/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/products.py
@@ -86,12 +86,13 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
     create_product_factory = property(get_create_product_factory)
     delete_product_factory = property(get_delete_product_factory)
 
-    def __init__(self, *args, view=None, **kwargs):
+    def __init__(self, *args, view=None, force_validation_only: bool = False, **kwargs):
 
         if view is None:
             raise ValueError("AmazonProduct factories require a view argument")
 
         self.view = view
+        self.force_validation_only = force_validation_only
         super().__init__(*args, **kwargs)
         self.attributes: Dict = {}
         self.image_attributes: Dict = {}
@@ -631,6 +632,7 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
             remote_parent_product=self.remote_instance,
             api=self.api,
             view=self.view,
+            force_validation_only=self.force_validation_only,
         )
         factory.run()
         remote_variation = factory.remote_instance
@@ -661,6 +663,7 @@ class AmazonProductUpdateFactory(AmazonProductBaseFactory, RemoteProductUpdateFa
             self.remote_rule,
             self.payload.get("attributes", {}),
             self.current_attrs,
+            force_validation_only=self.force_validation_only,
         )
         return resp
 
@@ -681,6 +684,7 @@ class AmazonProductCreateFactory(AmazonProductBaseFactory, RemoteProductCreateFa
             marketplace_id=self.view.remote_id,
             product_type=self.remote_rule,
             attributes=self.payload.get("attributes", {}),
+            force_validation_only=self.force_validation_only,
         )
 
         return resp
@@ -713,6 +717,7 @@ class AmazonProductSyncFactory(AmazonProductBaseFactory, RemoteProductSyncFactor
             self.remote_rule,
             self.payload.get("attributes", {}),
             self.current_attrs,
+            force_validation_only=self.force_validation_only,
         )
         return resp
 


### PR DESCRIPTION
## Summary
- allow Amazon product factories to force validation-only calls
- add tests to ensure create/update respect validation mode

## Testing
- `python manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductFactoriesTest.test_create_product_factory_forces_validation_mode sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductFactoriesTest.test_update_product_factory_forces_validation_mode --settings=OneSila.settings.sqlite` *(fails: `sqlite3.OperationalError: near ")": syntax error`)*

------
https://chatgpt.com/codex/tasks/task_e_68914ae34b54832e897c0c8846933ef6