### PR TITLE
feat: add multitenant manager for SalesChannelViewAssign

### DIFF
--- a/OneSila/sales_channels/managers.py
+++ b/OneSila/sales_channels/managers.py
@@ -1,7 +1,6 @@
 from core.managers import MultiTenantManager, MultiTenantQuerySet
 from polymorphic.managers import PolymorphicManager, PolymorphicQuerySet
 
-
 class RemoteProductConfiguratorQuerySet(PolymorphicQuerySet, MultiTenantQuerySet):
     """
     QuerySet for RemoteProductConfigurator with multitenancy and polymorphic support.
@@ -48,3 +47,14 @@ class RemoteProductConfiguratorManager(PolymorphicManager, MultiTenantManager):
     # Optionally, expose QuerySet methods directly on the Manager
     def create_from_remote_product(self, *args, **kwargs):
         return self.get_queryset().create_from_remote_product(*args, **kwargs)
+
+
+class SalesChannelViewAssignQuerySet(PolymorphicQuerySet, MultiTenantQuerySet):
+    """QuerySet for :class:`SalesChannelViewAssign` with multitenancy and polymorphic support."""
+
+
+class SalesChannelViewAssignManager(PolymorphicManager, MultiTenantManager):
+    """Manager for :class:`SalesChannelViewAssign` providing search and multitenancy."""
+
+    def get_queryset(self):
+        return SalesChannelViewAssignQuerySet(self.model, using=self._db)

--- a/OneSila/sales_channels/models/sales_channels.py
+++ b/OneSila/sales_channels/models/sales_channels.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from core.helpers import get_languages
 from integrations.models import Integration
 from sales_channels.models.mixins import RemoteObjectMixin
+from sales_channels.managers import SalesChannelViewAssignManager
 
 import logging
 
@@ -103,6 +104,8 @@ class SalesChannelViewAssign(PolymorphicModel, RemoteObjectMixin, models.Model):
     remote_product = models.ForeignKey('sales_channels.RemoteProduct', on_delete=models.SET_NULL, null=True,
                                        blank=True, help_text="The remote product associated with this assign.")
     needs_resync = models.BooleanField(default=False, help_text="Indicates if a resync is needed.")
+
+    objects = SalesChannelViewAssignManager()
 
     class Meta:
         unique_together = ('product', 'sales_channel_view')


### PR DESCRIPTION
## Summary
- add SalesChannelViewAssignQuerySet and SalesChannelViewAssignManager combining polymorphic and multitenant behavior
- use custom manager on SalesChannelViewAssign model

## Testing
- `python OneSila/manage.py test products_inspector.tests.tests_models` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*


------
https://chatgpt.com/codex/tasks/task_e_689507c29888832ea2dc81ca86c5588a