### PR TITLE
Validate overlapping sales channel price lists

### DIFF
--- a/OneSila/sales_channels/schema/types/filters.py
+++ b/OneSila/sales_channels/schema/types/filters.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from core.schema.core.types.types import auto
-from core.schema.core.types.filters import filter, SearchFilterMixin
+from core.schema.core.types.filters import filter, SearchFilterMixin, lazy
 from products.schema.types.filters import ProductFilter
 
 from sales_channels.models import (
@@ -139,6 +139,8 @@ class SalesChannelFilter(SearchFilterMixin):
 @filter(SalesChannelIntegrationPricelist)
 class SalesChannelIntegrationPricelistFilter(SearchFilterMixin):
     id: auto
+    sales_channel: Optional[SalesChannelFilter]
+    price_list: Optional[lazy['SalesPriceListFilter', "sales_prices.schema.types.filters"]]
 
 
 @filter(RemoteCurrency)

--- a/OneSila/sales_channels/schema/types/types.py
+++ b/OneSila/sales_channels/schema/types/types.py
@@ -226,6 +226,7 @@ class RemoteVatType(relay.Node, GetQuerysetMultiTenantMixin):
 @type(SalesChannelIntegrationPricelist, filters=SalesChannelIntegrationPricelistFilter, order=SalesChannelIntegrationPricelistOrder, pagination=True, fields='__all__')
 class SalesChannelIntegrationPricelistType(relay.Node, GetQuerysetMultiTenantMixin):
     sales_channel: SalesChannelType
+    price_list: Annotated['SalesPriceListType', lazy("sales_prices.schema.types.types")]
 
 
 @type(SalesChannelView, filters=SalesChannelViewFilter, order=SalesChannelViewOrder, pagination=True, fields='__all__')

--- a/OneSila/sales_channels/tests/tests_models.py
+++ b/OneSila/sales_channels/tests/tests_models.py
@@ -1,0 +1,142 @@
+from datetime import date
+
+from django.core.exceptions import ValidationError
+
+from core.tests import TestCase
+from sales_channels.models import SalesChannel, SalesChannelIntegrationPricelist
+from sales_channels.receivers import sales_channels__sales_channel__post_create_receiver
+from core.signals import post_create
+from unittest.mock import patch
+from sales_prices.models import SalesPriceList
+from currencies.models import Currency
+from currencies.currencies import currencies
+
+
+class SalesChannelIntegrationPricelistTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.patch_connect = patch(
+            'sales_channels.models.sales_channels.SalesChannel.connect',
+            lambda self: None,
+        )
+        self.patch_connect.start()
+        self.addCleanup(self.patch_connect.stop)
+
+        post_create.disconnect(sales_channels__sales_channel__post_create_receiver, sender=SalesChannel)
+        self.addCleanup(post_create.connect, sales_channels__sales_channel__post_create_receiver, sender=SalesChannel)
+
+        self.channel = SalesChannel.objects.create(
+            hostname="https://example.com",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.eur, _ = Currency.objects.get_or_create(
+            multi_tenant_company=self.multi_tenant_company, **currencies["DE"]
+        )
+        self.usd, _ = Currency.objects.get_or_create(
+            multi_tenant_company=self.multi_tenant_company, **currencies["US"]
+        )
+
+    def _create_pricelist(self, name, currency, start=None, end=None):
+        return SalesPriceList.objects.create(
+            name=name,
+            currency=currency,
+            start_date=start,
+            end_date=end,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def test_different_currency_overlapping_allowed(self):
+        pl1 = self._create_pricelist(
+            "pl1", self.eur, date(2025, 8, 1), date(2025, 9, 1)
+        )
+        pl2 = self._create_pricelist(
+            "pl2", self.usd, date(2025, 8, 1), date(2025, 9, 1)
+        )
+
+        SalesChannelIntegrationPricelist.objects.create(
+            sales_channel=self.channel,
+            price_list=pl1,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        SalesChannelIntegrationPricelist.objects.create(
+            sales_channel=self.channel,
+            price_list=pl2,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def test_overlapping_same_currency_not_allowed(self):
+        pl1 = self._create_pricelist(
+            "pl1", self.eur, date(2025, 8, 1), date(2025, 9, 1)
+        )
+        pl2 = self._create_pricelist(
+            "pl2", self.eur, date(2025, 8, 24), date(2025, 9, 24)
+        )
+
+        SalesChannelIntegrationPricelist.objects.create(
+            sales_channel=self.channel,
+            price_list=pl1,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        with self.assertRaises(ValidationError):
+            SalesChannelIntegrationPricelist.objects.create(
+                sales_channel=self.channel,
+                price_list=pl2,
+                multi_tenant_company=self.multi_tenant_company,
+            )
+
+    def test_open_ended_overlap_not_allowed(self):
+        pl1 = self._create_pricelist("pl1", self.eur, date(2025, 8, 1), None)
+        pl2 = self._create_pricelist(
+            "pl2", self.eur, date(2025, 12, 1), date(2026, 1, 1)
+        )
+
+        SalesChannelIntegrationPricelist.objects.create(
+            sales_channel=self.channel,
+            price_list=pl1,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        with self.assertRaises(ValidationError):
+            SalesChannelIntegrationPricelist.objects.create(
+                sales_channel=self.channel,
+                price_list=pl2,
+                multi_tenant_company=self.multi_tenant_company,
+            )
+
+    def test_multiple_base_pricelists_not_allowed(self):
+        pl1 = self._create_pricelist("pl1", self.eur)
+        pl2 = self._create_pricelist("pl2", self.eur)
+
+        SalesChannelIntegrationPricelist.objects.create(
+            sales_channel=self.channel,
+            price_list=pl1,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        with self.assertRaises(ValidationError):
+            SalesChannelIntegrationPricelist.objects.create(
+                sales_channel=self.channel,
+                price_list=pl2,
+                multi_tenant_company=self.multi_tenant_company,
+            )
+
+    def test_non_overlapping_same_currency_allowed(self):
+        pl1 = self._create_pricelist(
+            "pl1", self.eur, date(2025, 8, 1), date(2025, 9, 1)
+        )
+        pl2 = self._create_pricelist(
+            "pl2", self.eur, date(2025, 9, 2), date(2025, 10, 1)
+        )
+
+        SalesChannelIntegrationPricelist.objects.create(
+            sales_channel=self.channel,
+            price_list=pl1,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        SalesChannelIntegrationPricelist.objects.create(
+            sales_channel=self.channel,
+            price_list=pl2,
+            multi_tenant_company=self.multi_tenant_company,
+        )


### PR DESCRIPTION
## Summary
- prevent overlapping price lists with same currency per sales channel
- expose lazily-loaded price list in SalesChannelIntegrationPricelist GraphQL type and add filtering
- add tests for permitted and conflicting price list date ranges

## Testing
- `python OneSila/manage.py test sales_channels.tests.tests_models -v 2 --noinput --keepdb`

------
https://chatgpt.com/codex/tasks/task_e_689a5827e09c832eb6d9255e8e9107e9