### PR TITLE
Hotfix/amazon import improvements

### DIFF
--- a/OneSila/imports_exports/factories/media.py
+++ b/OneSila/imports_exports/factories/media.py
@@ -113,7 +113,7 @@ class ImportImageInstance(AbstractImportInstance):
 
         self.instance = None
         if not self.skip_create:
-            self.instance = Image.objects.create(**self.kwargs)
+            self.instance, _ = Image.objects.get_or_create(**self.kwargs)
 
     def post_process_logic(self):
 

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -781,8 +781,6 @@ class AmazonProductItemFactory(AmazonProductsImportProcessor):
 
     @timeit_and_log(logger, "AmazonProductItemFactory.run")
     def run(self):
-        logger.debug(F"AmazonProductItemFactory.run - channel: {self.sales_channel.remote_id}")
-
         try:
             self.process_product_item(self.product_data)
         except Exception as exc:  # capture unexpected errors

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -780,7 +780,7 @@ class AmazonProductItemFactory(AmazonProductsImportProcessor):
 
     @timeit_and_log(logger, "AmazonProductItemFactory.run")
     def run(self):
-        self._set_start_time(f"AmazonProductItemFactory.run - channel: {self.sales_channel.name}, lang: {self.language}")
+        self._set_start_time(f"AmazonProductItemFactory.run - channel: {self.sales_channel.remote_id} {self.sales_channel.country}, lang: {self.language}")
         try:
             self.process_product_item(self.product_data)
         except Exception as exc:  # capture unexpected errors

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -617,6 +617,8 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin, AddLogTimeen
         summary = self._get_summary(product)
         rule = self.get_product_rule(product)
         structured, language, view = self.get__product_data(product)
