### PR TITLE
Add translated_remote_name and LLM translation for Amazon select values

### DIFF
--- a/OneSila/llm/factories/amazon.py
+++ b/OneSila/llm/factories/amazon.py
@@ -1,0 +1,52 @@
+from .mixins import OpenAIMixin
+
+
+class AmazonSelectValueTranslationLLM(OpenAIMixin):
+    """Translate Amazon property select values using OpenAI."""
+    model = "gpt-4.1-nano"
+    temperature = 0.3
+    max_tokens = 20
+
+    def __init__(self, remote_value, from_language_code="auto", to_language_code="en", property_name=None, property_code=None):
+        super().__init__()
+        self.remote_value = remote_value
+        self.from_language_code = from_language_code
+        self.to_language_code = to_language_code
+        self.property_name = property_name
+        self.property_code = property_code
+
+    @property
+    def system_prompt(self):
+        return "You are translating e-commerce property values. Output only the translated value."
+
+    @property
+    def prompt(self):
+        context_line = ""
+        if self.property_name and self.property_code:
+            context_line = (
+                f"This value belongs to the amazon product attribute: '{self.property_name}' (code: {self.property_code}).\n"
+            )
+        return (
+            f"{context_line}"
+            f"Translate the following Amazon property select value from {self.from_language_code} to {self.to_language_code}:\n"
+            f"{self.remote_value}\n\n"
+            "Only respond with the translated value, no extra text, no explanation, no punctuation. "
+            "Just one word or phrase. If the value is numeric or contains numbers, keep the numbers as digits."
+        )
+
+    def translate(self):
+        response = self.openai.responses.create(
+            model=self.model,
+            instructions=self.system_prompt,
+            temperature=self.temperature,
+            max_output_tokens=self.max_tokens,
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": self.prompt}
+                    ]
+                }
+            ],
+        )
+        return response.output[0].content[0].text.strip()

--- a/OneSila/sales_channels/integrations/amazon/constants.py
+++ b/OneSila/sales_channels/integrations/amazon/constants.py
@@ -109,3 +109,9 @@ AMAZON_PATCH_SKIP_KEYS = {
     'swatch_product_image_locator', 'image_locator_ps01', 'image_locator_ps02',
     'image_locator_ps03', 'image_locator_ps04', 'image_locator_ps05', 'image_locator_ps06',
 }
+
+# Amazon property codes for which select value translations should be skipped
+AMAZON_SELECT_VALUE_TRANSLATION_IGNORE_CODES = {
+    'country_of_origin',
+    'language',
+}

--- a/OneSila/sales_channels/integrations/amazon/migrations/0049_amazonpropertyselectvalue_translated_remote_name.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0049_amazonpropertyselectvalue_translated_remote_name.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0048_amazonproduct_last_sync_at'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='amazonpropertyselectvalue',
+            name='translated_remote_name',
+            field=models.CharField(
+                max_length=512,
+                null=True,
+                blank=True,
+                help_text='Remote name translated into the company language.',
+            ),
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/models/properties.py
@@ -158,6 +158,12 @@ class AmazonPropertySelectValue(RemoteObjectMixin, models.Model):
         blank=True,
         help_text="The display name of the value in the given locale."
     )
