### PR TITLE
Handle missing products in update-only imports

### DIFF
--- a/OneSila/imports_exports/factories/mixins.py
+++ b/OneSila/imports_exports/factories/mixins.py
@@ -11,6 +11,15 @@ from core.logging_helpers import timeit_and_log
 logger = logging.getLogger(__name__)
 
 
+class UpdateOnlyInstanceNotFound(Exception):
+    """Raised when an update_only import cannot find the local instance."""
+
+    code = "UPDATE_ONLY_NOT_FOUND"
+
+    def __init__(self, message):
+        super().__init__(message)
+
+
 class AbstractImportInstance(abc.ABC):
     """
     Abstract base class for any import instance that processes a data dict.
@@ -196,6 +205,10 @@ class ImportOperationMixin:
         """
         raise error
 
+    def resolve_get_update_only_does_not_exist(self, error):
+        """Override to provide fallback logic when update_only lookups fail."""
+        raise error
+
     def get_or_create_instance(self):
         """
         Attempts to retrieve the local instance using the built kwargs; if not found, create it.
@@ -206,14 +219,16 @@ class ImportOperationMixin:
                 try:
                     self.instance = self.import_instance.local_class.objects.get(**self.get_kwargs)
                     self.created = False
-                except self.import_instance.local_class.DoesNotExist:
-                    kwargs_repr = ", ".join(f"{k}={v}" for k, v in self.get_kwargs.items())
-                    raise self.import_instance.local_class.DoesNotExist(
-                        f"{self.import_instance.local_class.__name__} matching query does not exist. "
-                        f"Looked for {kwargs_repr}"
-                    )
-                except IntegrityError as e:
-                    self.instance, self.created = self.resolve_get_or_create_integrity_error(e)
+                except self.import_instance.local_class.DoesNotExist as e:
+                    try:
+                        self.instance = self.resolve_get_update_only_does_not_exist(e)
+                        self.created = False
+                    except self.import_instance.local_class.DoesNotExist:
+                        kwargs_repr = ", ".join(f"{k}={v}" for k, v in self.get_kwargs.items())
+                        raise UpdateOnlyInstanceNotFound(
+                            f"{self.import_instance.local_class.__name__} matching query does not exist. "
+                            f"Looked for {kwargs_repr}"
+                        )
             elif self.force_created:
                 self.instance = self.import_instance.local_class.objects.create(**self.get_kwargs)
                 self.created = True

--- a/OneSila/imports_exports/factories/products.py
+++ b/OneSila/imports_exports/factories/products.py
@@ -55,6 +55,19 @@ class ProductImport(ImportOperationMixin):
 
         raise error
 
+    def resolve_get_update_only_does_not_exist(self, error):
+        sku = getattr(self.import_instance, 'sku', None)
+
+        if not sku:
+            raise error
+
+        existing = Product.objects.filter(sku=sku, multi_tenant_company=self.multi_tenant_company).first()
+
+        if existing:
+            return existing
+
+        raise error
+
 
 class AliasProductImport(ImportOperationMixin):
     get_identifiers = ['sku', 'type', 'alias_parent_product']


### PR DESCRIPTION
## Summary
- add `UpdateOnlyInstanceNotFound` exception and fallback logic for update-only retrievals
- log `UPDATE_ONLY_NOT_FOUND` when Amazon product import cannot find an update-only product
- cover new behavior with a unit test

## Testing
- `pre-commit run --files OneSila/imports_exports/factories/mixins.py OneSila/imports_exports/factories/products.py OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py`
- `pytest OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py::AmazonProductItemFactoryRunTest::test_broken_record_when_update_only_product_missing -q --ds=OneSila.settings.base` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a44b0600f0832ea385669cc0a1ad2e

## Summary by Sourcery

Add specific handling for missing update-only imports by introducing a custom exception, fallback lookup logic, and logging of broken records

New Features:
- Introduce UpdateOnlyInstanceNotFound exception with code UPDATE_ONLY_NOT_FOUND
- Add ERROR_UPDATE_ONLY_NOT_FOUND to AmazonProductsImportProcessor error constants

Enhancements:
- Extend get_or_create flow to call resolve_get_update_only_does_not_exist in mixins and products factory for fallback lookups
- Catch UpdateOnlyInstanceNotFound in AmazonProductsImportProcessor.run to log a broken record

Tests:
- Add unit test verifying a broken record is logged when an update-only product is missing