### PR TITLE
feat: add sku display to broken records

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/admin.py
+++ b/OneSila/sales_channels/integrations/amazon/admin.py
@@ -164,13 +164,28 @@ class CodeFilter(admin.SimpleListFilter):
 
 @admin.register(AmazonImportBrokenRecord)
 class AmazonImportBrokenRecordAdmin(admin.ModelAdmin):
-    list_display = ("import_process", "code")
+    list_display = ("import_process", "sku", "code")
     raw_id_fields = ("import_process",)
     list_filter = (CodeFilter,)
     search_fields = ("record__code",)
 
     readonly_fields = ["formatted_broken_record"]
     exclude = ("record",)
+
+    def sku(self, instance):
+        if not instance.record:
+            return "-"
+        data = instance.record.get("data", {}) or {}
+        if isinstance(data, dict):
+            sku = data.get("sku")
+            if sku:
+                return sku
+        context = instance.record.get("context", {}) or {}
+        if isinstance(context, dict):
+            sku = context.get("sku")
+            if sku:
+                return sku
+        return "-"
 
     def code(self, instance):
         if not instance.record:


### PR DESCRIPTION
## Summary
- show SKU for Amazon import broken records

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/admin.py`
- `pytest -q` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a45f313548832eb414919002603b66

## Summary by Sourcery

Add a SKU column to the AmazonImportBrokenRecord admin list by defining a sku method that retrieves the SKU from the record payload or context, defaulting to a placeholder when missing

New Features:
- Display SKU in the Django admin list view for AmazonImportBrokenRecord

Enhancements:
- Implement sku property to extract SKU from the record's data or context fields