### PR TITLE
feat(amazon): support auto-importing select values

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/auto_import.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/auto_import.py
@@ -1,0 +1,49 @@
+from properties.models import ProductProperty, Property
+from sales_channels.integrations.amazon.models import (
+    AmazonProductProperty,
+    AmazonPropertySelectValue,
+)
+from django.db.models import Q
+
+
+class AmazonAutoImportSelectValueFactory:
+    def __init__(self, select_value: AmazonPropertySelectValue):
+        self.select_value = select_value
+        self.remote_property = select_value.amazon_property
+        self.sales_channel = select_value.sales_channel
+
+    def run(self):
+        if not self.select_value.local_instance or not self.remote_property.local_instance:
+            return
+
+        qs = AmazonProductProperty.objects.filter(
+            sales_channel=self.sales_channel,
+            remote_property=self.remote_property,
+            local_instance__isnull=True,
+        ).filter(
+            Q(remote_select_value=self.select_value) |
+            Q(remote_select_values=self.select_value)
+        ).select_related("remote_product", "remote_product__local_instance")
+
+        for app in qs:
+            product = app.remote_product.local_instance
+            if not product:
+                continue
+
+            prop = self.remote_property.local_instance
+            pp, _ = ProductProperty.objects.get_or_create(
+                multi_tenant_company=product.multi_tenant_company,
+                product=product,
+                property=prop,
+            )
+
+            if prop.type == Property.TYPES.SELECT:
+                pp.value_select = self.select_value.local_instance
+                pp.save()
+            elif prop.type == Property.TYPES.MULTISELECT:
+                pp.save()
+                if self.select_value.local_instance not in pp.value_multi_select.all():
+                    pp.value_multi_select.add(self.select_value.local_instance)
+
+            app.local_instance = pp
+            app.save(update_fields=["local_instance"])

