### PR TITLE
Set Amazon simple product imports to update-only

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -877,6 +877,9 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
             update_current_rule=True
         )
 
+        if structured.get("type") != CONFIGURABLE:
+            instance.update_only = True
+
         instance.prepare_mirror_model_class(
             mirror_model_class=AmazonProduct,
             sales_channel=self.sales_channel,


### PR DESCRIPTION
## Summary
- only update existing products when Amazon import yields a non-configurable item
- add regression test to confirm the update_only flag is set

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_products_imports.AmazonProductsImportProcessorUpdateOnlyTest.test_non_configurable_product_update_only -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ee8393c4832ebd4b6d3ee22575b1

## Summary by Sourcery

Ensure Amazon simple product imports only update existing products and add a regression test for this behavior.

Enhancements:
- Set the update_only flag for non-configurable (simple) products in the Amazon import processor.

Tests:
- Add a test to verify that simple Amazon products have update_only set to True when imported.