### PR TITLE
Ensure Amazon products store last sync timestamp

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -5,6 +5,7 @@ from sales_channels.integrations.amazon.models.properties import AmazonProperty
 import json
 
 from django.conf import settings
+from django.utils import timezone
 from sp_api.base import SellingApiException
 from spapi import SellersApi, SPAPIConfig, SPAPIClient, DefinitionsApi, ListingsApi
 from sales_channels.integrations.amazon.decorators import throttle_safe
@@ -394,6 +395,10 @@ class GetAmazonAPIMixin:
             mode="VALIDATION_PREVIEW" if settings.DEBUG or force_validation_only else None,
         )
 
+        if getattr(self, "remote_product", None):
+            self.remote_product.last_sync_at = timezone.now()
+            self.remote_product.save(update_fields=["last_sync_at"])
+
         submission_id = getattr(response, "submission_id", None)
         processing_status = getattr(response, "status", None)
         log_identifier, _ = self.get_identifiers()
@@ -485,6 +490,10 @@ class GetAmazonAPIMixin:
             issue_locale=self._get_issue_locale(),
             mode="VALIDATION_PREVIEW" if settings.DEBUG or force_validation_only else None,
         )
+
+        if getattr(self, "remote_product", None):
+            self.remote_product.last_sync_at = timezone.now()
+            self.remote_product.save(update_fields=["last_sync_at"])
         submission_id = getattr(response, "submission_id", None)
         processing_status = getattr(response, "status", None)
         log_identifier, _ = self.get_identifiers()

--- a/OneSila/sales_channels/integrations/amazon/receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/receivers.py
@@ -131,13 +131,8 @@ def sales_channels__amazon_import_completed(sender, instance, **kwargs):
 @receiver(manual_sync_remote_product, sender='amazon.AmazonProduct')
 def amazon__product__manual_sync(sender, instance, view, force_validation_only=False, **kwargs):
     """Queue a task to resync an Amazon product."""
-    from django.utils import timezone
-
     product = instance.local_instance
     count = 1 + (getattr(product, 'get_configurable_variations', lambda: [])().count())
-
-    instance.last_sync_at = timezone.now()
-    instance.save(update_fields=["last_sync_at"])
 
     run_single_amazon_product_task_flow(
         task_func=resync_amazon_product_db_task,
@@ -149,9 +144,3 @@ def amazon__product__manual_sync(sender, instance, view, force_validation_only=F
     )
 
 
-@receiver(update_remote_product, sender='products.Product')
-def amazon__product__update_last_sync(sender, instance, **kwargs):
-    from django.utils import timezone
-    from sales_channels.integrations.amazon.models import AmazonProduct
-
-    AmazonProduct.objects.filter(local_instance=instance).update(last_sync_at=timezone.now())

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_last_sync.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_last_sync.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from model_bakery import baker
+
+from core.tests import TestCase
+from products.models import Product
+from sales_channels.integrations.amazon.factories.mixins import GetAmazonAPIMixin
+from sales_channels.integrations.amazon.models import (
+    AmazonProduct,
+    AmazonSalesChannel,
+    AmazonSalesChannelView,
+)
+
+from ..helpers import DisableWooCommerceSignalsMixin
+
+
+class DummyFactory(GetAmazonAPIMixin):
+    """Minimal factory to invoke mixin methods."""
+
+    def __init__(self, sales_channel, remote_product, view):
+        self.sales_channel = sales_channel
+        self.remote_product = remote_product
+        self.view = view
+
+    def _get_client(self):
+        return None
+
+    def _get_issue_locale(self):
+        return "en"
+
+    def update_assign_issues(self, *args, **kwargs):
+        pass
+
+    def get_identifiers(self):
+        return "id", None
+
+
+class AmazonProductLastSyncTest(DisableWooCommerceSignalsMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="VIEW",
+        )
+        local_product = baker.make(
+            Product,
+            multi_tenant_company=self.multi_tenant_company,
+            type=Product.SIMPLE,
+        )
+        self.remote_product = AmazonProduct.objects.create(
+            sales_channel=self.sales_channel,
+            local_instance=local_product,
+        )
+
+    @patch("sales_channels.integrations.amazon.factories.mixins.ListingsApi")
+    def test_create_product_updates_last_sync(self, listings_api_cls):
+        listings_api_cls.return_value.put_listings_item.return_value = SimpleNamespace()
+        fac = DummyFactory(self.sales_channel, self.remote_product, self.view)
+        product_type = SimpleNamespace(
+            product_type_code="CHAIR", listing_offer_required_properties={}
+        )
+
+        fac.create_product("SKU", self.view.remote_id, product_type, {"attr": "val"})
+
+        self.remote_product.refresh_from_db()
+        self.assertIsNotNone(self.remote_product.last_sync_at)
+
+    @patch("sales_channels.integrations.amazon.factories.mixins.ListingsApi")
+    def test_update_product_updates_last_sync(self, listings_api_cls):
+        listings_api_cls.return_value.patch_listings_item.return_value = SimpleNamespace()
+        fac = DummyFactory(self.sales_channel, self.remote_product, self.view)
+        product_type = SimpleNamespace(product_type_code="CHAIR")
+
+        fac.update_product(
+            "SKU",
+            self.view.remote_id,
+            product_type,
+            {"attr": "new"},
+            current_attributes={"attr": "old"},
+        )
+
+        self.remote_product.refresh_from_db()
+        self.assertIsNotNone(self.remote_product.last_sync_at)
+

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
@@ -143,23 +143,3 @@ class AmazonPropertyReceiversTest(TestCase):
         self.assertIsNone(self.remote_select_value.local_instance)
 
 
-class AmazonProductLastSyncReceiverTest(DisableWooCommerceSignalsMixin, TestCase):
-    def setUp(self):
-        super().setUp()
-        self.sales_channel = AmazonSalesChannel.objects.create(
-            multi_tenant_company=self.multi_tenant_company,
-            remote_id="SELLER",
-        )
-        self.product = Product.objects.create(
-            multi_tenant_company=self.multi_tenant_company,
-            type=Product.SIMPLE,
-        )
-        self.remote_product = AmazonProduct.objects.create(
-            sales_channel=self.sales_channel,
-            local_instance=self.product,
-        )
-
-    def test_last_sync_updated_on_update_signal(self):
-        update_remote_product.send(sender=Product, instance=self.product)
-        self.remote_product.refresh_from_db()
-        self.assertIsNotNone(self.remote_product.last_sync_at)


### PR DESCRIPTION
## Summary
- remove `last_sync_at` update from manual sync receiver
- add tests ensuring Amazon mixins record `last_sync_at`

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_last_sync -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6899af827e5c832ea46737c55e59b386