### PR TITLE
Add Amazon custom product GraphQL schemas

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -21,6 +21,12 @@ from sales_channels.integrations.amazon.schema.types.input import (
     BulkAmazonPropertySelectValueLocalInstanceInput,
     AmazonProductBrowseNodeInput,
     AmazonProductBrowseNodePartialInput,
+    AmazonMerchantAsinInput,
+    AmazonMerchantAsinPartialInput,
+    AmazonGtinExemptionInput,
+    AmazonGtinExemptionPartialInput,
+    AmazonVariationThemeInput,
+    AmazonVariationThemePartialInput,
 )
 from sales_channels.integrations.amazon.schema.types.types import (
     AmazonSalesChannelType,
@@ -35,6 +41,9 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonProductType as AmazonProductGraphqlType,
     SuggestedAmazonProductType, SuggestedAmazonProductTypeEntry,
     AmazonProductBrowseNodeType,
+    AmazonMerchantAsinType,
+    AmazonGtinExemptionType,
+    AmazonVariationThemeType,
 )
 from sales_channels.schema.types.input import SalesChannelViewPartialInput
 from core.schema.core.mutations import create, type, List, update, delete
@@ -290,3 +299,21 @@ class AmazonSalesChannelMutation:
     create_amazon_product_browse_node: AmazonProductBrowseNodeType = create(AmazonProductBrowseNodeInput)
     update_amazon_product_browse_node: AmazonProductBrowseNodeType = update(AmazonProductBrowseNodePartialInput)
     delete_amazon_product_browse_node: AmazonProductBrowseNodeType = delete()
+
+    create_amazon_merchant_asin: AmazonMerchantAsinType = create(AmazonMerchantAsinInput)
+    create_amazon_merchant_asins: List[AmazonMerchantAsinType] = create(AmazonMerchantAsinInput)
+    update_amazon_merchant_asin: AmazonMerchantAsinType = update(AmazonMerchantAsinPartialInput)
+    delete_amazon_merchant_asin: AmazonMerchantAsinType = delete()
+    delete_amazon_merchant_asins: List[AmazonMerchantAsinType] = delete()
+
+    create_amazon_gtin_exemption: AmazonGtinExemptionType = create(AmazonGtinExemptionInput)
+    create_amazon_gtin_exemptions: List[AmazonGtinExemptionType] = create(AmazonGtinExemptionInput)
+    update_amazon_gtin_exemption: AmazonGtinExemptionType = update(AmazonGtinExemptionPartialInput)
+    delete_amazon_gtin_exemption: AmazonGtinExemptionType = delete()
+    delete_amazon_gtin_exemptions: List[AmazonGtinExemptionType] = delete()
+
+    create_amazon_variation_theme: AmazonVariationThemeType = create(AmazonVariationThemeInput)
+    create_amazon_variation_themes: List[AmazonVariationThemeType] = create(AmazonVariationThemeInput)
+    update_amazon_variation_theme: AmazonVariationThemeType = update(AmazonVariationThemePartialInput)
+    delete_amazon_variation_theme: AmazonVariationThemeType = delete()
+    delete_amazon_variation_themes: List[AmazonVariationThemeType] = delete()

--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -14,6 +14,9 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonProductIssueType,
     AmazonBrowseNodeType,
     AmazonProductBrowseNodeType,
+    AmazonMerchantAsinType,
+    AmazonGtinExemptionType,
+    AmazonVariationThemeType,
 )
 
 
@@ -60,3 +63,12 @@ class AmazonSalesChannelsQuery:
 
     amazon_product_browse_node: AmazonProductBrowseNodeType = node()
     amazon_product_browse_nodes: DjangoListConnection[AmazonProductBrowseNodeType] = connection()
