### PR TITLE
feat: add Amazon product property query

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -4,6 +4,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonPropertyType,
     AmazonPropertySelectValueType,
     AmazonProductType,
+    AmazonProductPropertyType,
     AmazonProductTypeType,
     AmazonProductTypeItemType,
     AmazonSalesChannelImportType,
@@ -24,6 +25,9 @@ class AmazonSalesChannelsQuery:
 
     amazon_property_select_value: AmazonPropertySelectValueType = node()
     amazon_property_select_values: DjangoListConnection[AmazonPropertySelectValueType] = connection()
+
+    amazon_product_property: AmazonProductPropertyType = node()
+    amazon_product_properties: DjangoListConnection[AmazonProductPropertyType] = connection()
 
     amazon_product: AmazonProductType = node()
     amazon_products: DjangoListConnection[AmazonProductType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -12,8 +12,10 @@ from sales_channels.integrations.amazon.models import (
     AmazonProperty,
     AmazonPropertySelectValue,
     AmazonProduct,
+    AmazonProductProperty,
     AmazonProductType,
-    AmazonSalesChannelImport, AmazonProductTypeItem,
+    AmazonSalesChannelImport,
+    AmazonProductTypeItem,
     AmazonDefaultUnitConfigurator,
     AmazonRemoteLog,
     AmazonProductIssue,
@@ -23,6 +25,7 @@ from properties.schema.types.filters import (
     PropertySelectValueFilter,
     ProductPropertiesRuleFilter,
     ProductPropertiesRuleItemFilter,
+    ProductPropertyFilter,
 )
 from products.schema.types.filters import ProductFilter
 from sales_channels.schema.types.filters import (
@@ -129,6 +132,15 @@ class AmazonProductFilter(SearchFilterMixin):
     id: auto
     sales_channel: Optional[SalesChannelFilter]
     local_instance: Optional[ProductFilter]
+
+
+@filter(AmazonProductProperty)
+class AmazonProductPropertyFilter(SearchFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]
+    local_instance: Optional[ProductPropertyFilter]
+    remote_select_value: Optional[AmazonPropertySelectValueFilter]
+    remote_product: Optional[AmazonProductFilter]
 
 
 @filter(AmazonSalesChannelImport)

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -7,6 +7,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProperty,
     AmazonPropertySelectValue,
     AmazonProduct,
+    AmazonProductProperty,
     AmazonProductType,
     AmazonProductTypeItem,
     AmazonSalesChannelImport,
@@ -15,6 +16,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonSalesChannelView,
     AmazonProductIssue,
 )
+from properties.schema.types.ordering import ProductPropertyOrder
 
 
 @order(AmazonSalesChannel)
@@ -67,7 +69,16 @@ class AmazonRemoteLogOrder:
 class AmazonProductIssueOrder:
     id: auto
 
+
 @order(AmazonPropertySelectValue)
 class AmazonPropertySelectValueOrder:
     id: auto
     marketplace: Optional[AmazonSalesChannelViewOrder]
+
+
+@order(AmazonProductProperty)
+class AmazonProductPropertyOrder:
+    id: auto
+    local_instance: Optional[ProductPropertyOrder]
+    remote_product: Optional[AmazonProductOrder]
+    remote_select_value: Optional[AmazonPropertySelectValueOrder]

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -15,6 +15,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProperty,
     AmazonPropertySelectValue,
     AmazonProduct,
+    AmazonProductProperty,
     AmazonProductType,
     AmazonProductTypeItem,
     AmazonSalesChannelImport,
@@ -28,6 +29,7 @@ from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonPropertyFilter,
     AmazonPropertySelectValueFilter,
     AmazonProductFilter,
+    AmazonProductPropertyFilter,
     AmazonProductTypeFilter,
     AmazonProductTypeItemFilter,
     AmazonSalesChannelImportFilter, AmazonDefaultUnitConfiguratorFilter,
@@ -38,6 +40,7 @@ from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonPropertyOrder,
     AmazonPropertySelectValueOrder,
     AmazonProductOrder,
+    AmazonProductPropertyOrder,
     AmazonProductTypeOrder,
     AmazonProductTypeItemOrder,
     AmazonSalesChannelImportOrder,
@@ -252,6 +255,36 @@ class AmazonProductType(relay.Node, GetQuerysetMultiTenantMixin):
     @field()
     def has_errors(self, info) -> bool | None:
         return self.has_errors
+
+
+@type(
+    AmazonProductProperty,
+    filters=AmazonProductPropertyFilter,
+    order=AmazonProductPropertyOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonProductPropertyType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'AmazonSalesChannelType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]
+    local_instance: Optional[Annotated[
+        'ProductPropertyType',
+        lazy("properties.schema.types.types")
+    ]]
+    remote_product: Annotated[
+        'AmazonProductType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]
+    remote_select_value: Optional[Annotated[
+        'AmazonPropertySelectValueType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]]
+    remote_select_values: List[Annotated[
+        'AmazonPropertySelectValueType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]]
 
 
 @type(

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py
@@ -23,3 +23,39 @@ query ($id: GlobalID!) {
   }
 }
 """
+
+AMAZON_PRODUCT_PROPERTY_FILTER_BY_LOCAL_INSTANCE = """
+query ($localInstance: GlobalID!) {
+  amazonProductProperties(filters: {localInstance: {id: {exact: $localInstance}}}) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+"""
+
+AMAZON_PRODUCT_PROPERTY_FILTER_BY_REMOTE_SELECT_VALUE = """
+query ($remoteSelectValue: GlobalID!) {
+  amazonProductProperties(filters: {remoteSelectValue: {id: {exact: $remoteSelectValue}}}) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+"""
+
+AMAZON_PRODUCT_PROPERTY_FILTER_BY_REMOTE_PRODUCT = """
+query ($remoteProduct: GlobalID!) {
+  amazonProductProperties(filters: {remoteProduct: {id: {exact: $remoteProduct}}}) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+"""

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/tests_queries.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/tests_queries.py
@@ -7,12 +7,19 @@ from sales_channels.integrations.amazon.models import (
     AmazonProduct,
     AmazonProductIssue,
     AmazonSalesChannelView,
+    AmazonProperty,
+    AmazonPropertySelectValue,
+    AmazonProductProperty,
 )
 from products.models import Product
+from properties.models import Property, ProductProperty
 
 from .queries import (
     AMAZON_PRODUCT_FILTER_BY_LOCAL_INSTANCE,
     AMAZON_PRODUCT_WITH_ISSUES,
+    AMAZON_PRODUCT_PROPERTY_FILTER_BY_LOCAL_INSTANCE,
+    AMAZON_PRODUCT_PROPERTY_FILTER_BY_REMOTE_SELECT_VALUE,
+    AMAZON_PRODUCT_PROPERTY_FILTER_BY_REMOTE_PRODUCT,
 )
 
 
@@ -44,6 +51,94 @@ class AmazonProductQueryTest(TransactionTestCaseMixin, TransactionTestCase):
         edges = resp.data["amazonProducts"]["edges"]
         self.assertEqual(len(edges), 1)
         self.assertEqual(edges[0]["node"]["id"], self.to_global_id(self.amazon_product))
+
+
+class AmazonProductPropertyQueryTest(TransactionTestCaseMixin, TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = baker.make(
+            AmazonSalesChannel,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.product = baker.make(
+            Product,
+            multi_tenant_company=self.multi_tenant_company,
+            type="SIMPLE",
+        )
+        self.amazon_product = baker.make(
+            AmazonProduct,
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+        )
+        self.property = baker.make(
+            Property,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.product_property = baker.make(
+            ProductProperty,
+            product=self.product,
+            property=self.property,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.amazon_property = baker.make(
+            AmazonProperty,
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.property,
+        )
+        self.marketplace = baker.make(
+            AmazonSalesChannelView,
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.remote_select_value = baker.make(
+            AmazonPropertySelectValue,
+            amazon_property=self.amazon_property,
+            marketplace=self.marketplace,
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+            remote_value="VAL",
+        )
+        self.amazon_product_property = baker.make(
+            AmazonProductProperty,
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.product_property,
+            remote_product=self.amazon_product,
+            remote_property=self.amazon_property,
+            remote_select_value=self.remote_select_value,
+        )
+
+    def test_filter_by_local_instance(self):
+        resp = self.strawberry_test_client(
+            query=AMAZON_PRODUCT_PROPERTY_FILTER_BY_LOCAL_INSTANCE,
+            variables={"localInstance": self.to_global_id(self.product_property)},
+        )
+        self.assertTrue(resp.errors is None)
+        edges = resp.data["amazonProductProperties"]["edges"]
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0]["node"]["id"], self.to_global_id(self.amazon_product_property))
+
+    def test_filter_by_remote_select_value(self):
+        resp = self.strawberry_test_client(
+            query=AMAZON_PRODUCT_PROPERTY_FILTER_BY_REMOTE_SELECT_VALUE,
+            variables={"remoteSelectValue": self.to_global_id(self.remote_select_value)},
+        )
+        self.assertTrue(resp.errors is None)
+        edges = resp.data["amazonProductProperties"]["edges"]
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0]["node"]["id"], self.to_global_id(self.amazon_product_property))
+
+    def test_filter_by_remote_product(self):
+        resp = self.strawberry_test_client(
+            query=AMAZON_PRODUCT_PROPERTY_FILTER_BY_REMOTE_PRODUCT,
+            variables={"remoteProduct": self.to_global_id(self.amazon_product)},
+        )
+        self.assertTrue(resp.errors is None)
+        edges = resp.data["amazonProductProperties"]["edges"]
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0]["node"]["id"], self.to_global_id(self.amazon_product_property))
 
 
 class AmazonProductIssuesQueryTest(TransactionTestCaseMixin, TransactionTestCase):


### PR DESCRIPTION
## Summary
- add `AmazonProductProperty` GraphQL type with filtering and ordering
- expose Amazon product properties through new query fields
- test filtering of Amazon product properties by local instance, select value, and product

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/schema/types/filters.py OneSila/sales_channels/integrations/amazon/schema/types/ordering.py OneSila/sales_channels/integrations/amazon/schema/types/types.py OneSila/sales_channels/integrations/amazon/schema/queries.py OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py OneSila/sales_channels/integrations/amazon/tests/tests_schemas/tests_queries.py`
- `DJANGO_SETTINGS_MODULE=OneSila.settings python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_schemas.tests_queries.AmazonProductPropertyQueryTest --verbosity 2` *(failed: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689ef6b4b71c832ea55c745e02190216

## Summary by Sourcery

Add support for querying Amazon product properties via GraphQL with filtering and ordering, and verify the new query fields with tests.

New Features:
- Introduce AmazonProductProperty GraphQL type with filters, ordering, pagination, and all relevant fields.
- Expose amazonProductProperty and amazonProductProperties query endpoints in the Amazon schema.
- Enable filtering of AmazonProductProperty by local instance, remote select value, and remote product.

Tests:
- Add test suite to validate filtering of AmazonProductProperty by localInstance, remoteSelectValue, and remoteProduct.