### PR TITLE
Limit search term length

### DIFF
--- a/OneSila/core/managers/search.py
+++ b/OneSila/core/managers/search.py
@@ -34,6 +34,8 @@ class SearchQuerySetMixin:
         if fed the search_fields instead af grabbing them through the request which has been removed.
         """
         queryset = self
+        if search_term:
+            search_term = search_term[:100]
 
         # Apply keyword searches.
         def construct_search(field_name):
@@ -90,6 +92,8 @@ class SearchQuerySetMixin:
         return queryset, may_have_duplicates
 
     def search(self, search_term, multi_tenant_company=None):
+        if search_term:
+            search_term = search_term[:100]
         try:
             search_fields = self.model._meta.search_terms
         except AttributeError:


### PR DESCRIPTION
## Summary
- trim search query to maximum 100 characters to prevent server overload

## Testing
- `pre-commit run --files OneSila/core/managers/search.py`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6894f4bc6f2c832e908e2b85b39dc938

## Summary by Sourcery

Enhancements:
- Trim search terms to at most 100 characters in get_search_results and search methods to prevent server overload