### PR TITLE
feat(amazon): refresh and resync without assignment

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/input.py
@@ -3,6 +3,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
     AmazonProperty,
     AmazonPropertySelectValue,
+    AmazonProduct,
     AmazonProductType,
     AmazonProductTypeItem,
     AmazonSalesChannelImport,
@@ -68,6 +69,16 @@ class AmazonProductTypeItemInput:
 
 @partial(AmazonProductTypeItem, fields="__all__")
 class AmazonProductTypeItemPartialInput(NodeInput):
+    pass
+
+
+@input(AmazonProduct, fields="__all__")
+class AmazonProductInput:
+    pass
+
+
+@partial(AmazonProduct, fields="__all__")
+class AmazonProductPartialInput(NodeInput):
     pass
 
 


### PR DESCRIPTION
## Summary
- handle Amazon product IDs and views directly in latest issue refresh
- add mutation to manually resync an Amazon product with optional validation

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/schema/types/input.py OneSila/sales_channels/integrations/amazon/schema/mutations.py`
- `pytest OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_689152a96814832e94ca36a9ceccf305

## Summary by Sourcery

Enable direct refresh of Amazon listing issues using product and view inputs and add a mutation to manually resync Amazon products

New Features:
- Allow refresh_amazon_latest_issues mutation to refresh listing issues by providing AmazonProduct and AmazonSalesChannelView inputs directly
- Introduce resync_amazon_product mutation to manually trigger an Amazon product synchronization with an optional validation-only flag

Enhancements:
- Add AmazonProductPartialInput GraphQL input type for AmazonProduct to support the new mutations