### PR TITLE
Add optional name field for imports

### DIFF
--- a/OneSila/imports_exports/models.py
+++ b/OneSila/imports_exports/models.py
@@ -42,6 +42,12 @@ class Import(PolymorphicModel, models.Model):
         choices=STATUS_CHOICES,
         default=STATUS_NEW
     )
+    name = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text="Optional human-readable name for the import process.",
+    )
     error_traceback = models.TextField(
         null=True,
         blank=True,
@@ -151,7 +157,8 @@ class Import(PolymorphicModel, models.Model):
         return cleaned_errors
 
     def __str__(self):
-        return f"ImportProcess - {self.get_status_display()} ({self.percentage}%)"
+        base = f"{self.get_status_display()} ({self.percentage}%)"
+        return f"{self.name or 'ImportProcess'} - {base}"
 
     class Meta:
         ordering = ['-created_at']

--- a/OneSila/imports_exports/tests/tests_models.py
+++ b/OneSila/imports_exports/tests/tests_models.py
@@ -1,5 +1,5 @@
 from django.core.files.base import ContentFile
-from imports_exports.models import MappedImport
+from imports_exports.models import Import, MappedImport
 from core.tests import TestCase
 
 
@@ -11,3 +11,15 @@ class MappedImportUploadPathTest(TestCase):
         self.assertEqual(parts[0], str(self.multi_tenant_company.id))
         self.assertEqual(parts[1], 'mapped_imports')
         self.assertEqual(len(parts), 6)
+
+
+class ImportStrTest(TestCase):
+    def test_str_with_name(self):
+        import_process = Import.objects.create(
+            multi_tenant_company=self.multi_tenant_company, name="My Import"
+        )
+        self.assertEqual(str(import_process), "My Import - New (0%)")
+
+    def test_str_without_name(self):
+        import_process = Import.objects.create(multi_tenant_company=self.multi_tenant_company)
+        self.assertEqual(str(import_process), "ImportProcess - New (0%)")

--- a/OneSila/sales_channels/models/imports.py
+++ b/OneSila/sales_channels/models/imports.py
@@ -18,7 +18,8 @@ class SalesChannelImport(Import, models.Model):
     sales_channel = models.ForeignKey(SalesChannel, on_delete=models.CASCADE)
 
     def __str__(self):
-        return f"{self.sales_channel} - {self.get_status_display()} ({self.percentage}%)"
+        display_name = self.name or str(self.sales_channel)
+        return f"{display_name} - {self.get_status_display()} ({self.percentage}%)"
 
 
 class ImportProperty(ImportableModel):


### PR DESCRIPTION
## Summary
- allow naming import processes via new optional `name` field
- include name in `Import` and `SalesChannelImport` string representations
- add tests for named and unnamed import string outputs
- remove migration so it can be managed separately

## Testing
- `pre-commit run --files OneSila/imports_exports/models.py OneSila/sales_channels/models/imports.py OneSila/imports_exports/tests/tests_models.py`
- `python OneSila/manage.py test imports_exports.tests.tests_models` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a38b058d28832e810a19105e59e46c

## Summary by Sourcery

Add an optional name field to import models, update their string representations to include the name when provided, and add tests to verify the new behavior.

New Features:
- Introduce an optional name field on the Import model

Enhancements:
- Include the name in the __str__ methods for Import and SalesChannelImport with a fallback to default when absent

Tests:
- Add tests for the string output of Import with and without a name