### PR TITLE
Import Amazon browse nodes and GTIN exemptions

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/constants.py
+++ b/OneSila/sales_channels/integrations/amazon/constants.py
@@ -82,9 +82,11 @@ AMAZON_INTERNAL_PROPERTIES = [
     'condition_note', 'list_price', 'max_order_quantity', 'product_description', 'bullet_point',
     'child_parent_sku_relationship', 'variation_theme', 'master_pack_layers_per_pallet_quantity',
     'master_packs_per_layer_quantity', 'is_oem_sourced_product', 'parentage_level',
+    'recommended_browse_nodes',
 
     # Auto-linking/ASIN suggestion
     'merchant_suggested_asin', 'externally_assigned_product_identifier',
+    'supplier_declared_has_product_identifier_exemption',
 
     # Amazon-only compliance metadata (for now)
     'compliance_media', 'gpsr_safety_attestation', 'gpsr_manufacturer_reference',


### PR DESCRIPTION
## Summary
- capture GTIN exemption and browse node IDs during Amazon product import
- persist GTIN exemptions and browse node links per marketplace
- exclude Amazon-specific classification attributes from property mapping
- correctly parse recommended browse node IDs and cover with tests

## Testing
- `pytest OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py::AmazonProductsImportProcessorBrowseNodeGtinTest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_products_imports.AmazonProductsImportProcessorBrowseNodeGtinTest --keepdb -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e97e93c4832e939ea2cd0b637f6c

## Summary by Sourcery

Implement extraction and persistence of Amazon GTIN exemptions and recommended browse node IDs by extending the import parsing logic, adding model handlers, updating classification constants, and covering the changes with unit tests.

New Features:
- Capture GTIN exemption and recommended browse node IDs during Amazon product import
- Persist GTIN exemptions and browse node associations per product, sales channel, and view

Enhancements:
- Exclude Amazon-specific classification attributes from property mapping

Tests:
- Add unit tests for parsing and persisting GTIN exemptions and recommended browse nodes