### PR TITLE
Add admin pages for Amazon product models

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/admin.py
+++ b/OneSila/sales_channels/integrations/amazon/admin.py
@@ -21,6 +21,10 @@ from sales_channels.integrations.amazon.models import (
     AmazonTaxCode,
     AmazonDefaultUnitConfigurator,
     AmazonImportRelationship, AmazonImportBrokenRecord,
+    AmazonProductBrowseNode,
+    AmazonMerchantAsin,
+    AmazonVariationTheme,
+    AmazonGtinExemption,
 )
 from sales_channels.integrations.amazon.models.properties import AmazonPublicDefinition
 from django.contrib import admin
@@ -195,4 +199,45 @@ class AmazonPublicDefinitionAdmin(admin.ModelAdmin):
                 "last_fetched",
             )
         }),
+    )
+
+
+@admin.register(AmazonProductBrowseNode)
+class AmazonProductBrowseNodeAdmin(admin.ModelAdmin):
+    raw_id_fields = (
+        "product",
+        "sales_channel",
+        "sales_channel_view",
+        "multi_tenant_company",
+        "created_by_multi_tenant_user",
+    )
+
+
+@admin.register(AmazonMerchantAsin)
+class AmazonMerchantAsinAdmin(admin.ModelAdmin):
+    raw_id_fields = (
+        "product",
+        "view",
+        "multi_tenant_company",
+        "created_by_multi_tenant_user",
+    )
+
+
+@admin.register(AmazonVariationTheme)
+class AmazonVariationThemeAdmin(admin.ModelAdmin):
+    raw_id_fields = (
+        "product",
+        "view",
+        "multi_tenant_company",
+        "created_by_multi_tenant_user",
+    )
+
+
+@admin.register(AmazonGtinExemption)
+class AmazonGtinExemptionAdmin(admin.ModelAdmin):
+    raw_id_fields = (
+        "product",
+        "view",
+        "multi_tenant_company",
+        "created_by_multi_tenant_user",
     )


### PR DESCRIPTION
## Summary
- expose AmazonProductBrowseNode, AmazonMerchantAsin, AmazonVariationTheme and AmazonGtinExemption in Django admin

## Testing
- `python manage.py test sales_channels.integrations.amazon.tests` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a302bf40b8832e8858a22522af5531

## Summary by Sourcery

New Features:
- Expose AmazonProductBrowseNode, AmazonMerchantAsin, AmazonVariationTheme and AmazonGtinExemption in Django admin with raw_id_fields for related models