+        # Used for logging in the run() method
+        self.product_data_view = view
         missing_data = (
             not product.get("attributes")
             or not product.get("summaries")
@@ -780,7 +782,8 @@ class AmazonProductItemFactory(AmazonProductsImportProcessor):
 
     @timeit_and_log(logger, "AmazonProductItemFactory.run")
     def run(self):
-        logger.debug(F"AmazonProductItemFactory.run - channel: {self.sales_channel.remote_id} {self.sales_channel.country}, lang: {self.language}")
+        logger.debug(
+            F"AmazonProductItemFactory.run - channel: {self.sales_channel.remote_id} {self.sales_channel.country}, lang: {self.language}, view: {self.product_data_view}")
         try:
             self.process_product_item(self.product_data)
         except Exception as exc:  # capture unexpected errors

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -335,12 +335,12 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin, AddLogTimeen
         return remote_lang.local_instance if remote_lang else None
 
     @timeit_and_log(logger, "AmazonProductsImportProcessor.get__product_data")
-    def get__product_data(self, product_data):
+    def get__product_data(self, product_data, is_variation):
         summary = self._get_summary(product_data)
         asin = summary.get("asin")
         status = summary.get("status") or []
         sku = product_data.get("sku")
-        type = infer_product_type(product_data)
+        type = infer_product_type(product_data, is_variation)
         marketplace_id = summary.get("marketplace_id")
 
         name = summary.get("item_name")
@@ -616,7 +616,12 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin, AddLogTimeen
 
         summary = self._get_summary(product)
         rule = self.get_product_rule(product)
-        structured, language, view = self.get__product_data(product)
+        structured, language, view = self.get__product_data(product, is_variation)
+
+        # if on the main marketplaces was configurable because the other doesn't have relationships
+        # will return SIMPLE as default which is wrong
+        if remote_product:
+            structured['type'] = remote_product.local_instance.type
 
         missing_data = (
             not product.get("attributes")

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -617,8 +617,7 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin, AddLogTimeen
         summary = self._get_summary(product)
         rule = self.get_product_rule(product)
         structured, language, view = self.get__product_data(product)
-        # Used for logging in the run() method
-        self.product_data_view = view
+
         missing_data = (
             not product.get("attributes")
             or not product.get("summaries")
@@ -782,7 +781,7 @@ class AmazonProductItemFactory(AmazonProductsImportProcessor):
 
     @timeit_and_log(logger, "AmazonProductItemFactory.run")
     def run(self):
-        logger.debug(F"AmazonProductItemFactory.run - channel: {self.sales_channel.remote_id} {self.sales_channel.country}, view: {self.product_data_view}")
+        logger.debug(F"AmazonProductItemFactory.run - channel: {self.sales_channel.remote_id}")
 
         try:
             self.process_product_item(self.product_data)

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -780,6 +780,7 @@ class AmazonProductItemFactory(AmazonProductsImportProcessor):
 
     @timeit_and_log(logger, "AmazonProductItemFactory.run")
     def run(self):
+        self._set_start_time(f"AmazonProductItemFactory.run - channel: {self.sales_channel.name}, lang: {self.language}")
         try:
             self.process_product_item(self.product_data)
         except Exception as exc:  # capture unexpected errors

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -782,8 +782,8 @@ class AmazonProductItemFactory(AmazonProductsImportProcessor):
 
     @timeit_and_log(logger, "AmazonProductItemFactory.run")
     def run(self):
-        logger.debug(
-            F"AmazonProductItemFactory.run - channel: {self.sales_channel.remote_id} {self.sales_channel.country}, lang: {self.language}, view: {self.product_data_view}")
+        logger.debug(F"AmazonProductItemFactory.run - channel: {self.sales_channel.remote_id} {self.sales_channel.country}, view: {self.product_data_view}")
+
         try:
             self.process_product_item(self.product_data)
         except Exception as exc:  # capture unexpected errors

--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -780,7 +780,7 @@ class AmazonProductItemFactory(AmazonProductsImportProcessor):
 
     @timeit_and_log(logger, "AmazonProductItemFactory.run")
     def run(self):
-        self._set_start_time(f"AmazonProductItemFactory.run - channel: {self.sales_channel.remote_id} {self.sales_channel.country}, lang: {self.language}")
+        logger.debug(F"AmazonProductItemFactory.run - channel: {self.sales_channel.remote_id} {self.sales_channel.country}, lang: {self.language}")
         try:
             self.process_product_item(self.product_data)
         except Exception as exc:  # capture unexpected errors

--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -233,12 +233,12 @@ class GetAmazonAPIMixin:
 
         return sorted(product_types)
 
-    def get_all_products_by_marketplace(self, marketplace_id: str, listings_api, seller_id, issue_locale):
-        created_after = None
+    def get_all_products_by_marketplace(self, marketplace_id: str, listings_api, seller_id, issue_locale, given_created_after=None):
+
+        created_after = given_created_after
         while True:
             page_token = None
             last_created_date = None
-            total_results = 0
 
             logger.debug(f"[START CYCLE] created_after={created_after}")
 

--- a/OneSila/sales_channels/integrations/amazon/helpers.py
+++ b/OneSila/sales_channels/integrations/amazon/helpers.py
@@ -9,8 +9,12 @@ from core.helpers import ensure_serializable
 logger = logging.getLogger(__name__)
 
 
-def infer_product_type(data) -> str:
+def infer_product_type(data, is_variation) -> str:
     """Infer local product type from Amazon relationships data."""
+
+    if is_variation:
+        return SIMPLE
+
     if isinstance(data, dict):
         relationships = data.get("relationships") or []
     else:

--- a/OneSila/sales_channels/integrations/amazon/helpers.py
+++ b/OneSila/sales_channels/integrations/amazon/helpers.py
@@ -18,12 +18,20 @@ def infer_product_type(data) -> str:
 
     for relation in relationships:
         rels = relation.get("relationships", []) if isinstance(relation, dict) else getattr(relation, "relationships", []) or []
+
         for rel in rels:
+            rel_type = rel.get("type") if isinstance(rel, dict) else getattr(rel, "type", None)
+
+            # we only care about the type VARIATION
+            if rel_type != "VARIATION":
+                continue
+
             child_skus = rel.get("child_skus") if isinstance(rel, dict) else getattr(rel, "child_skus", None)
             if child_skus:
                 return CONFIGURABLE
 
     return SIMPLE
+
 
 
 def extract_description_and_bullets(attributes: dict) -> tuple[str | None, list[str]]:
@@ -102,6 +110,11 @@ def get_is_product_variation(data):
     for relation in relationships:
         rels = relation.get("relationships", []) if isinstance(relation, dict) else getattr(relation, "relationships", []) or []
         for rel in rels:
+
+            rel_type = rel.get("type") if isinstance(rel, dict) else getattr(rel, "type", None)
+            if rel_type != "VARIATION":
+                continue
+
             # Handle plural parent_skus list
             if isinstance(rel, dict):
                 skus = rel.get("parent_skus") or []


### PR DESCRIPTION
## Summary by Sourcery

Improve Amazon import logic by enhancing product type inference for variations, preserving existing types, adding import window control, and preventing duplicate media entries

Bug Fixes:
- Fix product type misclassification for Amazon product variations by refining relationship filtering

Enhancements:
- Add is_variation parameter to Amazon product type inference to correctly classify variation items
- Filter relationships by type "VARIATION" in infer_product_type and get_is_product_variation helpers
- Preserve remote product's existing type during import to prevent incorrect defaulting
- Introduce optional given_created_after parameter for get_all_products_by_marketplace to control import window
- Use get_or_create instead of create for Image instances in media imports to avoid duplicates