### PR TITLE
Add SalesPriceList import factory with tests

### DIFF
--- a/OneSila/imports_exports/factories/sales_prices.py
+++ b/OneSila/imports_exports/factories/sales_prices.py
@@ -1,0 +1,96 @@
+from core.helpers import get_nested_attr
+from imports_exports.factories.mixins import AbstractImportInstance, ImportOperationMixin
+from currencies.models import Currency
+from sales_prices.models import SalesPriceList
+
+
+class SalesPriceListImport(ImportOperationMixin):
+    """Import operation for SalesPriceList."""
+    get_identifiers = ['name', 'start_date', 'end_date', 'currency']
+
+    def build_kwargs(self):
+        """Build kwargs including None values for start and end dates."""
+        kwargs = {'multi_tenant_company': self.multi_tenant_company}
+        for identifier in self.get_identifiers:
+            value = get_nested_attr(self.import_instance, identifier)
+            if identifier in ['start_date', 'end_date']:
+                # Include even if None to filter by NULL values
+                kwargs[identifier] = value
+            elif value is not None or identifier == 'sales_channel':
+                kwargs[identifier] = value
+        self.get_kwargs = kwargs
+        self.get_translation_kwargs = kwargs
+
+
+class ImportSalesPriceListInstance(AbstractImportInstance):
+    """Import instance for SalesPriceList."""
+
+    def __init__(self, data: dict, import_process=None, currency=None, instance=None):
+        super().__init__(data, import_process, instance)
+        self.currency = currency
+
+        self.set_field_if_exists('currency_data')
+        self.set_field_if_exists('name')
+        self.set_field_if_exists('start_date')
+        self.set_field_if_exists('end_date')
+        self.set_field_if_exists('vat_included')
+        self.set_field_if_exists('auto_update_prices')
+        self.set_field_if_exists('auto_add_products')
+        self.set_field_if_exists('price_change_pcnt')
+        self.set_field_if_exists('discount_pcnt')
+        self.set_field_if_exists('notes')
+
+        self.validate()
+        self._set_currency()
+        self.created = False
+
+    @property
+    def local_class(self):
+        return SalesPriceList
+
+    @property
+    def updatable_fields(self):
+        return [
+            'vat_included',
+            'auto_update_prices',
+            'auto_add_products',
+            'price_change_pcnt',
+            'discount_pcnt',
+            'notes',
+        ]
+
+    def validate(self):
+        if not hasattr(self, 'name'):
+            raise ValueError("The 'name' field is required.")
+
+        currency_data = getattr(self, 'currency_data', None)
+        if not (self.currency or currency_data):
+            raise ValueError("Either 'currency' or 'currency_data' must be provided.")
+
+        if (
+            hasattr(self, 'start_date')
+            and hasattr(self, 'end_date')
+            and self.start_date
+            and self.end_date
+            and self.start_date > self.end_date
+        ):
+            raise ValueError("start_date cannot be after end_date.")
+
+    def _set_currency(self):
+        if self.currency:
+            return
+
+        if hasattr(self, 'currency_data'):
+            self.currency, _ = Currency.objects.get_or_create(
+                multi_tenant_company=self.multi_tenant_company,
+                **self.currency_data,
+            )
+            return
+
+        raise ValueError("There is no currency information provided.")
+
+    def process_logic(self):
+        fac = SalesPriceListImport(self, self.import_process, instance=self.instance)
+        fac.run()
+        self.instance = fac.instance
+        self.created = fac.created

--- a/OneSila/imports_exports/tests/tests_factories/tests_sales_price_lists.py
+++ b/OneSila/imports_exports/tests/tests_factories/tests_sales_price_lists.py
@@ -1,0 +1,73 @@
+from datetime import date
+
+from core.tests import TestCase
+from imports_exports.factories.sales_prices import ImportSalesPriceListInstance
+from imports_exports.models import Import
+from sales_prices.models import SalesPriceList
+
+
+class ImportSalesPriceListInstanceTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.import_process = Import.objects.create(multi_tenant_company=self.multi_tenant_company)
+
+    def test_create_without_dates(self):
+        data = {
+            'name': 'Retail',
+        }
+        inst = ImportSalesPriceListInstance(data, self.import_process, currency=self.currency)
+        inst.process()
+        self.assertIsNotNone(inst.instance)
+        self.assertIsNone(inst.instance.start_date)
+        self.assertIsNone(inst.instance.end_date)
+        self.assertEqual(inst.instance.name, 'Retail')
+
+    def test_create_with_dates(self):
+        data = {
+            'name': 'Promo',
+            'start_date': date(2024, 1, 1),
+            'end_date': date(2024, 12, 31),
+        }
+        inst = ImportSalesPriceListInstance(data, self.import_process, currency=self.currency)
+        inst.process()
+        self.assertEqual(inst.instance.start_date, date(2024, 1, 1))
+        self.assertEqual(inst.instance.end_date, date(2024, 12, 31))
+
+    def test_get_or_create_updates_existing(self):
+        existing = SalesPriceList.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            name='Retail',
+            currency=self.currency,
+            vat_included=False,
+            auto_update_prices=True,
+        )
+        data = {
+            'name': 'Retail',
+            'vat_included': True,
+            'auto_update_prices': False,
+        }
+        inst = ImportSalesPriceListInstance(data, self.import_process, currency=self.currency)
+        inst.process()
+        self.assertEqual(inst.instance.id, existing.id)
+        self.assertTrue(inst.instance.vat_included)
+        self.assertFalse(inst.instance.auto_update_prices)
+
+    def test_given_instance_updates_fields(self):
+        existing = SalesPriceList.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            name='Wholesale',
+            currency=self.currency,
+            vat_included=False,
+            auto_update_prices=True,
+        )
+        data = {
+            'vat_included': True,
+            'auto_update_prices': False,
+        }
+        inst = ImportSalesPriceListInstance(
+            data, self.import_process, currency=self.currency, instance=existing
+        )
+        inst.process()
+        self.assertEqual(inst.instance.id, existing.id)
+        self.assertTrue(inst.instance.vat_included)
+        self.assertFalse(inst.instance.auto_update_prices)


### PR DESCRIPTION
## Summary
- add `ImportSalesPriceListInstance` and `SalesPriceListImport` for creating and updating price lists
- test creating price lists, get-or-create behavior, and updating passed instances

## Testing
- `python manage.py test imports_exports.tests.tests_factories.tests_sales_price_lists -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689a06b918d4832e880ae6fe828fed94

## Summary by Sourcery

Implement import flow for SalesPriceList entities, enabling create-or-update logic with validation and currency resolution, and cover key scenarios with tests

New Features:
- Add ImportSalesPriceListInstance factory with field validation, currency handling, and update logic
- Add SalesPriceListImport operation to build and execute create/update actions based on name, dates, and currency

Tests:
- Add tests for creating sales price lists with and without dates
- Add tests for get-or-create behavior updating existing records
- Add tests for updating specified existing instances