### PR TITLE
Allow default price lists alongside dated ones

### DIFF
--- a/OneSila/sales_channels/tests/tests_models.py
+++ b/OneSila/sales_channels/tests/tests_models.py
@@ -77,24 +77,12 @@ class SalesChannelIntegrationPricelistTestCase(TestCase):
                 multi_tenant_company=self.multi_tenant_company,
             )
 
-    def test_open_ended_overlap_not_allowed(self):
-        pl1 = self._create_pricelist("pl1", self.eur, date(2025, 8, 1), None)
-        pl2 = self._create_pricelist(
-            "pl2", self.eur, date(2025, 12, 1), date(2026, 1, 1)
-        )
-
-        SalesChannelIntegrationPricelist.objects.create(
-            sales_channel=self.channel,
-            price_list=pl1,
-            multi_tenant_company=self.multi_tenant_company,
-        )
+    def test_open_ended_pricelist_not_allowed(self):
+        with self.assertRaises(ValidationError):
+            self._create_pricelist("pl1", self.eur, date(2025, 8, 1), None)
 
         with self.assertRaises(ValidationError):
-            SalesChannelIntegrationPricelist.objects.create(
-                sales_channel=self.channel,
-                price_list=pl2,
-                multi_tenant_company=self.multi_tenant_company,
-            )
+            self._create_pricelist("pl2", self.eur, None, date(2026, 1, 1))
 
     def test_multiple_base_pricelists_not_allowed(self):
         pl1 = self._create_pricelist("pl1", self.eur)

--- a/OneSila/sales_prices/models.py
+++ b/OneSila/sales_prices/models.py
@@ -142,6 +142,27 @@ class SalesPriceList(models.Model):
 
     objects = SalesPriceListManager()
 
+    def clean(self):
+        super().clean()
+        if (self.start_date and not self.end_date) or (
+            self.end_date and not self.start_date
+        ):
+            raise ValidationError(
+                {
+                    'start_date': _('Both start_date and end_date must be provided.'),
+                    'end_date': _('Both start_date and end_date must be provided.'),
+                }
+            )
+
+        if self.start_date and self.end_date and self.end_date < self.start_date:
+            raise ValidationError(
+                {'end_date': _('End date cannot be before start date.')}
+            )
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        return super().save(*args, **kwargs)
+
     def __str__(self):
         return '{} {}'.format(self.name, self.currency)
 

--- a/OneSila/sales_prices/tests/tests_models.py
+++ b/OneSila/sales_prices/tests/tests_models.py
@@ -1,5 +1,6 @@
 from django.db.utils import IntegrityError
 from django.core.exceptions import ValidationError
+from datetime import date
 from core.tests import TestCase
 from products.models import SimpleProduct
 from sales_prices.models import SalesPriceList, SalesPriceListItem
@@ -150,3 +151,29 @@ class SalesPriceListItemQuerySetTestCase(TestCase):
         self.assertFalse(price_list_price.salespricelist.auto_update_prices)
         self.assertEqual(price_list_price.price, price_list_price.price_override)
         self.assertEqual(price_list_price.discount, price_list_price.discount_override)
+
+
+class SalesPriceListValidationTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.currency, _ = Currency.objects.get_or_create(
+            multi_tenant_company=self.multi_tenant_company, **currencies['GB']
+        )
+
+    def test_start_without_end_not_allowed(self):
+        with self.assertRaises(ValidationError):
+            SalesPriceList.objects.create(
+                multi_tenant_company=self.multi_tenant_company,
+                name='pl',
+                currency=self.currency,
+                start_date=date(2025, 1, 1),
+            )
+
+    def test_end_without_start_not_allowed(self):
+        with self.assertRaises(ValidationError):
+            SalesPriceList.objects.create(
+                multi_tenant_company=self.multi_tenant_company,
+                name='pl',
+                currency=self.currency,
+                end_date=date(2025, 1, 1),
+            )


### PR DESCRIPTION
## Summary
- permit default price lists to coexist with dated price lists per currency
- prevent multiple fallback price lists and improve overlap validation
- require SalesPriceList start and end dates to be provided together
- add tests for price list date validation and default+dated combos

## Testing
- `python OneSila/manage.py test sales_channels.tests.tests_models.SalesChannelIntegrationPricelistTestCase sales_prices.tests.tests_models.SalesPriceListValidationTestCase --noinput` *(fails: database creation and migrations hang)*

------
https://chatgpt.com/codex/tasks/task_e_689b044f1a80832ea3330b950e18e95e