### PR TITLE
Handle unmapping of Amazon property select values

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/receivers.py
@@ -8,6 +8,7 @@ from sales_channels.signals import (
 from sales_channels.integrations.amazon.models import (
     AmazonSalesChannel,
     AmazonProperty,
+    AmazonPropertySelectValue,
     AmazonProductType,
 )
 from sales_channels.integrations.amazon.factories.sync.rule_sync import (
@@ -82,6 +83,18 @@ def sales_channels__amazon_property__auto_map_select_values(sender, instance: Am
 
     sync_factory = AmazonPropertySelectValuesSyncFactory(instance)
     sync_factory.run()
+
+
+@receiver(post_update, sender='amazon.AmazonProperty')
+def sales_channels__amazon_property__unmap_select_values(sender, instance: AmazonProperty, **kwargs):
+    """Unmap select values when a property mapping changes."""
+    if not instance.is_dirty_field('local_instance', check_relationship=True):
+        return
+
+    AmazonPropertySelectValue.objects.filter(
+        amazon_property=instance,
+        local_instance__isnull=False,
+    ).update(local_instance=None)
 
 
 @receiver(post_create, sender='amazon.AmazonProductType')


### PR DESCRIPTION
## Summary
- Unmap mapped AmazonPropertySelectValue entries whenever an AmazonProperty mapping changes
- Add regression tests for property unmapping and remapping scenarios

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/receivers.py OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_receivers.AmazonPropertyReceiversTest -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6899a078a26c832eac9e62b405f2cfde