### PR TITLE
fix infer_product_type to always get SIMPLE

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -335,12 +335,12 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin, AddLogTimeen
         return remote_lang.local_instance if remote_lang else None
 
     @timeit_and_log(logger, "AmazonProductsImportProcessor.get__product_data")
-    def get__product_data(self, product_data):
+    def get__product_data(self, product_data, is_variation):
         summary = self._get_summary(product_data)
         asin = summary.get("asin")
         status = summary.get("status") or []
         sku = product_data.get("sku")
-        type = infer_product_type(product_data)
+        type = infer_product_type(product_data, is_variation)
         marketplace_id = summary.get("marketplace_id")
 
         name = summary.get("item_name")
@@ -616,7 +616,12 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin, AddLogTimeen
 
         summary = self._get_summary(product)
         rule = self.get_product_rule(product)
-        structured, language, view = self.get__product_data(product)
+        structured, language, view = self.get__product_data(product, is_variation)
+
+        # if on the main marketplaces was configurable because the other doesn't have relationships
+        # will return SIMPLE as default which is wrong
+        if remote_product:
+            structured['type'] = remote_product.local_instance.type
 
         missing_data = (
             not product.get("attributes")

--- a/OneSila/sales_channels/integrations/amazon/helpers.py
+++ b/OneSila/sales_channels/integrations/amazon/helpers.py
@@ -9,8 +9,12 @@ from core.helpers import ensure_serializable
 logger = logging.getLogger(__name__)
 
 
-def infer_product_type(data) -> str:
+def infer_product_type(data, is_variation) -> str:
     """Infer local product type from Amazon relationships data."""
+
+    if is_variation:
+        return SIMPLE
+
     if isinstance(data, dict):
         relationships = data.get("relationships") or []
     else:


### PR DESCRIPTION
## Summary by Sourcery

Fix product type inference to correctly classify variations as SIMPLE and avoid overriding remote product types.

Bug Fixes:
- Force infer_product_type to return SIMPLE when is_variation is true
- Update get__product_data signature and calls to pass is_variation flag to infer_product_type
- Preserve remote_product.local_instance.type in structured data when remote_product exists