### PR TITLE
Rename Amazon import error to broken import process

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -58,7 +58,7 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
     import_rules = False
     import_products = True
 
-    ERROR_MULTIPLE_ASIN = "MULTIPLE_ASIN"
+    ERROR_BROKEN_IMPORT_PROCESS = "BROKEN_IMPORT_PROCESS"
     ERROR_MISSING_DATA = "MISSING_DATA"
     ERROR_NO_MAPPED_PRODUCT_TYPE = "NO_MAPPED_PRODUCT_TYPE"
     ERROR_PRODUCT_TYPE_MISMATCH = "PRODUCT_TYPE_MISMATCH"
@@ -895,12 +895,11 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
             instance.process()
         except IntegrityError as e:
             self._add_broken_record(
-                code=self.ERROR_MULTIPLE_ASIN,
-                message="Multiple ASINs for SKU",
+                code=self.ERROR_BROKEN_IMPORT_PROCESS,
+                message="Broken import process for SKU",
                 data=structured,
                 context={
                     "sku": structured.get("sku"),
-                    "asin": structured.get("__asin"),
                     "region": getattr(view, "api_region_code", None),
                     "is_variation": is_variation,
                 },


### PR DESCRIPTION
## Summary
- rename duplicate remote product error to broken import process
- keep broken record context limited to SKU, region, and variation flag

## Testing
- `python -m pytest` (fails: Requested setting INSTALLED_APPS, but settings are not configured)


------
https://chatgpt.com/codex/tasks/task_e_68a38ae44b6c832e8bf9277795d9acf2

## Summary by Sourcery

Rename the duplicate ASIN error to a generic broken import process and streamline its context data

Enhancements:
- Replace ERROR_MULTIPLE_ASIN code and message with ERROR_BROKEN_IMPORT_PROCESS and updated message
- Remove ASIN field from broken record context, keeping only SKU, region, and variation flag