### PR TITLE
Preserve default rule during Amazon product imports

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -430,7 +430,6 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
             if sales_pricelist_items:
                 structured["sales_pricelist_items"] = sales_pricelist_items
 
-
         attributes, mirror_map = self._parse_attributes(
             product_attrs, product_type_code, view
         )
@@ -691,6 +690,16 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
 
         summary = self._get_summary(product)
         rule = self.get_product_rule(product)
+
+        # Ensure we keep the rule from the default marketplace if the product
+        # already exists. This prevents overriding the initial rule when
+        # importing the product from additional marketplaces with a different
+        # product type.
+        if remote_product and remote_product.local_instance:
+            existing_rule = remote_product.local_instance.get_product_rule()
+            if existing_rule:
+                rule = existing_rule
+
         structured, language, view = self.get__product_data(product, is_variation, product_instance)
 
         # if on the main marketplaces was configurable because the other doesn't have relationships

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py
@@ -2,8 +2,21 @@ from unittest.mock import patch
 
 from core.tests import TestCase
 from imports_exports.models import Import
+from model_bakery import baker
+from properties.models import (
+    ProductProperty,
+    ProductPropertiesRule,
+    Property,
+    PropertySelectValue,
+    PropertySelectValueTranslation,
+)
 from sales_channels.integrations.amazon.factories.imports.products_imports import AmazonProductsImportProcessor
-from sales_channels.integrations.amazon.models import AmazonSalesChannel, AmazonSalesChannelView
+from sales_channels.integrations.amazon.models import (
+    AmazonProduct,
+    AmazonProductType,
+    AmazonSalesChannel,
+    AmazonSalesChannelView,
+)
 
 
 class AmazonProductsImportProcessorNameTest(TestCase):
@@ -33,10 +46,10 @@ class AmazonProductsImportProcessorNameTest(TestCase):
             }],
         }
         with patch.object(AmazonProductsImportProcessor, "get_api", return_value=None), \
-             patch.object(AmazonProductsImportProcessor, "_parse_images", return_value=[]), \
-             patch.object(AmazonProductsImportProcessor, "_parse_prices", return_value=([], [])), \
-             patch.object(AmazonProductsImportProcessor, "_parse_attributes", return_value=([], {})), \
-             patch.object(AmazonProductsImportProcessor, "_fetch_catalog_attributes", return_value=None):
+                patch.object(AmazonProductsImportProcessor, "_parse_images", return_value=[]), \
+                patch.object(AmazonProductsImportProcessor, "_parse_prices", return_value=([], [])), \
+                patch.object(AmazonProductsImportProcessor, "_parse_attributes", return_value=([], {})), \
+                patch.object(AmazonProductsImportProcessor, "_fetch_catalog_attributes", return_value=None):
             processor = AmazonProductsImportProcessor(self.import_process, self.sales_channel)
             structured, _, _ = processor.get__product_data(product_data, False)
         self.assertEqual(structured["name"], "Attr name")
@@ -54,10 +67,10 @@ class AmazonProductsImportProcessorNameTest(TestCase):
             }],
         }
         with patch.object(AmazonProductsImportProcessor, "get_api", return_value=None), \
-             patch.object(AmazonProductsImportProcessor, "_parse_images", return_value=[]), \
-             patch.object(AmazonProductsImportProcessor, "_parse_prices", return_value=([], [])), \
-             patch.object(AmazonProductsImportProcessor, "_parse_attributes", return_value=([], {})), \
-             patch.object(AmazonProductsImportProcessor, "_fetch_catalog_attributes", return_value=None):
+                patch.object(AmazonProductsImportProcessor, "_parse_images", return_value=[]), \
+                patch.object(AmazonProductsImportProcessor, "_parse_prices", return_value=([], [])), \
+                patch.object(AmazonProductsImportProcessor, "_parse_attributes", return_value=([], {})), \
+                patch.object(AmazonProductsImportProcessor, "_fetch_catalog_attributes", return_value=None):
             processor = AmazonProductsImportProcessor(self.import_process, self.sales_channel)
             structured, _, _ = processor.get__product_data(product_data, False)
         self.assertEqual(structured["name"], "Summary name")
@@ -98,3 +111,111 @@ class AmazonProductsImportProcessorPriceTest(TestCase):
         self.assertEqual(
             items[0]["salespricelist_data"]["currency_object"], self.currency
         )
