### PR TITLE
Add Amazon import data model

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -42,7 +42,10 @@ from dateutil.parser import parse
 from sales_channels.integrations.amazon.factories.sales_channels.issues import FetchRemoteIssuesFactory
 import datetime
 from imports_exports.helpers import append_broken_record, increment_processed_records
-from sales_channels.integrations.amazon.models.imports import AmazonImportRelationship
+from sales_channels.integrations.amazon.models.imports import (
+    AmazonImportRelationship,
+    AmazonImportData,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -702,7 +705,7 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
                 rule = existing_rule
 
         if rule is None:
-            rule =  self.get_product_rule(product)
+            rule = self.get_product_rule(product)
 
         structured, language, view = self.get__product_data(product, is_variation, product_instance)
 
@@ -848,6 +851,15 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
             view=view,
             response_data=product
         ).run()
+
+        product_obj = product_instance or instance.local_instance
+        if product_obj:
+            AmazonImportData.objects.update_or_create(
+                sales_channel=self.sales_channel,
+                product=product_obj,
+                view=view,
+                defaults={'data': product},
+            )
 
     def import_products_process(self):
         for product in self.get_products_data():

--- a/OneSila/sales_channels/integrations/amazon/migrations/0050_amazonimportdata.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0050_amazonimportdata.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0049_amazonpropertyselectvalue_translated_remote_name'),
+        ('products', '0019_alter_producttranslation_unique_together_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AmazonImportData',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('data', models.JSONField(blank=True, default=dict)),
+                ('product', models.ForeignKey(on_delete=models.CASCADE, related_name='amazon_import_data', to='products.product')),
+                ('sales_channel', models.ForeignKey(on_delete=models.CASCADE, related_name='import_data', to='amazon.amazonsaleschannel')),
+                ('view', models.ForeignKey(on_delete=models.CASCADE, related_name='import_data', to='amazon.amazonsaleschannelview')),
+            ],
+            options={
+                'verbose_name': 'Amazon Import Data',
+                'verbose_name_plural': 'Amazon Import Data',
+                'unique_together': {('sales_channel', 'product', 'view')},
+            },
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/imports.py
+++ b/OneSila/sales_channels/integrations/amazon/models/imports.py
@@ -33,7 +33,6 @@ class AmazonImportRelationship(models.Model):
         verbose_name_plural = "Amazon Import Relationships"
 
 
-
 class AmazonImportBrokenRecord(models.Model):
     """Store parent-child SKU pairs during async product import."""
 
@@ -46,3 +45,29 @@ class AmazonImportBrokenRecord(models.Model):
     class Meta:
         verbose_name = "Amazon Import Broken Record"
         verbose_name_plural = "Amazon Import Broken Records"
+
+
+class AmazonImportData(models.Model):
+    """Stores raw import data for each Amazon product."""
+
+    sales_channel = models.ForeignKey(
+        'amazon.AmazonSalesChannel',
+        on_delete=models.CASCADE,
+        related_name='import_data',
+    )
+    product = models.ForeignKey(
+        'products.Product',
+        on_delete=models.CASCADE,
+        related_name='amazon_import_data',
+    )
+    view = models.ForeignKey(
+        'amazon.AmazonSalesChannelView',
+        on_delete=models.CASCADE,
+        related_name='import_data',
+    )
+    data = models.JSONField(blank=True, default=dict)
+
+    class Meta:
+        unique_together = ('sales_channel', 'product', 'view')
+        verbose_name = 'Amazon Import Data'
+        verbose_name_plural = 'Amazon Import Data'

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py
@@ -16,6 +16,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProductType,
     AmazonSalesChannel,
     AmazonSalesChannelView,
+    AmazonImportData,
 )
 
 
@@ -219,3 +220,72 @@ class AmazonProductsImportProcessorRulePreserveTest(TestCase):
             called_rule = MockImportProductInstance.call_args.kwargs["rule"]
             self.assertEqual(called_rule, self.rule)
             self.assertTrue(mock_broken.called)
+
+
+class AmazonProductsImportProcessorImportDataTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="GB",
+        )
+        self.import_process = Import.objects.create(multi_tenant_company=self.multi_tenant_company)
+        self.product = baker.make(
+            "products.Product",
+            multi_tenant_company=self.multi_tenant_company,
+            type="SIMPLE",
+        )
+
+    def test_import_data_saved(self):
+        product_data = {
+            "sku": "SKU123",
+            "attributes": {"item_name": [{"value": "Name"}]},
+            "summaries": [
+                {
+                    "item_name": "Name",
+                    "asin": "ASIN1",
+                    "marketplace_id": "GB",
+                    "status": ["BUYABLE"],
+                    "product_type": "TYPE",
+                }
+            ],
+        }
+
+        structured = {"name": "Name", "sku": "SKU123", "__asin": "ASIN1", "type": "SIMPLE"}
+
+        with patch.object(AmazonProductsImportProcessor, "get__product_data", return_value=(structured, None, self.view)), \
+                patch("sales_channels.integrations.amazon.factories.imports.products_imports.ImportProductInstance") as MockImportProductInstance, \
+                patch.object(AmazonProductsImportProcessor, "update_remote_product"), \
+                patch.object(AmazonProductsImportProcessor, "handle_ean_code"), \
+                patch.object(AmazonProductsImportProcessor, "handle_attributes"), \
+                patch.object(AmazonProductsImportProcessor, "handle_translations"), \
+                patch.object(AmazonProductsImportProcessor, "handle_prices"), \
+                patch.object(AmazonProductsImportProcessor, "handle_images"), \
+                patch.object(AmazonProductsImportProcessor, "handle_variations"), \
+                patch.object(AmazonProductsImportProcessor, "handle_sales_channels_views"), \
+                patch("sales_channels.integrations.amazon.factories.imports.products_imports.FetchRemoteIssuesFactory") as MockIssuesFactory:
+
+            from types import SimpleNamespace
+
+            mock_instance = SimpleNamespace(
+                process=lambda: None,
+                prepare_mirror_model_class=lambda *args, **kwargs: None,
+                local_instance=self.product,
+                remote_instance=None,
+            )
+            MockImportProductInstance.return_value = mock_instance
+            MockIssuesFactory.return_value.run.return_value = None
+
+            processor = AmazonProductsImportProcessor(self.import_process, self.sales_channel)
+            processor.process_product_item(product_data)
+
+        saved = AmazonImportData.objects.get()
+        self.assertEqual(saved.sales_channel, self.sales_channel)
+        self.assertEqual(saved.product, self.product)
+        self.assertEqual(saved.view, self.view)
+        self.assertEqual(saved.data["sku"], "SKU123")


### PR DESCRIPTION
## Summary
- add `AmazonImportData` model to store raw Amazon product payloads
- persist import data at end of product import processing
- cover new model with tests and migration

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/models/imports.py OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py OneSila/sales_channels/integrations/amazon/migrations/0050_amazonimportdata.py`
- `python manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_products_imports.AmazonProductsImportProcessorImportDataTest -v 2` *(fails: connection to PostgreSQL refused)*

------
https://chatgpt.com/codex/tasks/task_e_689dd48929a4832ea39cbc43d33b7c76

## Summary by Sourcery

Add AmazonImportData model and migration, update AmazonProductsImportProcessor to save raw import payloads, and add tests for the new functionality

New Features:
- Introduce AmazonImportData model for storing raw Amazon product payloads
- Persist AmazonImportData in the products import processor after each product is processed

Build:
- Add migration to create AmazonImportData table with unique constraint on sales channel, product, and view

Tests:
- Add tests to verify AmazonImportData records are created with correct sales channel, product, view, and data