### PR TITLE
Add import handling for sales price list items

### DIFF
--- a/OneSila/imports_exports/tests/tests_factories/tests_sales_pricelist_items.py
+++ b/OneSila/imports_exports/tests/tests_factories/tests_sales_pricelist_items.py
@@ -1,0 +1,107 @@
+from core.tests import TestCase
+from imports_exports.models import Import
+from imports_exports.factories.sales_prices import (
+    ImportSalesPriceListItemInstance,
+    ImportSalesPriceListInstance,
+)
+from imports_exports.factories.products import ImportProductInstance
+from products.models import SimpleProduct
+from sales_prices.models import SalesPriceList, SalesPrice
+
+
+class ImportSalesPriceListItemInstanceTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.import_process = Import.objects.create(multi_tenant_company=self.multi_tenant_company)
+
+    def _create_product_with_sales_price(self):
+        product = SimpleProduct.objects.create(multi_tenant_company=self.multi_tenant_company)
+        sales_price, _ = product.salesprice_set.get_or_create(
+            multi_tenant_company=self.multi_tenant_company, currency=self.currency
+        )
+        sales_price.set_prices(rrp=100, price=90)
+        return product
+
+    def _create_pricelist(self):
+        return SalesPriceList.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            name="Retail",
+            currency=self.currency,
+        )
+
+    def test_create_with_objects(self):
+        product = self._create_product_with_sales_price()
+        pricelist = self._create_pricelist()
+        inst = ImportSalesPriceListItemInstance(
+            {}, self.import_process, sales_pricelist=pricelist, product=product
+        )
+        inst.process()
+        item = inst.instance
+        self.assertTrue(pricelist.salespricelistitem_set.filter(product=product).exists())
+        self.assertIsNotNone(item.price_auto)
+        self.assertIsNotNone(item.discount_auto)
+
+    def test_create_with_product_data(self):
+        pricelist = self._create_pricelist()
+        data = {"product_data": {"name": "Widget", "properties": []}, "disable_auto_update": True}
+        inst = ImportSalesPriceListItemInstance(
+            data, self.import_process, sales_pricelist=pricelist
+        )
+        inst.process()
+        item = inst.instance
+        self.assertEqual(item.product.name, "Widget")
+
+    def test_disable_auto_update(self):
+        product = self._create_product_with_sales_price()
+        pricelist = self._create_pricelist()
+        inst = ImportSalesPriceListItemInstance(
+            {},
+            self.import_process,
+            sales_pricelist=pricelist,
+            product=product,
+            disable_auto_update=True,
+        )
+        inst.process()
+        item = inst.instance
+        self.assertIsNone(item.price_auto)
+        self.assertIsNone(item.discount_auto)
+
+
+class ImportSalesPriceListWithItemsTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.import_process = Import.objects.create(multi_tenant_company=self.multi_tenant_company)
+
+    def test_sales_pricelist_with_items(self):
+        product = SimpleProduct.objects.create(multi_tenant_company=self.multi_tenant_company)
+        sales_price, _ = product.salesprice_set.get_or_create(
+            multi_tenant_company=self.multi_tenant_company, currency=self.currency
+        )
+        sales_price.set_prices(rrp=100, price=90)
+        data = {
+            "name": "Promo",
+            "sales_pricelist_items": [{"product": product}],
+        }
+        inst = ImportSalesPriceListInstance(
+            data, self.import_process, currency=self.currency
+        )
+        inst.process()
+        self.assertTrue(inst.instance.salespricelistitem_set.filter(product=product).exists())
+
+    def test_product_with_sales_pricelist_items(self):
+        pricelist = SalesPriceList.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            name="Retail",
+            currency=self.currency,
+        )
+        product_data = {
+            "name": "Imported",
+            "properties": [],
+            "sales_pricelist_items": [
+                {"salespricelist": pricelist, "disable_auto_update": True}
+            ],
+        }
+        inst = ImportProductInstance(product_data, self.import_process)
+        inst.process()
+        product = inst.instance
+        self.assertTrue(pricelist.salespricelistitem_set.filter(product=product).exists())


### PR DESCRIPTION
## Summary
- implement `ImportSalesPriceListItemInstance` with optional auto-update suppression
- allow `ImportSalesPriceListInstance` and `ImportProductInstance` to create nested sales price list items
- add comprehensive tests for sales price list item imports

## Testing
- `python OneSila/manage.py test imports_exports.tests.tests_factories.tests_sales_pricelist_items -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689a1a9b2e98832eb6b6603569ab4c89

## Summary by Sourcery

Enable comprehensive import support for SalesPriceListItem by creating a dedicated import instance, integrating nested item imports into existing workflows, and providing an option to disable post-create auto-updates.

New Features:
- Implement ImportSalesPriceListItemInstance to support importing sales price list items with nested SalesPriceList and Product references
- Enable nested import of sales price list items via the sales_pricelist_items field in both SalesPriceList and Product import flows
- Introduce disable_auto_update flag to temporarily suppress automatic update signals during item import

Tests:
- Add tests for sales price list item imports covering object and data-based creation, nested import scenarios, and auto-update suppression