### PR TITLE
Add code filter for broken Amazon import records

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/admin.py
+++ b/OneSila/sales_channels/integrations/amazon/admin.py
@@ -37,6 +37,7 @@ from pygments import highlight
 from pygments.lexers import JsonLexer
 from pygments.formatters import HtmlFormatter
 
+
 @admin.register(AmazonSalesChannel)
 class AmazonSalesChannelAdmin(PolymorphicChildModelAdmin):
     base_model = AmazonSalesChannel
@@ -147,27 +148,48 @@ class AmazonImportRelationshipAdmin(admin.ModelAdmin):
     raw_id_fields = ("import_process",)
 
 
+class CodeFilter(admin.SimpleListFilter):
+    title = "code"
+    parameter_name = "code"
+
+    def lookups(self, request, model_admin):
+        codes = model_admin.model.objects.values_list("record__code", flat=True).distinct()
+        return [(code, code) for code in codes if code]
+
+    def queryset(self, request, queryset):
+        if self.value():
+            return queryset.filter(record__code=self.value())
+        return queryset
+
+
 @admin.register(AmazonImportBrokenRecord)
 class AmazonImportBrokenRecordAdmin(admin.ModelAdmin):
-    list_display = ("import_process",)
+    list_display = ("import_process", "code")
     raw_id_fields = ("import_process",)
+    list_filter = (CodeFilter,)
+    search_fields = ("record__code",)
 
-    readonly_fields = ['formatted_broken_record']
-    exclude = ('record',)
+    readonly_fields = ["formatted_broken_record"]
+    exclude = ("record",)
+
+    def code(self, instance):
+        if not instance.record:
+            return "—"
+        return instance.record.get("code", "—")
 
     def formatted_broken_record(self, instance):
         if not instance.record:
             return "—"
 
         response = json.dumps(instance.record, sort_keys=True, indent=2, ensure_ascii=False)
-        formatter = HtmlFormatter(style='colorful')
+        formatter = HtmlFormatter(style="colorful")
         highlighted = highlight(response, JsonLexer(), formatter)
 
         # Clean up and apply inline style
         style = f"<style>{formatter.get_style_defs()}</style><br>"
-        return mark_safe(style + highlighted.replace('\\n', '<br/>'))
+        return mark_safe(style + highlighted.replace("\\n", "<br/>"))
 
-    formatted_broken_record.short_description = 'Broken Record'
+    formatted_broken_record.short_description = "Broken Record"
 
 
 @admin.register(AmazonPublicDefinition)


### PR DESCRIPTION
## Summary
- show broken record code in AmazonImportBrokenRecord admin list view
- allow filtering and searching by broken record code

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/admin.py`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a450ab3400832ea092003f7a99a1f2