### PR TITLE
Add Amazon resync manual sync receiver

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/flows/tasks_runner.py
+++ b/OneSila/sales_channels/integrations/amazon/flows/tasks_runner.py
@@ -51,6 +51,31 @@ def run_product_amazon_sales_channel_task_flow(
                 )
 
 
+def run_single_amazon_product_task_flow(
+    task_func,
+    view,
+    number_of_remote_requests=None,
+    **kwargs,
+):
+    """Queue a task for a specific Amazon product and view."""
+    sales_channel = view.sales_channel
+
+    task_kwargs = {
+        "sales_channel_id": sales_channel.id,
+        "view_id": view.id,
+        **kwargs,
+    }
+
+    transaction.on_commit(
+        lambda lb_task_kwargs=task_kwargs, integration_id=sales_channel.id: add_task_to_queue(
+            integration_id=integration_id,
+            task_func_path=get_import_path(task_func),
+            task_kwargs=lb_task_kwargs,
+            number_of_remote_requests=number_of_remote_requests,
+        )
+    )
+
+
 def run_delete_product_specific_amazon_sales_channel_task_flow(
     task_func,
     remote_class,

--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -201,12 +201,15 @@ class AmazonSalesChannelMutation:
                 _("You can't resync the product because is currently syncing."),
             )
 
-        manual_sync_remote_product.send(
-            sender=remote_product.__class__,
-            instance=remote_product,
-            view=view,
-            force_validation_only=force_validation_only,
-        )
+        # @TODO: remove force once full resync support is implemented
+        force_validation_only = True
+        if force_validation_only:
+            manual_sync_remote_product.send(
+                sender=remote_product.__class__,
+                instance=remote_product,
+                view=view,
+                force_validation_only=force_validation_only,
+            )
 
         return remote_product
 

--- a/OneSila/sales_channels/integrations/amazon/tasks.py
+++ b/OneSila/sales_channels/integrations/amazon/tasks.py
@@ -1,7 +1,8 @@
 from huey.contrib.djhuey import db_task
-from core.huey import LOW_PRIORITY, HIGH_PRIORITY
+from core.huey import LOW_PRIORITY, HIGH_PRIORITY, CRUCIAL_PRIORITY
 from sales_channels.decorators import remote_task
 from core.decorators import run_task_after_commit
+from integrations.factories.remote_task import BaseRemoteTask
 
 
 @db_task()
@@ -55,3 +56,33 @@ def create_amazon_product_type_rule_task(product_type_code: str, sales_channel_i
         sales_channel=sales_channel,
     )
     fac.run()
+
+
+@remote_task(priority=CRUCIAL_PRIORITY, number_of_remote_requests=1)
+@db_task()
+def resync_amazon_product_db_task(
+    task_queue_item_id,
+    sales_channel_id,
+    product_id,
+    remote_product_id,
+    view_id,
+    force_validation_only=False,
+):
+    """Run the resync factory for an Amazon product."""
+    from products.models import Product
+    from .models import AmazonSalesChannel, AmazonProduct, AmazonSalesChannelView
+    from .factories.products import AmazonProductSyncFactory
+
+    task = BaseRemoteTask(task_queue_item_id)
+
+    def actual_task():
+        factory = AmazonProductSyncFactory(
+            sales_channel=AmazonSalesChannel.objects.get(id=sales_channel_id),
+            local_instance=Product.objects.get(id=product_id),
+            remote_instance=AmazonProduct.objects.get(id=remote_product_id),
+            view=AmazonSalesChannelView.objects.get(id=view_id),
+            force_validation_only=force_validation_only,
+        )
+        factory.run()
+
+    task.execute(actual_task)

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
@@ -1,8 +1,16 @@
 from unittest.mock import patch
 
 from core.tests import TestCase
-from sales_channels.integrations.amazon.models import AmazonSalesChannel
+from sales_channels.integrations.amazon.models import (
+    AmazonSalesChannel,
+    AmazonSalesChannelView,
+    AmazonProduct,
+)
 from sales_channels.integrations.amazon.models.properties import AmazonProductType
+from products.models import Product
+from sales_channels.signals import manual_sync_remote_product
+from sales_channels.integrations.amazon.tasks import resync_amazon_product_db_task
+from .helpers import DisableWooCommerceSignalsMixin
 
 
 class AmazonProductTypeReceiversTest(TestCase):
@@ -29,3 +37,40 @@ class AmazonProductTypeReceiversTest(TestCase):
             product_type_code=pt.product_type_code,
             sales_channel_id=pt.sales_channel_id,
         )
+
+
+class AmazonManualSyncReceiverTest(DisableWooCommerceSignalsMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="VIEW",
+        )
+        self.product = Product.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Product.SIMPLE,
+        )
+        self.remote_product = AmazonProduct.objects.create(
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+        )
+
+    @patch("sales_channels.integrations.amazon.receivers.run_single_amazon_product_task_flow")
+    def test_manual_sync_queues_task(self, flow_mock):
+        manual_sync_remote_product.send(
+            sender=AmazonProduct,
+            instance=self.remote_product,
+            view=self.view,
+            force_validation_only=True,
+        )
+
+        flow_mock.assert_called_once()
+        _, kwargs = flow_mock.call_args
+        self.assertEqual(kwargs["task_func"], resync_amazon_product_db_task)
+        self.assertTrue(kwargs["force_validation_only"])
+        self.assertEqual(kwargs["view"], self.view)


### PR DESCRIPTION
## Summary
- queue Amazon product resync via new manual sync receiver and background task
- force validation-only resync in GraphQL mutation until full sync support
- cover Amazon manual resync signal with tests

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_receivers.AmazonManualSyncReceiverTest.test_manual_sync_queues_task -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68928b55f180832ebb8b0c949d8aacb5

## Summary by Sourcery

Add manual sync support for Amazon products by queuing a dedicated background task via a new receiver and task runner, enforce validation-only mode in the GraphQL mutation, and cover the flow with a unit test.

New Features:
- Add resync_amazon_product_db_task to perform Amazon product synchronization in the background
- Introduce run_single_amazon_product_task_flow helper to queue individual Amazon product tasks
- Implement manual_sync_remote_product receiver to trigger granular resync tasks for Amazon products
- Force validation-only mode in the GraphQL resync_amazon_product mutation until full sync is supported

Tests:
- Add AmazonManualSyncReceiverTest to verify that manual sync signals enqueue the correct background task