### PR TITLE
feat(core): add mixin to disable inspector signals

### DIFF
--- a/OneSila/core/mixins.py
+++ b/OneSila/core/mixins.py
@@ -1,0 +1,73 @@
+import types
+from typing import Set
+
+
+class TemporaryDisableInspectorSignalsMixin:
+    """Mixin to temporarily disable inspector signals for a specific company.
+
+    Usage:
+        mixin = TemporaryDisableInspectorSignalsMixin()
+        mixin.multi_tenant_company = <MultiTenantCompany>
+        mixin.disable_inspector_signals()
+        ... perform operations ...
+        mixin.refresh_inspector_status()
+
+    Note:
+        This mixin patches the ``inspector_block_refresh`` signal only. Other
+        helper functions such as ``recursively_check_components`` may still run
+        if triggered by unrelated signals.
+    """
+
+    _original_inspector_send = None
+    skipped_inspector_sku: Set[str]
+
+    def disable_inspector_signals(self) -> None:
+        """Temporarily patch the inspector signal to skip refreshes.
+
+        Any call to ``inspector_block_refresh.send`` for products belonging to
+        ``self.multi_tenant_company`` will be swallowed and the product SKU will
+        be recorded in ``self.skipped_inspector_sku``.
+        """
+        from products_inspector.signals import inspector_block_refresh
+
+        if self._original_inspector_send is not None:
+            return
+
+        self.skipped_inspector_sku = getattr(self, 'skipped_inspector_sku', set())
+        original_send = inspector_block_refresh.send
+
+        def patched_send(signal_self, sender, instance, **kwargs):
+            inspector = instance
+            product = getattr(inspector, 'product', None)
+            company = getattr(product, 'multi_tenant_company', None)
+            if company == self.multi_tenant_company:
+                # Record the SKU so we can re-run inspection later.
+                if product and product.sku:
+                    self.skipped_inspector_sku.add(product.sku)
+                return []
+            # For other companies, behave normally.
+            return original_send(sender, instance=instance, **kwargs)
+
+        inspector_block_refresh.send = types.MethodType(patched_send, inspector_block_refresh)
+        self._original_inspector_send = original_send
+
+    def refresh_inspector_status(self) -> None:
+        """Restore signals and re-run inspection for skipped products."""
+        from products_inspector.signals import inspector_block_refresh
+        from products_inspector.models import Inspector
+        from products.models import Product
+
+        if self._original_inspector_send is not None:
+            inspector_block_refresh.send = self._original_inspector_send
+            self._original_inspector_send = None
+
+        if hasattr(self, 'skipped_inspector_sku') and self.skipped_inspector_sku:
+            products = Product.objects.filter_multi_tenant(self.multi_tenant_company).filter(
+                sku__in=self.skipped_inspector_sku
+            )
+        else:
+            products = Product.objects.filter_multi_tenant(self.multi_tenant_company)
+
+        inspectors = Inspector.objects.filter(product__in=products)
+        for inspector in inspectors.iterator():
+            inspector.inspect_product(run_async=False)

--- a/OneSila/core/tests/tests_mixins.py
+++ b/OneSila/core/tests/tests_mixins.py
@@ -1,0 +1,49 @@
+from model_bakery import baker
+
+from core.tests import TestCase
+from core.mixins import TemporaryDisableInspectorSignalsMixin
+from products.models import SimpleProduct
+from products_inspector.constants import MISSING_PRICES_ERROR
+
+
+class DummyProcess(TemporaryDisableInspectorSignalsMixin):
+    def __init__(self, company):
+        self.multi_tenant_company = company
+
+
+class TemporaryDisableInspectorSignalsMixinTestCase(TestCase):
+    def test_disable_and_refresh_inspector_signals(self):
+        product = SimpleProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            active=False,
+        )
+        block = product.inspector.blocks.get(error_code=MISSING_PRICES_ERROR)
+        self.assertTrue(block.successfully_checked)
+
+        other_company = baker.make("core.MultiTenantCompany")
+        other_product = SimpleProduct.objects.create(
+            multi_tenant_company=other_company,
+            active=False,
+        )
+        other_block = other_product.inspector.blocks.get(error_code=MISSING_PRICES_ERROR)
+        self.assertTrue(other_block.successfully_checked)
+
+        proc = DummyProcess(self.multi_tenant_company)
+        proc.disable_inspector_signals()
+
+        product.active = True
+        product.save()
+
+        other_product.active = True
+        other_product.save()
+
+        block.refresh_from_db()
+        other_block.refresh_from_db()
+        self.assertTrue(block.successfully_checked)
+        self.assertFalse(other_block.successfully_checked)
+        self.assertIn(product.sku, proc.skipped_inspector_sku)
+        self.assertNotIn(other_product.sku, proc.skipped_inspector_sku)
+
+        proc.refresh_inspector_status()
+        block.refresh_from_db()
+        self.assertFalse(block.successfully_checked)


### PR DESCRIPTION
## Summary
- add mixin to temporarily disable inspector signals for a company
- document that only `inspector_block_refresh` is intercepted
- add tests verifying signal suppression and later refresh

## Testing
- `python OneSila/manage.py test core.tests.tests_mixins -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689b1ceb61f0832eaf1d651fc5cb6874

## Summary by Sourcery

Introduce a mixin to temporarily disable the products inspector refresh signal for a specific company and later replay skipped inspections.

New Features:
- Add TemporaryDisableInspectorSignalsMixin with methods to disable and restore the inspector_block_refresh signal
- Record skipped product SKUs during suppression and replay inspections on restore

Enhancements:
- Document that only the inspector_block_refresh signal is intercepted by the mixin

Tests:
- Add tests to verify that signals are suppressed for the target company and that inspections are re-run after restoration