+
+
+class AmazonProductsImportProcessorRulePreserveTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="GB",
+        )
+        self.import_process = Import.objects.create(multi_tenant_company=self.multi_tenant_company)
+
+        # create product type and rule
+        self.product_type_property = Property.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            is_product_type=True,
+            type=Property.TYPES.SELECT,
+        )
+        self.product_type_value = PropertySelectValue.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            property=self.product_type_property,
+        )
+        PropertySelectValueTranslation.objects.create(
+            propertyselectvalue=self.product_type_value,
+            multi_tenant_company=self.multi_tenant_company,
+            value="Default",
+        )
+        self.rule = ProductPropertiesRule.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            product_type=self.product_type_value,
+        )
+
+        self.product = baker.make(
+            "products.Product",
+            multi_tenant_company=self.multi_tenant_company,
+            type="SIMPLE",
+        )
+        ProductProperty.objects.create(
+            product=self.product,
+            property=self.product_type_property,
+            value_select=self.product_type_value,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        AmazonProductType.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            product_type_code="DEFAULT_CODE",
+            local_instance=self.rule,
+        )
+        self.remote_product = AmazonProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_sku="SKU123",
+            local_instance=self.product,
+            is_variation=False,
+        )
+
+    def test_rule_kept_when_product_type_mismatch(self):
+        product_data = {
+            "sku": "SKU123",
+            "attributes": {"item_name": [{"value": "Name"}]},
+            "summaries": [
+                {
+                    "item_name": "Name",
+                    "asin": "ASIN1",
+                    "marketplace_id": "GB",
+                    "status": ["BUYABLE"],
+                    "product_type": "OTHER_CODE",
+                }
+            ],
+        }
+
+        structured = {"name": "Name", "sku": "SKU123", "__asin": "ASIN1", "type": "SIMPLE"}
+
+        with patch.object(AmazonProductsImportProcessor, "get__product_data", return_value=(structured, None, self.view)), \
+                patch("imports_exports.factories.products.ImportProductInstance") as MockImportProductInstance, \
+                patch.object(AmazonProductsImportProcessor, "update_remote_product"), \
+                patch.object(AmazonProductsImportProcessor, "handle_ean_code"), \
+                patch.object(AmazonProductsImportProcessor, "handle_attributes"), \
+                patch.object(AmazonProductsImportProcessor, "handle_translations"), \
+                patch.object(AmazonProductsImportProcessor, "handle_prices"), \
+                patch.object(AmazonProductsImportProcessor, "handle_images"), \
+                patch.object(AmazonProductsImportProcessor, "handle_variations"), \
+                patch.object(AmazonProductsImportProcessor, "handle_sales_channels_views"), \
+                patch.object(AmazonProductsImportProcessor, "_add_broken_record") as mock_broken, \
+                patch("sales_channels.integrations.amazon.factories.imports.products_imports.FetchRemoteIssuesFactory") as MockIssuesFactory:
+
+            from types import SimpleNamespace
+
+            mock_instance = SimpleNamespace(
+                process=lambda: None,
+                prepare_mirror_model_class=lambda *args, **kwargs: None,
+                remote_instance=self.remote_product,
+            )
+            MockImportProductInstance.return_value = mock_instance
+            MockIssuesFactory.return_value.run.return_value = None
+
+            processor = AmazonProductsImportProcessor(self.import_process, self.sales_channel)
+            processor.process_product_item(product_data)
+
+            called_rule = MockImportProductInstance.call_args.kwargs["rule"]
+            self.assertEqual(called_rule, self.rule)
+            self.assertTrue(mock_broken.called)


### PR DESCRIPTION
## Summary
- keep existing product rule when importing Amazon listings with differing product types
- add regression test to ensure rule is not overwritten when types mismatch

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_products_imports.AmazonProductsImportProcessorRulePreserveTest.test_rule_kept_when_product_type_mismatch -v 2` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689c6578f72c832eb87fb3791f7fcbbd

## Summary by Sourcery

Preserve the original product properties rule when importing an existing Amazon product from additional marketplaces with a different product type, and add a regression test to verify this behavior

Bug Fixes:
- Prevent overwriting the initial product properties rule when importing an Amazon product with a mismatched product type from another marketplace

Tests:
- Add a regression test to ensure the existing rule is retained when product types mismatch during import