+
+    amazon_merchant_asin: AmazonMerchantAsinType = node()
+    amazon_merchant_asins: DjangoListConnection[AmazonMerchantAsinType] = connection()
+
+    amazon_gtin_exemption: AmazonGtinExemptionType = node()
+    amazon_gtin_exemptions: DjangoListConnection[AmazonGtinExemptionType] = connection()
+
+    amazon_variation_theme: AmazonVariationThemeType = node()
+    amazon_variation_themes: DjangoListConnection[AmazonVariationThemeType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -21,6 +21,9 @@ from sales_channels.integrations.amazon.models import (
     AmazonProductIssue,
     AmazonBrowseNode,
     AmazonProductBrowseNode,
+    AmazonMerchantAsin,
+    AmazonGtinExemption,
+    AmazonVariationTheme,
 )
 from properties.schema.types.filters import (
     PropertyFilter,
@@ -197,3 +200,27 @@ class AmazonProductBrowseNodeFilter(SearchFilterMixin):
     sales_channel: Optional[SalesChannelFilter]
     sales_channel_view: Optional[SalesChannelViewFilter]
     recommended_browse_node_id: auto
+
+
+@filter(AmazonMerchantAsin)
+class AmazonMerchantAsinFilter(SearchFilterMixin):
+    id: auto
+    product: Optional[ProductFilter]
+    view: Optional[SalesChannelViewFilter]
+    asin: auto
+
+
+@filter(AmazonGtinExemption)
+class AmazonGtinExemptionFilter(SearchFilterMixin):
+    id: auto
+    product: Optional[ProductFilter]
+    view: Optional[SalesChannelViewFilter]
+    value: auto
+
+
+@filter(AmazonVariationTheme)
+class AmazonVariationThemeFilter(SearchFilterMixin):
+    id: auto
+    product: Optional[ProductFilter]
+    view: Optional[SalesChannelViewFilter]
+    theme: auto

--- a/OneSila/sales_channels/integrations/amazon/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/input.py
@@ -10,6 +10,9 @@ from sales_channels.integrations.amazon.models import (
     AmazonDefaultUnitConfigurator,
     AmazonSalesChannelView,
     AmazonProductBrowseNode,
+    AmazonMerchantAsin,
+    AmazonGtinExemption,
+    AmazonVariationTheme,
 )
 from properties.schema.types.input import PropertySelectValuePartialInput
 from strawberry.relay import GlobalID
@@ -126,4 +129,34 @@ class AmazonProductBrowseNodeInput:
 
 @partial(AmazonProductBrowseNode, fields="__all__")
 class AmazonProductBrowseNodePartialInput(NodeInput):
+    pass
+
+
+@input(AmazonMerchantAsin, fields="__all__")
+class AmazonMerchantAsinInput:
+    pass
+
+
+@partial(AmazonMerchantAsin, fields="__all__")
+class AmazonMerchantAsinPartialInput(NodeInput):
+    pass
+
+
+@input(AmazonGtinExemption, fields="__all__")
+class AmazonGtinExemptionInput:
+    pass
+
+
+@partial(AmazonGtinExemption, fields="__all__")
+class AmazonGtinExemptionPartialInput(NodeInput):
+    pass
+
+
+@input(AmazonVariationTheme, fields="__all__")
+class AmazonVariationThemeInput:
+    pass
+
+
+@partial(AmazonVariationTheme, fields="__all__")
+class AmazonVariationThemePartialInput(NodeInput):
     pass

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -17,6 +17,9 @@ from sales_channels.integrations.amazon.models import (
     AmazonProductIssue,
     AmazonBrowseNode,
     AmazonProductBrowseNode,
+    AmazonMerchantAsin,
+    AmazonGtinExemption,
+    AmazonVariationTheme,
 )
 from properties.schema.types.ordering import ProductPropertyOrder
 from products.schema.types.ordering import ProductOrder
@@ -98,3 +101,24 @@ class AmazonBrowseNodeOrder:
 class AmazonProductBrowseNodeOrder:
     id: auto
     product: Optional[ProductOrder]
+
+
+@order(AmazonMerchantAsin)
+class AmazonMerchantAsinOrder:
+    id: auto
+    product: Optional[ProductOrder]
+    view: Optional[AmazonSalesChannelViewOrder]
+
+
+@order(AmazonGtinExemption)
+class AmazonGtinExemptionOrder:
+    id: auto
+    product: Optional[ProductOrder]
+    view: Optional[AmazonSalesChannelViewOrder]
+
+
+@order(AmazonVariationTheme)
+class AmazonVariationThemeOrder:
+    id: auto
+    product: Optional[ProductOrder]
+    view: Optional[AmazonSalesChannelViewOrder]

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -25,6 +25,9 @@ from sales_channels.integrations.amazon.models import (
     AmazonProductIssue,
     AmazonBrowseNode,
     AmazonProductBrowseNode,
+    AmazonMerchantAsin,
+    AmazonGtinExemption,
+    AmazonVariationTheme,
 )
 from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonSalesChannelFilter,
@@ -37,6 +40,7 @@ from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonSalesChannelImportFilter, AmazonDefaultUnitConfiguratorFilter,
     AmazonRemoteLogFilter, AmazonSalesChannelViewFilter, AmazonProductIssueFilter,
     AmazonBrowseNodeFilter, AmazonProductBrowseNodeFilter,
+    AmazonMerchantAsinFilter, AmazonGtinExemptionFilter, AmazonVariationThemeFilter,
 )
 from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonSalesChannelOrder,
@@ -50,6 +54,7 @@ from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonDefaultUnitConfiguratorOrder,
     AmazonRemoteLogOrder, AmazonSalesChannelViewOrder, AmazonProductIssueOrder,
     AmazonBrowseNodeOrder, AmazonProductBrowseNodeOrder,
+    AmazonMerchantAsinOrder, AmazonGtinExemptionOrder, AmazonVariationThemeOrder,
 )
 from sales_channels.schema.types.types import FormattedIssueType
 
