### PR TITLE
Use randomized tenant-specific upload paths

### DIFF
--- a/OneSila/core/models/multi_tenant.py
+++ b/OneSila/core/models/multi_tenant.py
@@ -16,6 +16,7 @@ from core.helpers import get_languages
 from core.managers import MultiTenantManager, MultiTenantUserLoginTokenManager
 from core.validators import phone_regex, validate_image_extension, \
     no_dots_in_filename
+from core.upload_paths import tenant_upload_to
 
 from get_absolute_url.helpers import generate_absolute_url
 from hashlib import shake_256
@@ -140,8 +141,12 @@ class MultiTenantUser(AbstractUser, MultiTenantAwareMixin):
     telegram_number = models.CharField(validators=[phone_regex], max_length=17, blank=True, null=True)
     onboarding_status = models.CharField(max_length=30, choices=ONBOARDING_STATUS_CHOICES, default=ADD_COMPANY)
 
-    avatar = models.ImageField(upload_to='avatars', null=True, blank=True,
-        validators=[validate_image_extension, no_dots_in_filename])
+    avatar = models.ImageField(
+        upload_to=tenant_upload_to('avatars'),
+        null=True,
+        blank=True,
+        validators=[validate_image_extension, no_dots_in_filename],
+    )
     avatar_resized = ImageSpecField(source='avatar',
                             processors=[ResizeToFill(100, 100)],
                             format='JPEG',

--- a/OneSila/core/tests/tests_models.py
+++ b/OneSila/core/tests/tests_models.py
@@ -1,4 +1,7 @@
 from django.utils import timezone
+from django.core.files import File
+from django.conf import settings
+import os
 
 from core.models.multi_tenant import MultiTenantUserLoginToken
 from core.tests import TestCase
@@ -31,3 +34,14 @@ class TestMultiTenantUserLoginTokenTestCase(TestCase):
 
         self.assertTrue(token.expires_at is not None)
         self.assertTrue(token.is_valid())
+
+
+class TestMultiTenantUserAvatarUploadPath(TestCase):
+    def test_avatar_upload_path(self):
+        image_path = os.path.join(settings.BASE_DIR.parent, 'core', 'tests', 'image_files', 'red.png')
+        with open(image_path, 'rb') as f:
+            self.user.avatar.save('red.png', File(f))
+        parts = self.user.avatar.name.split('/')
+        self.assertEqual(parts[0], str(self.multi_tenant_company.id))
+        self.assertEqual(parts[1], 'avatars')
+        self.assertEqual(len(parts), 8)

--- a/OneSila/core/upload_paths.py
+++ b/OneSila/core/upload_paths.py
@@ -1,0 +1,22 @@
+import os
+import random
+import string
+from functools import partial
+
+
+def _tenant_upload_to(instance, filename, subdir, depth=5, segment_length=2):
+    """Build a randomized path rooted at the tenant's company ID."""
+    company_id = getattr(instance, "multi_tenant_company_id", None)
+    if company_id is None:
+        company = getattr(instance, "multi_tenant_company", None)
+        company_id = getattr(company, "id", "unknown")
+    segments = [
+        "".join(random.choices(string.ascii_lowercase + string.digits, k=segment_length))
+        for _ in range(depth)
+    ]
+    return os.path.join(str(company_id), subdir, *segments, filename)
+
+
+def tenant_upload_to(subdir, depth=5, segment_length=2):
+    """Return a callable suitable for Django's ``upload_to`` argument."""
+    return partial(_tenant_upload_to, subdir=subdir, depth=depth, segment_length=segment_length)

--- a/OneSila/imports_exports/models.py
+++ b/OneSila/imports_exports/models.py
@@ -10,6 +10,7 @@ import mimetypes
 from django.core.exceptions import ValidationError
 
 from core.helpers import get_languages
+from core.upload_paths import tenant_upload_to
 
 
 class Import(PolymorphicModel, models.Model):
@@ -260,7 +261,6 @@ class TypedImport(Import):
 
         super().save(*args, **kwargs)
 
-
     def run(self):
         raise NotImplementedError("Cannot run a TypedImport directly. Use a concrete subclass like MappedImport.")
 
@@ -271,7 +271,7 @@ class MappedImport(TypedImport):
     """
 
     json_file = models.FileField(
-        upload_to="mapped_imports/",
+        upload_to=tenant_upload_to("mapped_imports"),
         null=True,
         blank=True,
         help_text="Optional uploaded mapped JSON file."
@@ -328,4 +328,3 @@ class ImportReport(models.Model):
     def save(self, *args, **kwargs):
         self.full_clean()
         super().save(*args, **kwargs)
-

--- a/OneSila/imports_exports/tests/tests_models.py
+++ b/OneSila/imports_exports/tests/tests_models.py
@@ -1,0 +1,13 @@
+from django.core.files.base import ContentFile
+from imports_exports.models import MappedImport
+from core.tests import TestCase
+
+
+class MappedImportUploadPathTest(TestCase):
+    def test_json_file_upload_path(self):
+        mapped_import = MappedImport.objects.create(multi_tenant_company=self.multi_tenant_company)
+        mapped_import.json_file.save('data.json', ContentFile(b'{}'))
+        parts = mapped_import.json_file.name.split('/')
+        self.assertEqual(parts[0], str(self.multi_tenant_company.id))
+        self.assertEqual(parts[1], 'mapped_imports')
+        self.assertEqual(len(parts), 8)

--- a/OneSila/media/models.py
+++ b/OneSila/media/models.py
@@ -9,6 +9,7 @@ from get_absolute_url.helpers import generate_absolute_url
 
 from core.validators import no_dots_in_filename, validate_image_extension, \
     validate_file_extensions
+from core.upload_paths import tenant_upload_to
 from .image_specs import ImageWebSpec
 from .managers import ImageManager, VideoManager, FileManager
 
@@ -47,18 +48,26 @@ class Media(models.Model):
     video_url = models.URLField(null=True, blank=True)
 
     image_type = models.CharField(max_length=5, choices=IMAGE_TYPE_CHOICES, default=PACK_SHOT)
-    image = models.ImageField(_('Image (High resolution)'),
-        upload_to='images/', validators=[validate_image_extension],
-        null=True, blank=True)
+    image = models.ImageField(
+        _('Image (High resolution)'),
+        upload_to=tenant_upload_to('images'),
+        validators=[validate_image_extension],
+        null=True,
+        blank=True,
+    )
     image_web = ImageSpecField(source='image',
         id='mediapp:image:imagewebspec')
     onesila_thumbnail = ImageSpecField(source='image',
         id='mediapp:image:onesilathumbnail')
     image_hash = models.CharField(_('image hash'), max_length=100, blank=True, null=True)
 
-    file = models.FileField(_('File'),
-        upload_to='files/', validators=[validate_file_extensions, no_dots_in_filename],
-        null=True, blank=True)
+    file = models.FileField(
+        _('File'),
+        upload_to=tenant_upload_to('files'),
+        validators=[validate_file_extensions, no_dots_in_filename],
+        null=True,
+        blank=True,
+    )
 
     # can be created by the system
     owner = models.ForeignKey(MultiTenantUser, on_delete=models.CASCADE, blank=True, null=True)

--- a/OneSila/media/tests/tests_models.py
+++ b/OneSila/media/tests/tests_models.py
@@ -2,6 +2,7 @@ from media.models import Media
 from core.tests import TestCase
 from model_bakery import baker
 from django.core.files import File
+from django.core.files.base import ContentFile
 from django.conf import settings
 import os
 from .helpers import CreateImageMixin
@@ -25,3 +26,18 @@ class MediaTestCase(CreateImageMixin, TestCase):
         # Cached images are converted to jpg, no matter what the source.
         self.assertTrue(url.endswith('.jpg'))
         self.assertTrue(url.startswith('http'))
+
+    def test_image_upload_path(self):
+        image = self.create_image(fname='red.png', multi_tenant_company=self.multi_tenant_company)
+        parts = image.image.name.split('/')
+        self.assertEqual(parts[0], str(self.multi_tenant_company.id))
+        self.assertEqual(parts[1], 'images')
+        self.assertEqual(len(parts), 8)
+
+    def test_file_upload_path(self):
+        media = Media.objects.create(multi_tenant_company=self.multi_tenant_company, type=Media.FILE)
+        media.file.save('test.pdf', ContentFile(b'test'))
+        parts = media.file.name.split('/')
+        self.assertEqual(parts[0], str(self.multi_tenant_company.id))
+        self.assertEqual(parts[1], 'files')
+        self.assertEqual(len(parts), 8)


### PR DESCRIPTION
## Summary
- route uploaded files into folders rooted by tenant ID
- add Symfony-style random segments for images, files, avatars, and mapped imports
- test that each model stores uploads under the company id with randomized subfolders
- remove committed migration files so they can be regenerated locally

## Testing
- `pre-commit run --files OneSila/core/migrations/0008_alter_multitenantuser_avatar.py OneSila/imports_exports/migrations/0014_alter_mappedimport_json_file.py OneSila/media/migrations/0004_alter_media_file_alter_media_image.py`
- `python OneSila/manage.py test core.tests.tests_models media.tests.tests_models imports_exports.tests.tests_models`

------
https://chatgpt.com/codex/tasks/task_e_689b4bc1dcd4832e9552f8cd5660f012

## Summary by Sourcery

Route all uploaded files and images into tenant-specific directories with Symfony-style randomized subfolders using a new tenant_upload_to helper

Enhancements:
- Add tenant_upload_to helper to generate company-rooted paths with random segments
- Apply tenant_upload_to to Media.image, Media.file, MultiTenantUser.avatar, and MappedImport.json_file

Tests:
- Add tests to verify tenant ID, subdirectory, and randomized depth for image, file, avatar, and import uploads

Chores:
- Remove committed migration files to allow local regeneration