### PR TITLE
Track Amazon product last sync time

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/migrations/0048_amazonproduct_last_sync_at.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0048_amazonproduct_last_sync_at.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0047_amazonimageproductassociation_imported_url'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='amazonproduct',
+            name='last_sync_at',
+            field=models.DateTimeField(blank=True, null=True, help_text='Timestamp of the last sync with Amazon.'),
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/products.py
+++ b/OneSila/sales_channels/integrations/amazon/models/products.py
@@ -41,6 +41,12 @@ class AmazonProduct(RemoteProduct):
         help_text="Indicates if this listing was created by us and we can manage listing level data.",
     )
 
+    last_sync_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text="Timestamp of the last sync with Amazon.",
+    )
+
     @property
     def remote_type(self):
         return self.get_remote_rule().product_type_code


### PR DESCRIPTION
## Summary
- add `last_sync_at` field to AmazonProduct
- record timestamp on manual or automatic product updates
- add regression test for update signal

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_receivers.AmazonProductLastSyncReceiverTest.test_last_sync_updated_on_update_signal -v 2` *(fails: django.db.utils.OperationalError: near ")": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68999935fc54832e85d5e60a62f3aa71