### PR TITLE
Include locale metadata for Amazon listing content

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/products/content.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/content.py
@@ -103,13 +103,30 @@ class AmazonProductContentUpdateFactory(GetAmazonAPIMixin, RemoteProductContentU
             )
 
         attrs = {}
+        language_tag = self.view.language_tag if self.view else None
+        marketplace_id = self.view.remote_id if self.view else None
         if item_name:
-            attrs["item_name"] = [{"value": item_name}]
+            attrs["item_name"] = [{
+                "value": item_name,
+                "language_tag": language_tag,
+                "marketplace_id": marketplace_id,
+            }]
         if is_safe_content(product_description):
-            attrs["product_description"] = [{"value": product_description}]
+            attrs["product_description"] = [{
+                "value": product_description,
+                "language_tag": language_tag,
+                "marketplace_id": marketplace_id,
+            }]
 
         if bullet_points:
-            attrs["bullet_point"] = [{"value": bp} for bp in bullet_points]
+            attrs["bullet_point"] = [
+                {
+                    "value": bp,
+                    "language_tag": language_tag,
+                    "marketplace_id": marketplace_id,
+                }
+                for bp in bullet_points
+            ]
 
         return {k: v for k, v in attrs.items() if v not in (None, "")}
 

--- a/OneSila/sales_channels/integrations/amazon/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/products.py
@@ -237,13 +237,30 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
             )
 
         attrs = {}
+        language_tag = self.view.language_tag if self.view else None
+        marketplace_id = self.view.remote_id if self.view else None
         if item_name:
-            attrs["item_name"] = [{"value": item_name}]
+            attrs["item_name"] = [{
+                "value": item_name,
+                "language_tag": language_tag,
+                "marketplace_id": marketplace_id,
+            }]
         if is_safe_content(product_description):
-            attrs["product_description"] = [{"value": product_description}]
+            attrs["product_description"] = [{
+                "value": product_description,
+                "language_tag": language_tag,
+                "marketplace_id": marketplace_id,
+            }]
 
         if bullet_points:
-            attrs["bullet_point"] = [{"value": bp} for bp in bullet_points]
+            attrs["bullet_point"] = [
+                {
+                    "value": bp,
+                    "language_tag": language_tag,
+                    "marketplace_id": marketplace_id,
+                }
+                for bp in bullet_points
+            ]
 
         return {k: v for k, v in attrs.items() if v not in (None, "")}
 

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py
@@ -169,11 +169,31 @@ class AmazonProductContentUpdateFactoryTest(DisableWooCommerceSignalsMixin, Test
             "productType": "CHAIR",
             "requirements": "LISTING",
             "attributes": {
-                "item_name": [{"value": "Chair name"}],
-                "product_description": [{"value": "Chair description"}],
+                "item_name": [
+                    {
+                        "value": "Chair name",
+                        "language_tag": "en",
+                        "marketplace_id": "GB",
+                    }
+                ],
+                "product_description": [
+                    {
+                        "value": "Chair description",
+                        "language_tag": "en",
+                        "marketplace_id": "GB",
+                    }
+                ],
                 "bullet_point": [
-                    {"value": "Point one"},
-                    {"value": "Point two"},
+                    {
+                        "value": "Point one",
+                        "language_tag": "en",
+                        "marketplace_id": "GB",
+                    },
+                    {
+                        "value": "Point two",
+                        "language_tag": "en",
+                        "marketplace_id": "GB",
+                    },
                 ],
             },
         }