+    translated_remote_name = models.CharField(
+        max_length=512,
+        null=True,
+        blank=True,
+        help_text="Remote name translated into the company language.",
+    )
     local_instance = models.ForeignKey(
         'properties.PropertySelectValue',
         null=True,
@@ -172,6 +178,7 @@ class AmazonPropertySelectValue(RemoteObjectMixin, models.Model):
         unique_together = ('amazon_property', 'marketplace', 'remote_value')
         search_terms = [
             'remote_name',
+            'translated_remote_name',
             'remote_value',
             'amazon_property__name',
             'amazon_property__code',

--- a/OneSila/sales_channels/integrations/amazon/receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/receivers.py
@@ -23,6 +23,10 @@ from sales_channels.integrations.amazon.tasks import (
     create_amazon_product_type_rule_task,
     resync_amazon_product_db_task,
 )
+from sales_channels.integrations.amazon.constants import (
+    AMAZON_SELECT_VALUE_TRANSLATION_IGNORE_CODES,
+)
+from llm.factories.amazon import AmazonSelectValueTranslationLLM
 from imports_exports.signals import import_success
 from sales_channels.integrations.amazon.factories.imports.products_imports import AmazonConfigurableVariationsFactory
 from sales_channels.integrations.amazon.flows.tasks_runner import run_single_amazon_product_task_flow
@@ -96,6 +100,41 @@ def sales_channels__amazon_property__unmap_select_values(sender, instance: Amazo
         amazon_property=instance,
         local_instance__isnull=False,
     ).update(local_instance=None)
+
+
+@receiver(post_create, sender='amazon.AmazonPropertySelectValue')
+def sales_channels__amazon_property_select_value__translate(sender, instance: AmazonPropertySelectValue, **kwargs):
+    """Translate remote select value names into the company language."""
+    remote_language_obj = instance.marketplace.remote_languages.first()
+    remote_lang = remote_language_obj.local_instance if remote_language_obj else None
+    company_lang = instance.sales_channel.multi_tenant_company.language
+
+    remote_name = instance.remote_name or instance.remote_value
+
+    if instance.amazon_property.code in AMAZON_SELECT_VALUE_TRANSLATION_IGNORE_CODES:
+        instance.translated_remote_name = remote_name
+        instance.save(update_fields=['translated_remote_name'])
+        return
+
+    if not remote_lang or remote_lang == company_lang:
+        instance.translated_remote_name = remote_name
+        instance.save(update_fields=['translated_remote_name'])
+        return
+
+    translator = AmazonSelectValueTranslationLLM(
+        remote_value=remote_name,
+        from_language_code=remote_lang,
+        to_language_code=company_lang,
+        property_name=instance.amazon_property.name,
+        property_code=instance.amazon_property.code,
+    )
+    try:
+        translated = translator.translate()
+    except Exception:
+        translated = remote_name
+
+    instance.translated_remote_name = translated
+    instance.save(update_fields=['translated_remote_name'])
 
 
 @receiver(post_create, sender='amazon.AmazonProductType')

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
@@ -10,6 +10,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProperty,
     AmazonPropertySelectValue,
     AmazonProductType,
+    AmazonRemoteLanguage,
 )
 from products.models import Product
 from sales_channels.signals import manual_sync_remote_product, update_remote_product
@@ -141,5 +142,103 @@ class AmazonPropertyReceiversTest(TestCase):
 
         self.remote_select_value.refresh_from_db()
         self.assertIsNone(self.remote_select_value.local_instance)
+
+
+class AmazonSelectValueTranslationReceiverTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+        self.marketplace = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="VIEW",
+        )
+        self.property = baker.make(
+            Property,
+            type=Property.TYPES.SELECT,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.remote_property = AmazonProperty.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.property,
+            code="color",
+            type=Property.TYPES.SELECT,
+        )
+
+    @patch("sales_channels.integrations.amazon.receivers.AmazonSelectValueTranslationLLM.translate", return_value="Red")
+    def test_translate_when_language_diff(self, translate_mock):
+        AmazonRemoteLanguage.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            sales_channel_view=self.marketplace,
+            remote_code="de_DE",
+            local_instance="de",
+        )
+
+        val = AmazonPropertySelectValue.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            amazon_property=self.remote_property,
+            marketplace=self.marketplace,
+            remote_value="rot",
+            remote_name="Rot",
+        )
+
+        translate_mock.assert_called_once()
+        val.refresh_from_db()
+        self.assertEqual(val.translated_remote_name, "Red")
+
+    @patch("sales_channels.integrations.amazon.receivers.AmazonSelectValueTranslationLLM.translate")
+    def test_no_translation_when_language_same(self, translate_mock):
+        AmazonRemoteLanguage.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            sales_channel_view=self.marketplace,
+            remote_code="en_US",
+            local_instance="en",
+        )
+
+        val = AmazonPropertySelectValue.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            amazon_property=self.remote_property,
+            marketplace=self.marketplace,
+            remote_value="red",
+            remote_name="Red",
+        )
+
+        translate_mock.assert_not_called()
+        val.refresh_from_db()
+        self.assertEqual(val.translated_remote_name, "Red")
+
+    @patch("sales_channels.integrations.amazon.receivers.AmazonSelectValueTranslationLLM.translate")
+    def test_ignored_code_skips_translation(self, translate_mock):
+        AmazonRemoteLanguage.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            sales_channel_view=self.marketplace,
+            remote_code="de_DE",
+            local_instance="de",
+        )
+
+        self.remote_property.code = "country_of_origin"
+        self.remote_property.save()
+
+        val = AmazonPropertySelectValue.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            amazon_property=self.remote_property,
+            marketplace=self.marketplace,
+            remote_value="DE",
+            remote_name="Deutschland",
+        )
+
+        translate_mock.assert_not_called()
+        val.refresh_from_db()
+        self.assertEqual(val.translated_remote_name, "Deutschland")
 
 


### PR DESCRIPTION
## Summary
- add `translated_remote_name` field to Amazon property select values
- translate select values using gpt-4.1-nano with new LLM factory
- skip translation for certain Amazon codes and add unit tests

## Testing
- `python manage.py test sales_channels.integrations.amazon.tests.tests_receivers.AmazonSelectValueTranslationReceiverTest -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689c68b084b0832e9b85f9ae9154e866