### PR TITLE
Fix ImportProductInstance patch path

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py
@@ -191,7 +191,7 @@ class AmazonProductsImportProcessorRulePreserveTest(TestCase):
         structured = {"name": "Name", "sku": "SKU123", "__asin": "ASIN1", "type": "SIMPLE"}
 
         with patch.object(AmazonProductsImportProcessor, "get__product_data", return_value=(structured, None, self.view)), \
-                patch("imports_exports.factories.products.ImportProductInstance") as MockImportProductInstance, \
+                patch("sales_channels.integrations.amazon.factories.imports.products_imports.ImportProductInstance") as MockImportProductInstance, \
                 patch.object(AmazonProductsImportProcessor, "update_remote_product"), \
                 patch.object(AmazonProductsImportProcessor, "handle_ean_code"), \
                 patch.object(AmazonProductsImportProcessor, "handle_attributes"), \


### PR DESCRIPTION
## Summary
- fix unit test to patch ImportProductInstance from amazon products imports module

## Testing
- `python manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_products_imports.AmazonProductsImportProcessorRulePreserveTest.test_rule_kept_when_product_type_mismatch -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689c90a71f3c832ea46345332cc196ef

## Summary by Sourcery

Fix the patch path for ImportProductInstance in the AmazonProductsImportProcessor unit test

Bug Fixes:
- Correct the mocked ImportProductInstance path to the actual module location

Tests:
- Update the test to patch sales_channels.integrations.amazon.factories.imports.products_imports.ImportProductInstance