--- a/OneSila/sales_channels/integrations/amazon/factories/properties/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/properties/properties.py
@@ -55,6 +55,7 @@ class AmazonProductPropertyCreateFactory(AmazonProductPropertyBaseMixin, RemoteP
 
     def post_create_process(self):
         super().post_create_process()
+        self.update_remote_select_fields(self.remote_instance)
 
 
 class AmazonProductPropertyUpdateFactory(AmazonProductPropertyBaseMixin, RemoteProductPropertyUpdateFactory):
@@ -136,6 +137,10 @@ class AmazonProductPropertyUpdateFactory(AmazonProductPropertyBaseMixin, RemoteP
         create_factory.run()
 
         self.remote_instance = create_factory.remote_instance
+
+    def post_update_process(self):
+        super().post_update_process()
+        self.update_remote_select_fields(self.remote_instance)
 
 
 class AmazonProductPropertyDeleteFactory(AmazonProductPropertyBaseMixin, RemoteProductPropertyDeleteFactory):

--- a/OneSila/sales_channels/integrations/amazon/migrations/0051_amazonproductproperty_remote_select_values.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0051_amazonproductproperty_remote_select_values.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('amazon', '0050_amazonimportdata'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='amazonproductproperty',
+            name='remote_select_value',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL,
+                                    related_name='product_properties', to='amazon.amazonpropertyselectvalue'),
+        ),
+        migrations.AddField(
+            model_name='amazonproductproperty',
+            name='remote_select_values',
+            field=models.ManyToManyField(blank=True, related_name='product_properties_multi', to='amazon.amazonpropertyselectvalue'),
+        ),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/properties.py
+++ b/OneSila/sales_channels/integrations/amazon/models/properties.py
@@ -191,6 +191,21 @@ class AmazonPropertySelectValue(RemoteObjectMixin, models.Model):
 class AmazonProductProperty(RemoteProductProperty):
     """Amazon specific remote product property."""
 
+    remote_select_value = models.ForeignKey(
+        AmazonPropertySelectValue,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="product_properties",
+        help_text="Reference to the remote select value if applicable.",
+    )
+    remote_select_values = models.ManyToManyField(
+        AmazonPropertySelectValue,
+        blank=True,
+        related_name="product_properties_multi",
+        help_text="References to remote select values for multiselect properties.",
+    )
+
     class Meta:
         verbose_name_plural = _('Amazon Product Properties')
 
@@ -233,15 +248,15 @@ class AmazonProductType(RemoteObjectMixin, models.Model):
                 fields=['local_instance', 'sales_channel'],
                 condition=Q(local_instance__isnull=False),
                 name='unique_amazonproducttype_local_instance_sales_channel_not_null',
-                violation_error_message = _(
-                "An Amazon product type with this local rule already exists for this sales channel."
-            )
+                violation_error_message=_(
+                    "An Amazon product type with this local rule already exists for this sales channel."
+                )
             ),
             UniqueConstraint(
                 fields=['product_type_code', 'sales_channel'],
                 condition=Q(product_type_code__isnull=False),
                 name='unique_amazonproducttype_code_sales_channel_not_null',
-                violation_error_message= _(
+                violation_error_message=_(
                     "An Amazon product type with this product type code already exists for this sales channel."
                 )
             )

--- a/OneSila/sales_channels/integrations/amazon/receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/receivers.py
@@ -137,6 +137,17 @@ def sales_channels__amazon_property_select_value__translate(sender, instance: Am
     instance.save(update_fields=['translated_remote_name'])
 
 
+@receiver(post_update, sender='amazon.AmazonPropertySelectValue')
+def sales_channels__amazon_property_select_value__auto_import(sender, instance: AmazonPropertySelectValue, **kwargs):
+    """Auto-import mapped select values into product properties."""
+    if not instance.is_dirty_field('local_instance', check_relationship=True):
+        return
+
+    from sales_channels.integrations.amazon.tasks import amazon_auto_import_select_value_task
+
+    amazon_auto_import_select_value_task(instance.id)
+
+
 @receiver(post_create, sender='amazon.AmazonProductType')
 @receiver(post_update, sender='amazon.AmazonProductType')
 def sales_channels__amazon_product_type__ensure_asin(sender, instance, **kwargs):
@@ -181,5 +192,3 @@ def amazon__product__manual_sync(sender, instance, view, force_validation_only=F
         remote_product_id=instance.id,
         force_validation_only=force_validation_only,
     )
-
-

--- a/OneSila/sales_channels/integrations/amazon/tasks.py
+++ b/OneSila/sales_channels/integrations/amazon/tasks.py
@@ -59,6 +59,18 @@ def create_amazon_product_type_rule_task(product_type_code: str, sales_channel_i
     fac.run()
 
 
+@db_task()
+def amazon_auto_import_select_value_task(select_value_id: int):
+    from sales_channels.integrations.amazon.models import AmazonPropertySelectValue
+    from sales_channels.integrations.amazon.factories.auto_import import (
+        AmazonAutoImportSelectValueFactory,
+    )
+
+    select_value = AmazonPropertySelectValue.objects.get(id=select_value_id)
+    fac = AmazonAutoImportSelectValueFactory(select_value)
+    fac.run()
+
+
 @remote_task(priority=CRUCIAL_PRIORITY, number_of_remote_requests=1)
 @db_task()
 def resync_amazon_product_db_task(

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_auto_import_select_value_factory.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_auto_import_select_value_factory.py
@@ -1,0 +1,83 @@
+from core.tests import TestCase
+from model_bakery import baker
+from properties.models import Property, PropertySelectValue, ProductProperty
+from products.models import Product
+from sales_channels.integrations.amazon.models import (
+    AmazonSalesChannel,
+    AmazonSalesChannelView,
+    AmazonProduct,
+    AmazonProperty,
+    AmazonPropertySelectValue,
+    AmazonProductProperty,
+)
+from sales_channels.integrations.amazon.factories.auto_import import AmazonAutoImportSelectValueFactory
+from ..helpers import DisableWooCommerceSignalsMixin
+
+
+class AmazonAutoImportSelectValueFactoryTest(DisableWooCommerceSignalsMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="VIEW",
+        )
+        self.property = baker.make(
+            Property,
+            type=Property.TYPES.SELECT,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.remote_property = AmazonProperty.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.property,
+            code="color",
+            type=Property.TYPES.SELECT,
+            allows_unmapped_values=True,
+        )
+        self.product = Product.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Product.SIMPLE,
+        )
+        self.remote_product = AmazonProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+        )
+        self.remote_select_value = AmazonPropertySelectValue.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            amazon_property=self.remote_property,
+            marketplace=self.view,
+            remote_value="red",
+            remote_name="Red",
+        )
+        self.remote_product_property = AmazonProductProperty.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_product=self.remote_product,
+            remote_property=self.remote_property,
+            remote_value="red",
+            remote_select_value=self.remote_select_value,
+        )
+
+    def test_run_maps_and_creates_product_property(self):
+        local_value = baker.make(
+            PropertySelectValue,
+            property=self.property,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.remote_select_value.local_instance = local_value
+        self.remote_select_value.save()
+
+        fac = AmazonAutoImportSelectValueFactory(self.remote_select_value)
+        fac.run()
+
+        pp = ProductProperty.objects.get(product=self.product, property=self.property)
+        self.assertEqual(pp.value_select, local_value)
+        self.remote_product_property.refresh_from_db()
+        self.assertEqual(self.remote_product_property.local_instance, pp)

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
@@ -242,3 +242,48 @@ class AmazonSelectValueTranslationReceiverTest(TestCase):
         self.assertEqual(val.translated_remote_name, "Deutschland")
 
 
+class AmazonSelectValueAutoImportReceiverTest(DisableWooCommerceSignalsMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+        self.marketplace = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="VIEW",
+        )
+        self.property = baker.make(
+            Property,
+            type=Property.TYPES.SELECT,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.remote_property = AmazonProperty.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.property,
+            code="color",
+            type=Property.TYPES.SELECT,
+            allows_unmapped_values=True,
+        )
+        self.remote_select_value = AmazonPropertySelectValue.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            amazon_property=self.remote_property,
+            marketplace=self.marketplace,
+            remote_value="red",
+            remote_name="Red",
+        )
+
+    @patch("sales_channels.integrations.amazon.receivers.amazon_auto_import_select_value_task")
+    def test_triggered_on_mapping(self, task_mock):
+        local_val = baker.make(
+            PropertySelectValue,
+            property=self.property,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.remote_select_value.local_instance = local_val
+        self.remote_select_value.save()
+
+        task_mock.assert_called_once_with(self.remote_select_value.id)


### PR DESCRIPTION
## Summary
- track unmapped Amazon select options on product properties
- auto-import product properties when select values get mapped

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/models/properties.py OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py OneSila/sales_channels/integrations/amazon/factories/properties/properties.py OneSila/sales_channels/integrations/amazon/factories/auto_import.py OneSila/sales_channels/integrations/amazon/receivers.py OneSila/sales_channels/integrations/amazon/tasks.py OneSila/sales_channels/integrations/amazon/migrations/0051_amazonproductproperty_remote_select_values.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_auto_import_select_value_factory.py OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_auto_import_select_value_factory sales_channels.integrations.amazon.tests.tests_receivers.AmazonSelectValueAutoImportReceiverTest -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689df7c8a654832e8fef9ed8f79b8ff1

## Summary by Sourcery

Add support for auto-importing Amazon select values by extending AmazonProductProperty with select mapping fields, updating import factories to handle these fields, triggering a background task on mapping changes, and automatically creating/updating local product properties.

New Features:
- Add remote_select_value and remote_select_values fields to AmazonProductProperty to track mapped select options
- Trigger amazon_auto_import_select_value_task when an AmazonPropertySelectValue is mapped to import corresponding local product properties
- Implement AmazonAutoImportSelectValueFactory and a DB task to automatically create or update ProductProperty and link it to AmazonProductProperty

Enhancements:
- Enhance import factories to parse, propagate, and synchronize remote_select_value(s) during product and property imports
- Introduce update_remote_select_fields logic in the properties mixin to keep remote select fields in sync on create and update

Tests:
- Add tests for AmazonAutoImportSelectValueFactory behavior
- Add receiver test to ensure the auto-import task is triggered on select value mapping

Chores:
- Add Django migration to add remote_select_value and remote_select_values to AmazonProductProperty