### PR TITLE
Allow importing products without a name

### DIFF
--- a/OneSila/imports_exports/factories/products.py
+++ b/OneSila/imports_exports/factories/products.py
@@ -154,9 +154,6 @@ class ImportProductInstance(AbstractImportInstance, AddLogTimeentry):
         """
         Validate that the 'value' key exists.
         """
-        if not hasattr(self, 'name'):
-            raise ValueError("The 'name' field is required.")
-
         if hasattr(self, 'type') and self.type not in [Product.SIMPLE, Product.CONFIGURABLE, Product.BUNDLE, Product.ALIAS]:
             raise ValueError("Invalid 'type' value.")
 
@@ -286,10 +283,10 @@ class ImportProductInstance(AbstractImportInstance, AddLogTimeentry):
 
     def _set_translations(self):
 
-        if not getattr(self, 'translations', []):
+        if not getattr(self, 'translations', []) and getattr(self, 'name', None):
 
             self.translations = [{
-                'name': getattr(self, 'name', 'Unnamed'),
+                'name': self.name,
                 'language': self.language,
                 'sales_channel': self.sales_channel,
             }]

--- a/OneSila/imports_exports/tests/tests_factories/tests_products.py
+++ b/OneSila/imports_exports/tests/tests_factories/tests_products.py
@@ -18,16 +18,17 @@ class ImportProductInstanceValidateTest(TestCase):
         super().setUp()
         self.import_process = Import.objects.create(multi_tenant_company=self.multi_tenant_company)
 
-    def test_missing_name_raises_error(self):
+    def test_missing_name_creates_no_translation(self):
         data = {
             "sku": "SKU123",
             "type": "SIMPLE"
         }
 
-        with self.assertRaises(ValueError) as cm:
-            ImportProductInstance(data, self.import_process)
+        instance = ImportProductInstance(data, self.import_process)
+        instance.pre_process_logic()
 
-        self.assertIn("The 'name' field is required", str(cm.exception))
+        self.assertFalse(hasattr(instance, 'name'))
+        self.assertEqual(instance.translations, [])
 
     def test_valid_with_name_and_sku(self):
         data = {


### PR DESCRIPTION
## Summary
- Allow product imports without a name and skip translation creation when absent
- Adjust tests for optional product names

## Testing
- `pre-commit run --files OneSila/imports_exports/factories/products.py OneSila/imports_exports/tests/tests_factories/tests_products.py`
- `python OneSila/manage.py test imports_exports.tests.tests_factories.tests_products` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689d183ce35c832eaf6f6904f90b5ce0