### PR TITLE
Add filters to find products by sales channel view assignments

### DIFF
--- a/OneSila/products/schema/types/filters.py
+++ b/OneSila/products/schema/types/filters.py
@@ -79,6 +79,46 @@ class ProductFilter(SearchFilterMixin, ExcluideDemoDataFilterMixin):
 
         return queryset, Q()
 
+    @custom_filter
+    def assigned_to_sales_channel_view(
+        self,
+        queryset: QuerySet,
+        value: str,
+        prefix: str
+    ) -> tuple[QuerySet, Q]:
+
+        if value not in (None, UNSET):
+            _, view_id = from_base64(value)
+            assigns_qs = SalesChannelViewAssign.objects.filter(
+                product_id=OuterRef("pk"),
+                sales_channel_view_id=view_id,
+            )
+            queryset = queryset.annotate(
+                assigned_to_view=Exists(assigns_qs)
+            ).filter(assigned_to_view=True)
+
+        return queryset, Q()
+
+    @custom_filter
+    def not_assigned_to_sales_channel_view(
+        self,
+        queryset: QuerySet,
+        value: str,
+        prefix: str
+    ) -> tuple[QuerySet, Q]:
+
+        if value not in (None, UNSET):
+            _, view_id = from_base64(value)
+            assigns_qs = SalesChannelViewAssign.objects.filter(
+                product_id=OuterRef("pk"),
+                sales_channel_view_id=view_id,
+            )
+            queryset = queryset.annotate(
+                assigned_to_view=Exists(assigns_qs)
+            ).filter(assigned_to_view=False)
+
+        return queryset, Q()
+
 
 @filter(BundleProduct)
 class BundleProductFilter(SearchFilterMixin):

--- a/OneSila/products/tests/tests_filters.py
+++ b/OneSila/products/tests/tests_filters.py
@@ -1,0 +1,69 @@
+from django.test import TransactionTestCase
+from core.tests.tests_schemas.tests_queries import TransactionTestCaseMixin
+from products.models import SimpleProduct
+from sales_channels.models import SalesChannelViewAssign
+from sales_channels.integrations.amazon.models import (
+    AmazonSalesChannel,
+    AmazonSalesChannelView,
+)
+from .tests_schemas.queries import (
+    PRODUCTS_ASSIGNED_TO_VIEW_QUERY,
+    PRODUCTS_NOT_ASSIGNED_TO_VIEW_QUERY,
+)
+
+
+class ProductFilterSalesChannelViewTestCase(TransactionTestCaseMixin, TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            hostname="https://example.com",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.view1 = AmazonSalesChannelView.objects.create(
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.view2 = AmazonSalesChannelView.objects.create(
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.p1 = SimpleProduct.objects.create(multi_tenant_company=self.multi_tenant_company)
+        self.p2 = SimpleProduct.objects.create(multi_tenant_company=self.multi_tenant_company)
+        self.p3 = SimpleProduct.objects.create(multi_tenant_company=self.multi_tenant_company)
+
+        SalesChannelViewAssign.objects.create(
+            product=self.p1,
+            sales_channel_view=self.view1,
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        SalesChannelViewAssign.objects.create(
+            product=self.p3,
+            sales_channel_view=self.view2,
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def _query_ids(self, query, variables):
+        resp = self.strawberry_test_client(query=query, variables=variables)
+        self.assertIsNone(resp.errors)
+        expected_ids = {self.p1.id, self.p2.id, self.p3.id}
+        found_ids = {
+            int(self.from_global_id(edge["node"]["id"])[1])
+            for edge in resp.data["products"]["edges"]
+        }
+        return found_ids & expected_ids
+
+    def test_assigned_to_sales_channel_view(self):
+        ids = self._query_ids(
+            PRODUCTS_ASSIGNED_TO_VIEW_QUERY,
+            {"view": self.to_global_id(self.view1)},
+        )
+        self.assertSetEqual(ids, {self.p1.id})
+
+    def test_not_assigned_to_sales_channel_view(self):
+        ids = self._query_ids(
+            PRODUCTS_NOT_ASSIGNED_TO_VIEW_QUERY,
+            {"view": self.to_global_id(self.view1)},
+        )
+        self.assertSetEqual(ids, {self.p2.id, self.p3.id})

--- a/OneSila/products/tests/tests_schemas/queries.py
+++ b/OneSila/products/tests/tests_schemas/queries.py
@@ -33,3 +33,19 @@ query products($excludeDemoData: Boolean!) {
   }
 }
 """
+
+PRODUCTS_ASSIGNED_TO_VIEW_QUERY = """
+query Products($view: ID!) {
+  products(filters: {assignedToSalesChannelView: $view}) {
+    edges { node { id } }
+  }
+}
+"""
+
+PRODUCTS_NOT_ASSIGNED_TO_VIEW_QUERY = """
+query Products($view: ID!) {
+  products(filters: {notAssignedToSalesChannelView: $view}) {
+    edges { node { id } }
+  }
+}
+"""


### PR DESCRIPTION
## Summary
- add ProductFilter filters for products assigned to a SalesChannelView
- add ProductFilter filters for products not assigned to a SalesChannelView
- add tests for SalesChannelView assignment filters

## Testing
- `python OneSila/manage.py test products.tests.tests_filters.ProductFilterSalesChannelViewTestCase --verbosity=2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6894e7f41b80832e8bbb2bea6e2717ad

## Summary by Sourcery

Add custom filters to query products by their assignment to sales channel views and introduce tests to validate both assigned and unassigned scenarios

New Features:
- Add `assignedToSalesChannelView` filter to retrieve products linked to a specific SalesChannelView
- Add `notAssignedToSalesChannelView` filter to retrieve products not linked to a specific SalesChannelView

Tests:
- Add GraphQL queries and a TransactionTestCase to verify the new sales channel view assignment filters