@@ -383,6 +388,60 @@ class AmazonProductBrowseNodeType(relay.Node, GetQuerysetMultiTenantMixin):
         lazy("sales_channels.integrations.amazon.schema.types.types")
     ]
     sales_channel_view: Annotated[
+        'AmazonSalesChannelViewType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]
+
+
+@type(
+    AmazonMerchantAsin,
+    filters=AmazonMerchantAsinFilter,
+    order=AmazonMerchantAsinOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonMerchantAsinType(relay.Node, GetQuerysetMultiTenantMixin):
+    product: Annotated[
+        'ProductType',
+        lazy("products.schema.types.types")
+    ]
+    view: Annotated[
+        'AmazonSalesChannelViewType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]
+
+
+@type(
+    AmazonGtinExemption,
+    filters=AmazonGtinExemptionFilter,
+    order=AmazonGtinExemptionOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonGtinExemptionType(relay.Node, GetQuerysetMultiTenantMixin):
+    product: Annotated[
+        'ProductType',
+        lazy("products.schema.types.types")
+    ]
+    view: Annotated[
+        'AmazonSalesChannelViewType',
+        lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]
+
+
+@type(
+    AmazonVariationTheme,
+    filters=AmazonVariationThemeFilter,
+    order=AmazonVariationThemeOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonVariationThemeType(relay.Node, GetQuerysetMultiTenantMixin):
+    product: Annotated[
+        'ProductType',
+        lazy("products.schema.types.types")
+    ]
+    view: Annotated[
         'AmazonSalesChannelViewType',
         lazy("sales_channels.integrations.amazon.schema.types.types")
     ]

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py
@@ -59,3 +59,39 @@ query ($remoteProduct: GlobalID!) {
   }
 }
 """
+
+AMAZON_MERCHANT_ASIN_FILTER_BY_PRODUCT = """
+query ($product: GlobalID!) {
+  amazonMerchantAsins(filters: {product: {id: {exact: $product}}}) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+"""
+
+AMAZON_GTIN_EXEMPTION_FILTER_BY_PRODUCT = """
+query ($product: GlobalID!) {
+  amazonGtinExemptions(filters: {product: {id: {exact: $product}}}) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+"""
+
+AMAZON_VARIATION_THEME_FILTER_BY_PRODUCT = """
+query ($product: GlobalID!) {
+  amazonVariationThemes(filters: {product: {id: {exact: $product}}}) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+"""


### PR DESCRIPTION
## Summary
- add GraphQL types, inputs, filters and ordering for AmazonMerchantAsin, AmazonGtinExemption and AmazonVariationTheme
- expose queries and mutations for the new Amazon product helpers
- cover new queries with basic tests

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/schema/mutations.py OneSila/sales_channels/integrations/amazon/schema/queries.py OneSila/sales_channels/integrations/amazon/schema/types/filters.py OneSila/sales_channels/integrations/amazon/schema/types/input.py OneSila/sales_channels/integrations/amazon/schema/types/ordering.py OneSila/sales_channels/integrations/amazon/schema/types/types.py OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py OneSila/sales_channels/integrations/amazon/tests/tests_schemas/tests_queries.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_schemas.tests_queries` (fails: connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68a3a758c2bc832eb47eb9f1a5a6dfe8

## Summary by Sourcery

Introduce full GraphQL support for Amazon merchant ASINs, GTIN exemptions, and variation themes by adding types, filters, inputs, ordering, queries, and mutations, and cover them with basic filter tests.

New Features:
- Add GraphQL types, filters, inputs, and ordering for AmazonMerchantAsin, AmazonGtinExemption, and AmazonVariationTheme
- Expose node and connection queries plus create/update/delete mutations for the new Amazon product helper types

Tests:
- Add basic tests for product-based filtering of merchant ASINs, GTIN exemptions, and variation themes