### PR TITLE
Allow creating variations during update-only imports

### DIFF
--- a/OneSila/imports_exports/factories/variations.py
+++ b/OneSila/imports_exports/factories/variations.py
@@ -55,6 +55,8 @@ class ImportConfigurableVariationInstance(AbstractImportInstance):
 
         if not self.variation_product and hasattr(self, 'variation_data'):
             self.variation_import_instance = ImportProductInstance(self.variation_data, self.import_process, sales_channel=self.sales_channel)
+            # allow creating variations even when the import is update_only
+            self.variation_import_instance.update_only = False
 
     def pre_process_logic(self):
         if not self.config_product:
@@ -231,6 +233,8 @@ class ImportBundleVariationInstance(AbstractImportInstance):
 
         if not self.variation_product and hasattr(self, 'variation_data'):
             self.variation_import_instance = ImportProductInstance(self.variation_data, self.import_process, sales_channel=self.sales_channel)
+            # allow creating variations even when the import is update_only
+            self.variation_import_instance.update_only = False
 
     def pre_process_logic(self):
         if not self.bundle_product:
@@ -306,6 +310,8 @@ class ImportAliasVariationInstance(AbstractImportInstance):
         if not self.alias_product:
             self.variation_data["alias_parent_product"] = self.parent_product
             self.alias_product_import_instance = ImportProductInstance(self.variation_data, self.import_process, sales_channel=self.sales_channel)
+            # allow creating alias variations even when the import is update_only
+            self.alias_product_import_instance.update_only = False
             self.alias_product_import_instance.process()
             self.alias_product = self.alias_product_import_instance.instance
 


### PR DESCRIPTION
## Summary
- allow creation of variation products when parent imports run in update-only mode
- test configurable, bundle, and alias variation creation under update-only imports

## Testing
- `pre-commit run --files OneSila/imports_exports/factories/variations.py OneSila/imports_exports/tests/tests_factories/tests_variations.py`
- `python OneSila/manage.py test imports_exports.tests.tests_factories.tests_variations` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689ed0f1cbcc832ea7851a4311ae7dab

## Summary by Sourcery

Allow creating configurable, bundle, and alias product variations during update-only imports by overriding the update_only flag on variation import instances

Enhancements:
- Override update_only to False on variation import instances in configurable, bundle, and alias variation factories

Tests:
- Add ImportVariationUpdateOnlyTest with test cases for configurable, bundle, and alias variation creation under update-only imports