### PR TITLE
Expose Amazon product issues via GraphQL

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -244,6 +244,10 @@ class AmazonProductType(relay.Node, GetQuerysetMultiTenantMixin):
         'ProductType',
         lazy("products.schema.types.types")
     ]]
+    issues: List[Annotated[
+        'AmazonProductIssueType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]]
 
     @field()
     def has_errors(self, info) -> bool | None:

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py
@@ -9,3 +9,17 @@ query ($localInstance: GlobalID!) {
   }
 }
 """
+
+AMAZON_PRODUCT_WITH_ISSUES = """
+query ($id: GlobalID!) {
+  amazonProduct(id: $id) {
+    id
+    issues {
+      code
+      message
+      severity
+      isValidationIssue
+    }
+  }
+}
+"""

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/tests_queries.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/tests_queries.py
@@ -2,10 +2,18 @@ from django.test import TransactionTestCase
 from model_bakery import baker
 
 from core.tests.tests_schemas.tests_queries import TransactionTestCaseMixin
-from sales_channels.integrations.amazon.models import AmazonSalesChannel, AmazonProduct
+from sales_channels.integrations.amazon.models import (
+    AmazonSalesChannel,
+    AmazonProduct,
+    AmazonProductIssue,
+    AmazonSalesChannelView,
+)
 from products.models import Product
 
-from .queries import AMAZON_PRODUCT_FILTER_BY_LOCAL_INSTANCE
+from .queries import (
+    AMAZON_PRODUCT_FILTER_BY_LOCAL_INSTANCE,
+    AMAZON_PRODUCT_WITH_ISSUES,
+)
 
 
 class AmazonProductQueryTest(TransactionTestCaseMixin, TransactionTestCase):
@@ -36,3 +44,46 @@ class AmazonProductQueryTest(TransactionTestCaseMixin, TransactionTestCase):
         edges = resp.data["amazonProducts"]["edges"]
         self.assertEqual(len(edges), 1)
         self.assertEqual(edges[0]["node"]["id"], self.to_global_id(self.amazon_product))
+
+
+class AmazonProductIssuesQueryTest(TransactionTestCaseMixin, TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = baker.make(
+            AmazonSalesChannel,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.product = baker.make(
+            Product,
+            multi_tenant_company=self.multi_tenant_company,
+            type="SIMPLE",
+        )
+        self.amazon_product = baker.make(
+            AmazonProduct,
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+        )
+        self.view = baker.make(
+            AmazonSalesChannelView,
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.issue = baker.make(
+            AmazonProductIssue,
+            remote_product=self.amazon_product,
+            view=self.view,
+            multi_tenant_company=self.multi_tenant_company,
+            code="ISSUE_CODE",
+            message="Problem",
+        )
+
+    def test_product_issues(self):
+        resp = self.strawberry_test_client(
+            query=AMAZON_PRODUCT_WITH_ISSUES,
+            variables={"id": self.to_global_id(self.amazon_product)},
+        )
+        self.assertTrue(resp.errors is None)
+        issues = resp.data["amazonProduct"]["issues"]
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0]["code"], self.issue.code)


### PR DESCRIPTION
## Summary
- expose `issues` relation on AmazonProduct GraphQL type
- add query helper and test to fetch product issues

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/schema/types/types.py OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py OneSila/sales_channels/integrations/amazon/tests/tests_schemas/tests_queries.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_schemas.tests_queries.AmazonProductIssuesQueryTest.test_product_issues -v 2` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689152dd9424832ebc3217b97e791422