### PR TITLE
Add update_only mode for importers

### DIFF
--- a/OneSila/imports_exports/migrations/0015_import_update_only.py
+++ b/OneSila/imports_exports/migrations/0015_import_update_only.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('imports_exports', '0014_alter_mappedimport_json_file'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='import',
+            name='update_only',
+            field=models.BooleanField(default=False, help_text='If True, the import will only update existing objects and fail if they do not exist.'),
+        ),
+    ]

--- a/OneSila/imports_exports/models.py
+++ b/OneSila/imports_exports/models.py
@@ -51,6 +51,10 @@ class Import(PolymorphicModel, models.Model):
         default=False,
         help_text="If True, existing objects fetched during the import will not be updated.",
     )
+    update_only = models.BooleanField(
+        default=False,
+        help_text="If True, the import will only update existing objects and fail if they do not exist.",
+    )
     skip_broken_records = models.BooleanField(
         default=False,
         help_text="If True, the import will skip records that raise errors and continue processing."

--- a/OneSila/imports_exports/tests/tests_factories/tests_mapped_imports.py
+++ b/OneSila/imports_exports/tests/tests_factories/tests_mapped_imports.py
@@ -4,6 +4,7 @@ from django.core.files.base import ContentFile
 from core.tests import TestCase
 from imports_exports.models import MappedImport
 
+
 class MappedImportSkipBrokenRecordsTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -57,3 +58,35 @@ class MappedImportSkipBrokenRecordsTest(TestCase):
         self.assertIn('step', mapped_import.broken_records[0])
         self.assertIn('error', mapped_import.broken_records[0])
         self.assertIn('traceback', mapped_import.broken_records[0])
+
+
+class MappedImportUpdateOnlyBrokenRecordsTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.company = self.multi_tenant_company
+
+    def create_import_file(self, data):
+        json_content = json.dumps(data, ensure_ascii=False, indent=2)
+        tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".json", mode="w+")
+        tmp_file.write(json_content)
+        tmp_file.flush()
+        tmp_file.seek(0)
+        return ContentFile(tmp_file.read().encode("utf-8"), name="test_products.json")
+
+    def test_missing_product_logged_when_update_only(self):
+        product_data = [{"sku": "P999", "name": "Missing Product", "type": "SIMPLE"}]
+        file_content = self.create_import_file(product_data)
+        mapped_import = MappedImport.objects.create(
+            multi_tenant_company=self.company,
+            type='product',
+            skip_broken_records=True,
+            update_only=True,
+        )
+        mapped_import.json_file.save("products.json", file_content, save=True)
+
+        mapped_import.run()
+        mapped_import.refresh_from_db()
+
+        self.assertEqual(mapped_import.status, 'success')
+        self.assertEqual(len(mapped_import.broken_records), 1)
+        self.assertIn('error', mapped_import.broken_records[0])


### PR DESCRIPTION
## Summary
- add `update_only` flag to `Import` and importer instances
- raise error when an instance is missing in update-only mode
- cover update-only behavior with tests

## Testing
- `pre-commit run --files OneSila/imports_exports/factories/mixins.py OneSila/imports_exports/models.py OneSila/imports_exports/migrations/0015_import_update_only.py OneSila/imports_exports/tests/tests_factories/tests_products.py OneSila/imports_exports/tests/tests_factories/tests_mapped_imports.py`
- `python OneSila/manage.py test imports_exports.tests.tests_factories.tests_products.ImportProductInstanceUpdateOnlyTest --verbosity=2 --settings=test_settings` *(fails: Error 111 connecting to 127.0.0.1:6379)*
- `python OneSila/manage.py test imports_exports.tests.tests_factories.tests_mapped_imports.MappedImportUpdateOnlyBrokenRecordsTest --verbosity=2 --settings=test_settings` *(fails: Error 111 connecting to 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_689cd1fe016c832e83f127b3360c2c51