### PR TITLE
Add Amazon price list parsing and flexible currency support

### DIFF
--- a/OneSila/imports_exports/factories/products.py
+++ b/OneSila/imports_exports/factories/products.py
@@ -23,6 +23,7 @@ from imports_exports.factories.sales_prices import ImportSalesPriceListItemInsta
 from taxes.models import VatRate
 from currencies.currencies import iso_list
 from core.exceptions import ValidationError
+from sales_channels.models import SalesChannelIntegrationPricelist
 
 import logging
 logger = logging.getLogger(__name__)
@@ -424,6 +425,11 @@ class ImportProductInstance(AbstractImportInstance, AddLogTimeentry):
             import_instance.process()
             if import_instance.instance is not None:
                 item_ids.append(import_instance.instance.id)
+                if self.sales_channel:
+                    SalesChannelIntegrationPricelist.objects.get_or_create(
+                        sales_channel=self.sales_channel,
+                        price_list=import_instance.salespricelist,
+                    )
         self.sales_pricelist_item_instances = SalesPriceListItem.objects.filter(id__in=item_ids)
 
     @timeit_and_log(logger)

--- a/OneSila/imports_exports/tests/tests_factories/tests_sales_price_lists.py
+++ b/OneSila/imports_exports/tests/tests_factories/tests_sales_price_lists.py
@@ -15,7 +15,9 @@ class ImportSalesPriceListInstanceTests(TestCase):
         data = {
             'name': 'Retail',
         }
-        inst = ImportSalesPriceListInstance(data, self.import_process, currency=self.currency)
+        inst = ImportSalesPriceListInstance(
+            data, self.import_process, currency_object=self.currency
+        )
         inst.process()
         self.assertIsNotNone(inst.instance)
         self.assertIsNone(inst.instance.start_date)
@@ -28,7 +30,9 @@ class ImportSalesPriceListInstanceTests(TestCase):
             'start_date': date(2024, 1, 1),
             'end_date': date(2024, 12, 31),
         }
-        inst = ImportSalesPriceListInstance(data, self.import_process, currency=self.currency)
+        inst = ImportSalesPriceListInstance(
+            data, self.import_process, currency_object=self.currency
+        )
         inst.process()
         self.assertEqual(inst.instance.start_date, date(2024, 1, 1))
         self.assertEqual(inst.instance.end_date, date(2024, 12, 31))
@@ -46,7 +50,9 @@ class ImportSalesPriceListInstanceTests(TestCase):
             'vat_included': True,
             'auto_update_prices': False,
         }
-        inst = ImportSalesPriceListInstance(data, self.import_process, currency=self.currency)
+        inst = ImportSalesPriceListInstance(
+            data, self.import_process, currency_object=self.currency
+        )
         inst.process()
         self.assertEqual(inst.instance.id, existing.id)
         self.assertTrue(inst.instance.vat_included)
@@ -65,7 +71,7 @@ class ImportSalesPriceListInstanceTests(TestCase):
             'auto_update_prices': False,
         }
         inst = ImportSalesPriceListInstance(
-            data, self.import_process, currency=self.currency, instance=existing
+            data, self.import_process, currency_object=self.currency, instance=existing
         )
         inst.process()
         self.assertEqual(inst.instance.id, existing.id)

--- a/OneSila/imports_exports/tests/tests_factories/tests_sales_pricelist_items.py
+++ b/OneSila/imports_exports/tests/tests_factories/tests_sales_pricelist_items.py
@@ -85,7 +85,7 @@ class ImportSalesPriceListWithItemsTests(TestCase):
             "sales_pricelist_items": [{"product": product}],
         }
         inst = ImportSalesPriceListInstance(
-            data, self.import_process, currency=self.currency
+            data, self.import_process, currency_object=self.currency
         )
         inst.process()
         self.assertTrue(inst.instance.salespricelistitem_set.filter(product=product).exists())


### PR DESCRIPTION
## Summary
- Ensure Amazon price parser raises an error for unknown currencies and passes currency objects when building price lists
- Simplify SalesPriceList import to accept a `currency_object` parameter, avoiding overlap with currency ISO codes
- Test Amazon price parsing for missing currencies and currency-object handoff

## Testing
- `pre-commit run --files OneSila/imports_exports/factories/sales_prices.py OneSila/imports_exports/tests/tests_factories/tests_sales_price_lists.py OneSila/imports_exports/tests/tests_factories/tests_sales_pricelist_items.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_products_imports imports_exports.tests.tests_factories.tests_sales_pricelist_items` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689a583ec53c832eb1abbaabf4206102