### PR TITLE
Fix Amazon browse node primary key and parent mapping

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/migrations/0058_clear_amazonbrowsenode_data.py
+++ b/OneSila/sales_channels/integrations/amazon/migrations/0058_clear_amazonbrowsenode_data.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+def delete_browse_nodes(apps, schema_editor):
+    AmazonBrowseNode = apps.get_model('amazon', 'AmazonBrowseNode')
+    AmazonBrowseNode.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('amazon', '0057_amazonbrowsenode_parent_node'),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_browse_nodes, migrations.RunPython.noop),
+    ]

--- a/OneSila/sales_channels/integrations/amazon/models/recommended_browse_nodes.py
+++ b/OneSila/sales_channels/integrations/amazon/models/recommended_browse_nodes.py
@@ -5,7 +5,7 @@ from products.models import Product
 from sales_channels.models import SalesChannel, SalesChannelView
 
 class AmazonBrowseNode(models.SharedModel):
-    remote_id = models.CharField(max_length=50, primary_key=True)  # browseNodeId
+    remote_id = models.CharField(max_length=50, db_index=True)  # browseNodeId
     marketplace_id = models.CharField(max_length=20, db_index=True)  # e.g., A1F83G8C2ARO7P
 
     name = models.CharField(max_length=512, null=True, blank=True)  # browseNodeName


### PR DESCRIPTION
## Summary
- Remove primary key from Amazon browse node remote_id and index it
- Rebuild browse node parents in a second pass and mark roots when parent missing
- Add migration to clear existing browse node data before schema change

## Testing
- `python manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_browse_node_sync_factory` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a46ba9bdf4832e95c532057e5134d8

## Summary by Sourcery

Refactor Amazon browse node synchronization to support a numeric primary key, clear existing data via migration, and accurately rebuild parent links with root marking.

Bug Fixes:
- Rebuild parent relationships in a second pass and mark nodes as roots when their parent is missing

Enhancements:
- Convert remote_id from primary key to indexed field and rely on default numeric PK
- Add migration to clear existing browse node data before applying the schema change
- Update sync logic to map remote IDs to internal IDs for parent assignment

Build:
- Include Django migration to delete all AmazonBrowseNode records ahead of schema alteration

Tests:
- Add test to verify nodes are marked as roots when their parent is not found