### PR TITLE
Prefer attribute item_name in Amazon importer

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -346,7 +346,7 @@ class AmazonProductsImportProcessor(ImportMixin, GetAmazonAPIMixin, AddLogTimeen
         product_type_code = summary.get("product_type")
         product_attrs = product_data.get("attributes") or {}
 
-        name = summary.get("item_name")
+        name = extract_amazon_attribute_value(product_attrs, "item_name") or summary.get("item_name")
 
         # it seems that sometimes the name can be None coming from Amazon. IN that case we fallback to sku
         if name is None:

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py
@@ -1,0 +1,63 @@
+from unittest.mock import patch
+
+from core.tests import TestCase
+from imports_exports.models import Import
+from sales_channels.integrations.amazon.factories.imports.products_imports import AmazonProductsImportProcessor
+from sales_channels.integrations.amazon.models import AmazonSalesChannel, AmazonSalesChannelView
+
+
+class AmazonProductsImportProcessorNameTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER"
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="GB",
+        )
+        self.import_process = Import.objects.create(multi_tenant_company=self.multi_tenant_company)
+
+    def test_name_from_attributes(self):
+        product_data = {
+            "sku": "SKU123",
+            "attributes": {"item_name": [{"value": "Attr name"}]},
+            "summaries": [{
+                "item_name": "Summary name",
+                "asin": "ASIN",
+                "marketplace_id": "GB",
+                "status": ["BUYABLE"],
+                "product_type": "TYPE",
+            }],
+        }
+        with patch.object(AmazonProductsImportProcessor, "get_api", return_value=None), \
+             patch.object(AmazonProductsImportProcessor, "_parse_images", return_value=[]), \
+             patch.object(AmazonProductsImportProcessor, "_parse_prices", return_value=[]), \
+             patch.object(AmazonProductsImportProcessor, "_parse_attributes", return_value=([], {})), \
+             patch.object(AmazonProductsImportProcessor, "_fetch_catalog_attributes", return_value=None):
+            processor = AmazonProductsImportProcessor(self.import_process, self.sales_channel)
+            structured, _, _ = processor.get__product_data(product_data, False)
+        self.assertEqual(structured["name"], "Attr name")
+
+    def test_name_fallback_to_summary(self):
+        product_data = {
+            "sku": "SKU123",
+            "attributes": {},
+            "summaries": [{
+                "item_name": "Summary name",
+                "asin": "ASIN",
+                "marketplace_id": "GB",
+                "status": ["BUYABLE"],
+                "product_type": "TYPE",
+            }],
+        }
+        with patch.object(AmazonProductsImportProcessor, "get_api", return_value=None), \
+             patch.object(AmazonProductsImportProcessor, "_parse_images", return_value=[]), \
+             patch.object(AmazonProductsImportProcessor, "_parse_prices", return_value=[]), \
+             patch.object(AmazonProductsImportProcessor, "_parse_attributes", return_value=([], {})), \
+             patch.object(AmazonProductsImportProcessor, "_fetch_catalog_attributes", return_value=None):
+            processor = AmazonProductsImportProcessor(self.import_process, self.sales_channel)
+            structured, _, _ = processor.get__product_data(product_data, False)
+        self.assertEqual(structured["name"], "Summary name")


### PR DESCRIPTION
## Summary
- Ensure Amazon product import uses `item_name` from attributes before falling back to summary
- Add tests covering name extraction from attributes and summary

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_products_imports -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6899a603969c832ea223f61d4310a726