@@ -184,18 +204,45 @@ class AmazonProductContentUpdateFactoryTest(DisableWooCommerceSignalsMixin, Test
         self.assertEqual(body.get("productType"), "CHAIR")
 
         self.assertIn(
-            {'op': 'add', 'path': '/attributes/item_name', 'value': [{'value': 'Chair name'}]},
+            {
+                'op': 'add',
+                'path': '/attributes/item_name',
+                'value': [{
+                    'value': 'Chair name',
+                    'language_tag': 'en',
+                    'marketplace_id': 'GB',
+                }],
+            },
             patches,
         )
         self.assertIn(
-            {'op': 'add', 'path': '/attributes/product_description', 'value': [{'value': 'Chair description'}]},
+            {
+                'op': 'add',
+                'path': '/attributes/product_description',
+                'value': [{
+                    'value': 'Chair description',
+                    'language_tag': 'en',
+                    'marketplace_id': 'GB',
+                }],
+            },
             patches,
         )
         self.assertIn(
             {
                 'op': 'add',
                 'path': '/attributes/bullet_point',
-                'value': [{'value': 'Point one'}, {'value': 'Point two'}],
+                'value': [
+                    {
+                        'value': 'Point one',
+                        'language_tag': 'en',
+                        'marketplace_id': 'GB',
+                    },
+                    {
+                        'value': 'Point two',
+                        'language_tag': 'en',
+                        'marketplace_id': 'GB',
+                    },
+                ],
             },
             patches,
         )

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
@@ -732,9 +732,27 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
 
         expected_attributes = {
             "merchant_suggested_asin": [{"value": "ASIN123"}],
-            "item_name": [{"value": "Chair name"}],
-            "product_description": [{"value": "Chair description"}],
-            "bullet_point": [{"value": "First bullet"}],
+            "item_name": [
+                {
+                    "value": "Chair name",
+                    "language_tag": "en",
+                    "marketplace_id": "GB",
+                }
+            ],
+            "product_description": [
+                {
+                    "value": "Chair description",
+                    "language_tag": "en",
+                    "marketplace_id": "GB",
+                }
+            ],
+            "bullet_point": [
+                {
+                    "value": "First bullet",
+                    "language_tag": "en",
+                    "marketplace_id": "GB",
+                }
+            ],
             "purchasable_offer": [
                 {
                     "audience": "ALL",
@@ -799,7 +817,15 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
         mock_instance = mock_listings.return_value
         mock_instance.patch_listings_item.return_value = self.get_put_and_patch_item_listing_mock_response()
 
-        current_attrs = {"item_name": "Old name"}
+        current_attrs = {
+            "item_name": [
+                {
+                    "value": "Old name",
+                    "language_tag": "en",
+                    "marketplace_id": "GB",
+                }
+            ]
+        }
         mock_instance.get_listings_item.return_value = SimpleNamespace(attributes=current_attrs)
 
         fac = AmazonProductUpdateFactory(
@@ -817,7 +843,11 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
             {
                 "op": "replace",
                 "path": "/attributes/item_name",
-                "value": [{"value": "Chair name"}],
+                "value": [{
+                    "value": "Chair name",
+                    "language_tag": "en",
+                    "marketplace_id": "GB",
+                }],
             },
             body["patches"]
         )
@@ -988,9 +1018,27 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
         }
         expected_attributes = {
             "merchant_suggested_asin": [{"value": "ASIN123"}],
-            "item_name": [{"value": "Chair name"}],
-            "product_description": [{"value": "Chair description"}],
-            "bullet_point": [{"value": "First bullet"}],
+            "item_name": [
+                {
+                    "value": "Chair name",
+                    "language_tag": "fr",
+                    "marketplace_id": "FR",
+                }
+            ],
+            "product_description": [
+                {
+                    "value": "Chair description",
+                    "language_tag": "fr",
+                    "marketplace_id": "FR",
+                }
+            ],
+            "bullet_point": [
+                {
+                    "value": "First bullet",
+                    "language_tag": "fr",
+                    "marketplace_id": "FR",
+                }
+            ],
             "purchasable_offer": [
                 {
                     "audience": "ALL",
@@ -1690,8 +1738,22 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
 
         body = mock_instance.put_listings_item.call_args.kwargs.get("body")
         attrs = body.get("attributes", {})
-        self.assertEqual(attrs.get("item_name"), [{"value": "Channel Name"}])
-        self.assertEqual(attrs.get("product_description"), [{"value": "Channel Description"}])
+        self.assertEqual(
+            attrs.get("item_name"),
+            [{
+                "value": "Channel Name",
+                "language_tag": "en",
+                "marketplace_id": "GB",
+            }],
+        )
+        self.assertEqual(
+            attrs.get("product_description"),
+            [{
+                "value": "Channel Description",
+                "language_tag": "en",
+                "marketplace_id": "GB",
+            }],
+        )
 
     @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
     @patch.object(AmazonMediaProductThroughBase, "_get_images", return_value=["https://example.com/img.jpg"])
@@ -1734,8 +1796,22 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
         body = mock_instance.put_listings_item.call_args.kwargs.get("body")
         attrs = body.get("attributes", {})
 
-        self.assertEqual(attrs.get("item_name"), [{"value": "Channel Name"}])
-        self.assertEqual(attrs.get("product_description"), [{"value": "Global Description"}])
+        self.assertEqual(
+            attrs.get("item_name"),
+            [{
+                "value": "Channel Name",
+                "language_tag": "en",
+                "marketplace_id": "GB",
+            }],
+        )
+        self.assertEqual(
+            attrs.get("product_description"),
+            [{
+                "value": "Global Description",
+                "language_tag": "en",
+                "marketplace_id": "GB",
+            }],
+        )
 
     @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
     @patch.object(AmazonMediaProductThroughBase, "_get_images", return_value=["https://example.com/img.jpg"])
@@ -1775,7 +1851,7 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
             ],
         )
 
-        self.assertEqual(attrs.get("list_price"),[{"currency": "GBP", "value_with_tax": 80.0}])
+        self.assertEqual(attrs.get("list_price"), [{"currency": "GBP", "value_with_tax": 80.0}])
 
     @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
     @patch.object(AmazonMediaProductThroughBase, "_get_images", return_value=["https://example.com/img.jpg"])
@@ -1927,9 +2003,35 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
         mock_instance = mock_listings.return_value
         mock_instance.put_listings_item.return_value = self.get_put_and_patch_item_listing_mock_response()
 
-        with patch.object(dummy, "get_listing_attributes", return_value={"item_name": [{"value": "Old"}]}) as mock_get:
+        with patch.object(
+            dummy,
+            "get_listing_attributes",
+            return_value={
+                "item_name": [
+                    {
+                        "value": "Old",
+                        "language_tag": "en",
+                        "marketplace_id": "GB",
+                    }
+                ]
+            },
+        ) as mock_get:
             product_type = AmazonProductType.objects.get(local_instance=self.rule)
-            dummy.update_product("AMZSKU", self.view.remote_id, product_type, {"item_name": [{"value": "New"}]}, None)
+            dummy.update_product(
+                "AMZSKU",
+                self.view.remote_id,
+                product_type,
+                {
+                    "item_name": [
+                        {
+                            "value": "New",
+                            "language_tag": "en",
+                            "marketplace_id": "GB",
+                        }
+                    ]
+                },
+                None,
+            )
 
             mock_get.assert_called_once_with("AMZSKU", self.view.remote_id)
 
@@ -1939,9 +2041,15 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
             {
                 "op": "replace",
                 "path": "/attributes/item_name",
-                "value": [{"value": "New"}],
+                "value": [
+                    {
+                        "value": "New",
+                        "language_tag": "en",
+                        "marketplace_id": "GB",
+                    }
+                ],
             },
-            patches
+            patches,
         )
 
 


### PR DESCRIPTION
## Summary
- attach `language_tag` and `marketplace_id` to Amazon item name, description, and bullet point attributes
- update Amazon factory tests for new attribute structure

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_content_factories sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories` *(fails: django.db.utils.OperationalError: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6895b5a5e8e8832ebd4b76b2b3b5ac1c

## Summary by Sourcery

Attach locale metadata to Amazon listing content attributes and update factories and tests to support the new attribute structure

New Features:
- Include language_tag and marketplace_id in item_name, product_description, and bullet_point attributes for Amazon listings

Enhancements:
- Update Amazon product and content factories to populate language_tag and marketplace_id in content attributes

Tests:
- Revise Amazon factory tests to validate the new attribute structure with language_tag and marketplace_id