### PR TITLE
Add timing decorator for Amazon import troubleshooting

### DIFF
--- a/OneSila/core/decorators.py
+++ b/OneSila/core/decorators.py
@@ -35,6 +35,28 @@ def timeit_and_log(logger, default_msg='', print_logger=False):
     return deco_timeit
 
 
+def track_time(logger, default_msg=''):
+    """
+    Measure execution time of the wrapped function and log it.
+
+    TODO: switch to logger.info once info logs are visible.
+    """
+    def deco_timeit(f):
+
+        @wraps(f)
+        def f_timeit(*args, **kwargs):
+            start = datetime.now()
+            result = f(*args, **kwargs)
+            stop = datetime.now()
+            msg = f"{default_msg} {f.__name__} took {stop - start}" if default_msg else f"{f.__name__} took {stop - start}"
+            logger.error(msg)  # TODO: use logger.info when logging configuration is fixed
+            return result
+
+        return f_timeit
+
+    return deco_timeit
+
+
 def trigger_pre_and_post_save(dirty_field, signal_pre=None, signal_post=None):
     """
     Trigger a pre-save and post-save signal on the save method.

--- a/OneSila/imports_exports/factories/products.py
+++ b/OneSila/imports_exports/factories/products.py
@@ -21,6 +21,7 @@ from sales_prices.models import SalesPrice
 from taxes.models import VatRate
 from currencies.currencies import iso_list
 from core.exceptions import ValidationError
+from core.decorators import track_time
 
 import logging
 logger = logging.getLogger(__name__)
@@ -361,6 +362,7 @@ class ImportProductInstance(AbstractImportInstance):
 
         self.product_property_instances = ProductProperty.objects.filter(id__in=product_property_ids)
 
+    @track_time(logger)
     def set_images(self):
 
         images_instances_ids = []
@@ -383,6 +385,7 @@ class ImportProductInstance(AbstractImportInstance):
         self.image_instances = Image.objects.filter(id__in=images_instances_ids)
         self.images_associations_instances = MediaProductThrough.objects.filter(id__in=images_instances_associations_ids)
 
+    @track_time(logger)
     def set_prices(self):
         sales_price_ids = []
         for price in self.prices:
@@ -393,6 +396,7 @@ class ImportProductInstance(AbstractImportInstance):
                 # if the price is wrong we will skip it
                 pass
 
+    @track_time(logger)
     def set_variations(self):
         from .variations import ImportConfiguratorVariationsInstance, ImportConfigurableVariationInstance
 
@@ -422,6 +426,7 @@ class ImportProductInstance(AbstractImportInstance):
 
         self.variations_products_instances = Product.objects.filter(id__in=variation_products_ids)
 
+    @track_time(logger)
     def set_bundle_variations(self):
         from .variations import ImportBundleVariationInstance
 
@@ -440,6 +445,7 @@ class ImportProductInstance(AbstractImportInstance):
 
         self.bundle_variations_instances = Product.objects.filter(id__in=variation_products_ids)
 
+    @track_time(logger)
     def set_alias_variations(self):
         from .variations import ImportAliasVariationInstance
 

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -34,6 +34,7 @@ from sales_channels.integrations.amazon.constants import AMAZON_INTERNAL_PROPERT
 from sales_channels.integrations.amazon.models.properties import AmazonPublicDefinition
 from sales_channels.models import SalesChannelViewAssign
 from core.helpers import ensure_serializable
+from core.decorators import track_time
 from dateutil.parser import parse
 import datetime
 from imports_exports.helpers import append_broken_record, increment_processed_records
@@ -458,6 +459,7 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
                 amazon_ean_code.ean_code = import_instance.ean_code
                 amazon_ean_code.save()
 
+    @track_time(logger)
     def handle_attributes(self, import_instance: ImportProductInstance):
         if hasattr(import_instance, "properties"):
             product_properties = import_instance.product_property_instances
@@ -493,6 +495,7 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
                 if updated:
                     remote_product_property.save()
 
+    @track_time(logger)
     def handle_translations(self, import_instance: ImportProductInstance):
         if hasattr(import_instance, "translations"):
             AmazonProductContent.objects.get_or_create(
@@ -501,6 +504,7 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
                 remote_product=import_instance.remote_instance,
             )
 
+    @track_time(logger)
     def handle_prices(self, import_instance: ImportProductInstance):
         if hasattr(import_instance, "prices"):
             remote_product = import_instance.remote_instance
@@ -529,6 +533,7 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
                 amazon_price.price_data = price_data
                 amazon_price.save()
 
+    @track_time(logger)
     def handle_images(self, import_instance: ImportProductInstance):
         if hasattr(import_instance, "images"):
             for image_ass in import_instance.images_associations_instances:
@@ -539,6 +544,7 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
                     remote_product=import_instance.remote_instance,
                 )
 
+    @track_time(logger)
     def handle_variations(self, import_instance: ImportProductInstance):
         theme = import_instance.data.get("__amazon_theme")
         if not theme:
@@ -585,6 +591,7 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
             ) from e
 
 
+    @track_time(logger)
     def process_product_item(self, product):
         from sales_channels.integrations.amazon.factories.sales_channels.issues import FetchRemoteIssuesFactory
 
@@ -740,6 +747,7 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin):
             response_data=product
         ).run()
 
+    @track_time(logger)
     def import_products_process(self):
         for product in self.get_products_data():
             self.process_product_item(product)
@@ -763,6 +771,7 @@ class AmazonProductItemFactory(AmazonProductsImportProcessor):
         self.is_last = is_last
         self.updated_with = updated_with
 
+    @track_time(logger)
     def run(self):
         try:
             self.process_product_item(self.product_data)


### PR DESCRIPTION
## Summary
- add `track_time` decorator that logs execution time (temporarily at error level)
- instrument heavy Amazon import and product instance methods with timing logs

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68914d5653e4832ebe962b5b5ddcb981

## Summary by Sourcery

Introduce a timing decorator to track execution duration and apply it to key Amazon import and product import methods to aid in performance analysis

New Features:
- Add track_time decorator to measure and log function execution times

Enhancements:
- Instrument Amazon import methods and product import factory methods with the timing decorator for performance troubleshooting