### PR TITLE
Add marketplace-specific GTIN exemption and variation theme models

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/schema_imports.py
@@ -2,7 +2,6 @@ import logging
 from imports_exports.factories.imports import ImportMixin
 from sales_channels.integrations.amazon.factories.mixins import (
     GetAmazonAPIMixin,
-    EnsureGtinExemptionMixin,
 )
 from sales_channels.integrations.amazon.factories.sales_channels.full_schema import AmazonProductTypeRuleFactory
 logger = logging.getLogger(__name__)
@@ -11,7 +10,6 @@ logger = logging.getLogger(__name__)
 class AmazonSchemaImportProcessor(
     ImportMixin,
     GetAmazonAPIMixin,
-    EnsureGtinExemptionMixin,
 ):
     import_properties = False
     import_select_values = False
@@ -24,7 +22,6 @@ class AmazonSchemaImportProcessor(
         self.sales_channel = sales_channel
         self.initial_sales_channel_status = sales_channel.active
         self.api = self.get_api()
-        self.gtin_exemption_property = self._ensure_gtin_exemption()
 
     def prepare_import_process(self):
         # during the import this needs to stay false to prevent trying to create the mirror models because
@@ -46,7 +43,6 @@ class AmazonSchemaImportProcessor(
             product_type_fac = AmazonProductTypeRuleFactory(
                 product_type_code=product_type_code,
                 sales_channel=self.sales_channel,
-                gtin_exemption_property=self.gtin_exemption_property,
                 api=self.api,
                 language=self.language,
             )

--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -552,33 +552,3 @@ class EnsureMerchantSuggestedAsinMixin:
         return remote_property
 
 
-class EnsureGtinExemptionMixin:
-    """Mixin ensuring the supplier_declared_has_product_identifier_exemption property exists."""
-
-    def _ensure_gtin_exemption(self):
-        remote_property, _ = AmazonProperty.objects.get_or_create(
-            allow_multiple=True,
-            multi_tenant_company=self.sales_channel.multi_tenant_company,
-            sales_channel=self.sales_channel,
-            code="supplier_declared_has_product_identifier_exemption",
-            defaults={"type": Property.TYPES.BOOLEAN},
-        )
-
-        if not remote_property.local_instance:
-            local_property, _ = Property.objects.get_or_create(
-                internal_name="supplier_declared_has_product_identifier_exemption",
-                multi_tenant_company=self.sales_channel.multi_tenant_company,
-                defaults={"type": Property.TYPES.BOOLEAN},
-            )
-
-            PropertyTranslation.objects.get_or_create(
-                property=local_property,
-                language=self.sales_channel.multi_tenant_company.language,
-                multi_tenant_company=self.sales_channel.multi_tenant_company,
-                defaults={"name": "GTIN Exemption"},
-            )
-
-            remote_property.local_instance = local_property
-            remote_property.save()
-
-        return remote_property

--- a/OneSila/sales_channels/integrations/amazon/models/__init__.py
+++ b/OneSila/sales_channels/integrations/amazon/models/__init__.py
@@ -2,7 +2,8 @@ from .orders import AmazonOrder, AmazonOrderItem
 from .products import (
     AmazonProduct, AmazonInventory, AmazonPrice,
     AmazonProductContent, AmazonImageProductAssociation,
-    AmazonCategory, AmazonEanCode, AmazonMerchantAsin
+    AmazonCategory, AmazonEanCode, AmazonMerchantAsin,
+    AmazonGtinExemption, AmazonVariationTheme
 )
 from .properties import (
     AmazonProperty, AmazonPropertySelectValue, AmazonProductProperty, AmazonProductType, AmazonProductTypeItem

--- a/OneSila/sales_channels/integrations/amazon/models/products.py
+++ b/OneSila/sales_channels/integrations/amazon/models/products.py
@@ -1,5 +1,6 @@
 from core import models
 from core.helpers import ensure_serializable
+from django.core.exceptions import ValidationError
 from sales_channels.models.products import (
     RemoteProduct,
     RemoteInventory,
@@ -140,3 +141,76 @@ class AmazonMerchantAsin(models.Model):
         unique_together = ("product", "view")
         verbose_name = 'Amazon Merchant ASIN'
         verbose_name_plural = 'Amazon Merchant ASINs'
+
+
+class AmazonGtinExemption(models.Model):
+    """Store GTIN exemption flag per marketplace."""
+
+    product = models.ForeignKey(
+        'products.Product',
+        on_delete=models.CASCADE,
+        related_name='amazon_gtin_exemptions',
+        help_text='The product this exemption belongs to.',
+    )
+    view = models.ForeignKey(
+        'amazon.AmazonSalesChannelView',
+        on_delete=models.CASCADE,
+        related_name='product_gtin_exemptions',
+        help_text='Marketplace for this exemption.',
+    )
+    value = models.BooleanField(default=False)
+
+    class Meta:
+        unique_together = ("product", "view")
+        verbose_name = 'Amazon GTIN Exemption'
+        verbose_name_plural = 'Amazon GTIN Exemptions'
+
+
+class AmazonVariationTheme(models.Model):
+    """Store variation theme per marketplace."""
+
+    product = models.ForeignKey(
+        'products.Product',
+        on_delete=models.CASCADE,
+        related_name='amazon_variation_themes',
+        help_text='The product this variation theme belongs to.',
+    )
+    view = models.ForeignKey(
+        'amazon.AmazonSalesChannelView',
+        on_delete=models.CASCADE,
+        related_name='product_variation_themes',
+        help_text='Marketplace for this variation theme.',
+    )
+    theme = models.CharField(max_length=64)
+
+    class Meta:
+        unique_together = ("product", "view")
+        verbose_name = 'Amazon Variation Theme'
+        verbose_name_plural = 'Amazon Variation Themes'
+
+    def clean(self):
+        from products.models import Product as LocalProduct
+        from sales_channels.integrations.amazon.models import AmazonProductType
+
+        if self.product.type != LocalProduct.CONFIGURABLE:
+            raise ValidationError("Variation themes are only allowed for configurable products.")
+
+        rule = self.product.get_product_rule()
+        if rule is None:
+            raise ValidationError("Product type not set.")
+
+        try:
+            remote_rule = AmazonProductType.objects.get(
+                local_instance=rule,
+                sales_channel=self.view.sales_channel,
+            )
+        except AmazonProductType.DoesNotExist as e:
+            raise ValidationError("Amazon product type not found.") from e
+
+        themes = remote_rule.variation_themes or []
+        if self.theme not in themes:
+            raise ValidationError("Invalid variation theme for product type.")
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        return super().save(*args, **kwargs)


### PR DESCRIPTION
## Summary
- Store GTIN exemption flags per product and marketplace
- Store variation themes per product and marketplace with validation and attribute duplication
- Clear variation themes when product type changes
- Include multi-tenant company when persisting variation themes
- Duplicate attributes for any variation theme token by appending `_name`
- Remove generated migrations so they can be created manually

## Testing
- `./OneSila/run_tests_locally.sh` *(fails: line 1: ../venv/bin/activate: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f99d65a38832eacb8d70534d978ae

## Summary by Sourcery

Introduce per-marketplace persistence for GTIN exemptions and variation themes, refactor factories and import processors to leverage these models, enforce validation and clear themes on product type changes, and update tests while removing legacy mixins and generated migrations.

New Features:
- Add AmazonGtinExemption model to store GTIN exemption per product per marketplace
- Add AmazonVariationTheme model to store variation theme per product per marketplace with validation
- Automatically clear stored variation themes when a product’s type property changes

Enhancements:
- Refactor product sync factories to fetch GTIN exemption and variation theme via new models
- Duplicate each variation theme part as a `_name` attribute when building payloads
- Enforce that variation themes only apply to configurable products and valid themes in model validation
- Update import handlers to persist variation themes for imported configurable products
- Remove legacy EnsureGtinExemptionMixin and generated migrations

Tests:
- Update tests to create and validate AmazonGtinExemption and AmazonVariationTheme instances
- Assert attribute duplication (`_name` fields) in variation payloads