### PR TITLE
Add property usage filters

### DIFF
--- a/OneSila/properties/schema/types/filters.py
+++ b/OneSila/properties/schema/types/filters.py
@@ -12,7 +12,7 @@ from properties.models import Property, ProductProperty, \
     ProductProperty, PropertySelectValue, PropertyTranslation, ProductPropertyTextTranslation, PropertySelectValueTranslation, ProductPropertiesRule, \
     ProductPropertiesRuleItem
 from products.schema.types.filters import ProductFilter
-from django.db.models import Q, F, Count
+from django.db.models import Q, F, Count, Exists, OuterRef
 from core.managers import QuerySet
 from strawberry import UNSET
 
@@ -24,6 +24,24 @@ class PropertyFilter(SearchFilterMixin, ExcluideDemoDataFilterMixin):
     is_product_type: auto
     type: auto
     internal_name: auto
+
+    @custom_filter
+    def used_in_products(
+        self,
+        queryset: QuerySet,
+        value: bool,
+        prefix: str,
+    ) -> tuple[QuerySet, Q]:
+        if value not in (None, UNSET):
+            usage_qs = ProductProperty._base_manager.filter(
+                property_id=OuterRef("pk"),
+                multi_tenant_company_id=OuterRef("multi_tenant_company_id"),
+            )
+            queryset = queryset.annotate(
+                has_usage=Exists(usage_qs)
+            ).filter(has_usage=value)
+
+        return queryset, Q()
 
     @custom_filter
     def missing_main_translation(
@@ -79,6 +97,25 @@ class PropertySelectValueFilter(SearchFilterMixin, ExcluideDemoDataFilterMixin):
     id: auto
     property: Optional[PropertyFilter]
     image: Optional[ImageFilter]
+
+    @custom_filter
+    def used_in_products(
+        self,
+        queryset: QuerySet,
+        value: bool,
+        prefix: str,
+    ) -> tuple[QuerySet, Q]:
+        if value not in (None, UNSET):
+            usage_qs = ProductProperty._base_manager.filter(
+                Q(value_select_id=OuterRef("pk"))
+                | Q(value_multi_select=OuterRef("pk")),
+                multi_tenant_company_id=OuterRef("multi_tenant_company_id"),
+            )
+            queryset = queryset.annotate(
+                has_usage=Exists(usage_qs)
+            ).filter(has_usage=value)
+
+        return queryset, Q()
 
     @custom_filter
     def is_product_type(self, queryset, value: bool, prefix: str):

--- a/OneSila/properties/tests/tests_schemas/queries.py
+++ b/OneSila/properties/tests/tests_schemas/queries.py
@@ -14,6 +14,14 @@ query Properties($missingTranslations: Boolean!) {
 }
 """
 
+PROPERTIES_USED_IN_PRODUCTS_QUERY = """
+query Properties($usedInProducts: Boolean!) {
+  properties(filters: {usedInProducts: $usedInProducts}) {
+    edges { node { id } }
+  }
+}
+"""
+
 PROPERTY_SELECT_VALUES_MISSING_MAIN_TRANSLATION_QUERY = """
 query PropertySelectValues($missingMainTranslation: Boolean!) {
   propertySelectValues(filters: {missingMainTranslation: $missingMainTranslation}) {
@@ -25,6 +33,14 @@ query PropertySelectValues($missingMainTranslation: Boolean!) {
 PROPERTY_SELECT_VALUES_MISSING_TRANSLATIONS_QUERY = """
 query PropertySelectValues($missingTranslations: Boolean!) {
   propertySelectValues(filters: {missingTranslations: $missingTranslations}) {
+    edges { node { id } }
+  }
+}
+"""
+
+PROPERTY_SELECT_VALUES_USED_IN_PRODUCTS_QUERY = """
+query PropertySelectValues($usedInProducts: Boolean!) {
+  propertySelectValues(filters: {usedInProducts: $usedInProducts}) {
     edges { node { id } }
   }
 }


### PR DESCRIPTION
## Summary
- add `used_in_products` filter for properties
- expose `used_in_products` filter for property select values
- add tests for filtering used property and select value records

## Testing
- `python manage.py test properties.tests.tests_filters.PropertyFilterUsedInProductsTestCase properties.tests.tests_filters.PropertySelectValueFilterUsedInProductsTestCase -v 2 --keepdb`

------
https://chatgpt.com/codex/tasks/task_e_6894e6924cb4832e904e134c076d7d28