### PR TITLE
Add Amazon product GraphQL queries

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -3,6 +3,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonSalesChannelType,
     AmazonPropertyType,
     AmazonPropertySelectValueType,
+    AmazonProductType,
     AmazonProductTypeType,
     AmazonProductTypeItemType,
     AmazonSalesChannelImportType,
@@ -23,6 +24,9 @@ class AmazonSalesChannelsQuery:
 
     amazon_property_select_value: AmazonPropertySelectValueType = node()
     amazon_property_select_values: DjangoListConnection[AmazonPropertySelectValueType] = connection()
+
+    amazon_product: AmazonProductType = node()
+    amazon_products: DjangoListConnection[AmazonProductType] = connection()
 
     amazon_product_type: AmazonProductTypeType = node()
     amazon_product_types: DjangoListConnection[AmazonProductTypeType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -11,6 +11,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
     AmazonProperty,
     AmazonPropertySelectValue,
+    AmazonProduct,
     AmazonProductType,
     AmazonSalesChannelImport, AmazonProductTypeItem,
     AmazonDefaultUnitConfigurator,
@@ -23,6 +24,7 @@ from properties.schema.types.filters import (
     ProductPropertiesRuleFilter,
     ProductPropertiesRuleItemFilter,
 )
+from products.schema.types.filters import ProductFilter
 from sales_channels.schema.types.filters import (
     SalesChannelFilter,
     SalesChannelViewFilter,
@@ -120,6 +122,13 @@ class AmazonProductTypeItemFilter(SearchFilterMixin):
     local_instance: Optional[ProductPropertiesRuleItemFilter]
     remote_property: Optional[AmazonPropertyFilter]
     remote_type: auto
+
+
+@filter(AmazonProduct)
+class AmazonProductFilter(SearchFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]
+    local_instance: Optional[ProductFilter]
 
 
 @filter(AmazonSalesChannelImport)

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -4,6 +4,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
     AmazonProperty,
     AmazonPropertySelectValue,
+    AmazonProduct,
     AmazonProductType,
     AmazonProductTypeItem,
     AmazonSalesChannelImport,
@@ -26,6 +27,11 @@ class AmazonPropertyOrder:
 
 @order(AmazonPropertySelectValue)
 class AmazonPropertySelectValueOrder:
+    id: auto
+
+
+@order(AmazonProduct)
+class AmazonProductOrder:
     id: auto
 
 

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -14,6 +14,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
     AmazonProperty,
     AmazonPropertySelectValue,
+    AmazonProduct,
     AmazonProductType,
     AmazonProductTypeItem,
     AmazonSalesChannelImport,
@@ -26,6 +27,7 @@ from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonSalesChannelFilter,
     AmazonPropertyFilter,
     AmazonPropertySelectValueFilter,
+    AmazonProductFilter,
     AmazonProductTypeFilter,
     AmazonProductTypeItemFilter,
     AmazonSalesChannelImportFilter, AmazonDefaultUnitConfiguratorFilter,
@@ -35,6 +37,7 @@ from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonSalesChannelOrder,
     AmazonPropertyOrder,
     AmazonPropertySelectValueOrder,
+    AmazonProductOrder,
     AmazonProductTypeOrder,
     AmazonProductTypeItemOrder,
     AmazonSalesChannelImportOrder,
@@ -223,6 +226,28 @@ class AmazonSalesChannelViewType(relay.Node, GetQuerysetMultiTenantMixin):
     @field()
     def active(self, info) -> bool:
         return self.sales_channel.active
+
+
+@type(
+    AmazonProduct,
+    filters=AmazonProductFilter,
+    order=AmazonProductOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonProductType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'AmazonSalesChannelType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]
+    local_instance: Optional[Annotated[
+        'ProductType',
+        lazy("products.schema.types.types")
+    ]]
+
+    @field()
+    def has_errors(self, info) -> bool | None:
+        return self.has_errors
 
 
 @type(

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py
@@ -1,0 +1,11 @@
+AMAZON_PRODUCT_FILTER_BY_LOCAL_INSTANCE = """
+query ($localInstance: GlobalID!) {
+  amazonProducts(filters: {localInstance: {id: {exact: $localInstance}}}) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+"""

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/tests_queries.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/tests_queries.py
@@ -1,0 +1,38 @@
+from django.test import TransactionTestCase
+from model_bakery import baker
+
+from core.tests.tests_schemas.tests_queries import TransactionTestCaseMixin
+from sales_channels.integrations.amazon.models import AmazonSalesChannel, AmazonProduct
+from products.models import Product
+
+from .queries import AMAZON_PRODUCT_FILTER_BY_LOCAL_INSTANCE
+
+
+class AmazonProductQueryTest(TransactionTestCaseMixin, TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = baker.make(
+            AmazonSalesChannel,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.product = baker.make(
+            Product,
+            multi_tenant_company=self.multi_tenant_company,
+            type="SIMPLE",
+        )
+        self.amazon_product = baker.make(
+            AmazonProduct,
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+        )
+
+    def test_filter_by_local_instance(self):
+        resp = self.strawberry_test_client(
+            query=AMAZON_PRODUCT_FILTER_BY_LOCAL_INSTANCE,
+            variables={"localInstance": self.to_global_id(self.product)},
+        )
+        self.assertTrue(resp.errors is None)
+        edges = resp.data["amazonProducts"]["edges"]
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0]["node"]["id"], self.to_global_id(self.amazon_product))


### PR DESCRIPTION
## Summary
- expose `amazonProduct(s)` GraphQL queries
- allow filtering Amazon products by associated local instance
- cover Amazon product query filtering in tests

## Testing
- `python manage.py test sales_channels.integrations.amazon.tests.tests_schemas.tests_queries -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68914a53e690832eb8e074a66da18684

## Summary by Sourcery

Add AmazonProduct GraphQL support including list and node queries, filtering by local instance, ordering, pagination, and test coverage.

New Features:
- Expose AmazonProduct and AmazonProducts GraphQL queries

Enhancements:
- Add AmazonProduct filtering by local instance with corresponding filter and ordering classes
- Register AmazonProduct type in GraphQL schema with pagination and error flag field

Tests:
- Add tests for filtering Amazon products by local instance