### PR TITLE
Refactor Amazon external product ID handling

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -529,7 +529,11 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
                 product=remote_product.local_instance,
                 view=view,
                 multi_tenant_company=self.sales_channel.multi_tenant_company,
-                defaults={"asin": asin},
+                defaults={
+                    "value": asin,
+                    "type": AmazonExternalProductId.TYPE_ASIN,
+                    "created_asin": asin,
+                },
             )
 
         if remote_product.syncing_current_percentage != 100:

--- a/OneSila/sales_channels/integrations/amazon/models/products.py
+++ b/OneSila/sales_channels/integrations/amazon/models/products.py
@@ -121,26 +121,44 @@ class AmazonEanCode(RemoteEanCode):
 
 
 class AmazonExternalProductId(models.Model):
-    """Store merchant-provided ASIN per marketplace."""
+    """Store merchant-provided product identifiers per marketplace."""
+
+    TYPE_ASIN = "ASIN"
+    TYPE_UPC = "UPC"
+    TYPE_ISBN = "ISBN"
+    TYPE_GCID = "GCID"
+    TYPE_GTIN = "GTIN"
+    TYPE_JAN = "JAN"
+
+    TYPE_CHOICES = [
+        (TYPE_ASIN, "ASIN"),
+        (TYPE_UPC, "UPC"),
+        (TYPE_ISBN, "ISBN"),
+        (TYPE_GCID, "GCID"),
+        (TYPE_GTIN, "GTIN"),
+        (TYPE_JAN, "JAN"),
+    ]
 
     product = models.ForeignKey(
         'products.Product',
         on_delete=models.CASCADE,
         related_name='amazon_merchant_asins',
-        help_text='The product this ASIN belongs to.',
+        help_text='The product this identifier belongs to.',
     )
     view = models.ForeignKey(
         'amazon.AmazonSalesChannelView',
         on_delete=models.CASCADE,
         related_name='product_asins',
-        help_text='Marketplace for this ASIN.',
+        help_text='Marketplace for this identifier.',
     )
+    type = models.CharField(max_length=4, choices=TYPE_CHOICES, default=TYPE_ASIN)
     value = models.CharField(max_length=32)
+    created_asin = models.CharField(max_length=32, null=True, blank=True)
 
     class Meta:
         unique_together = ("product", "view")
-        verbose_name = 'Amazon Merchant ASIN'
-        verbose_name_plural = 'Amazon Merchant ASINs'
+        verbose_name = 'Amazon External Product ID'
+        verbose_name_plural = 'Amazon External Product IDs'
 
 
 class AmazonGtinExemption(models.Model):

--- a/OneSila/sales_channels/integrations/amazon/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/mutations.py
@@ -375,11 +375,11 @@ class AmazonSalesChannelMutation:
     update_amazon_product_browse_node: AmazonProductBrowseNodeType = update(AmazonProductBrowseNodePartialInput)
     delete_amazon_product_browse_node: AmazonProductBrowseNodeType = delete()
 
-    create_amazon_merchant_asin: AmazonExternalProductIdType = create(AmazonExternalProductIdInput)
-    create_amazon_merchant_asins: List[AmazonExternalProductIdType] = create(AmazonExternalProductIdInput)
-    update_amazon_merchant_asin: AmazonExternalProductIdType = update(AmazonExternalProductIdPartialInput)
-    delete_amazon_merchant_asin: AmazonExternalProductIdType = delete()
-    delete_amazon_merchant_asins: List[AmazonExternalProductIdType] = delete()
+    create_amazon_external_product_id: AmazonExternalProductIdType = create(AmazonExternalProductIdInput)
+    create_amazon_external_product_ids: List[AmazonExternalProductIdType] = create(AmazonExternalProductIdInput)
+    update_amazon_external_product_id: AmazonExternalProductIdType = update(AmazonExternalProductIdPartialInput)
+    delete_amazon_external_product_id: AmazonExternalProductIdType = delete()
+    delete_amazon_external_product_ids: List[AmazonExternalProductIdType] = delete()
 
     create_amazon_gtin_exemption: AmazonGtinExemptionType = create(AmazonGtinExemptionInput)
     create_amazon_gtin_exemptions: List[AmazonGtinExemptionType] = create(AmazonGtinExemptionInput)

--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -64,8 +64,8 @@ class AmazonSalesChannelsQuery:
     amazon_product_browse_node: AmazonProductBrowseNodeType = node()
     amazon_product_browse_nodes: DjangoListConnection[AmazonProductBrowseNodeType] = connection()
 
-    amazon_merchant_asin: AmazonExternalProductIdType = node()
-    amazon_merchant_asins: DjangoListConnection[AmazonExternalProductIdType] = connection()
+    amazon_external_product_id: AmazonExternalProductIdType = node()
+    amazon_external_product_ids: DjangoListConnection[AmazonExternalProductIdType] = connection()
 
     amazon_gtin_exemption: AmazonGtinExemptionType = node()
     amazon_gtin_exemptions: DjangoListConnection[AmazonGtinExemptionType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -210,6 +210,8 @@ class AmazonExternalProductIdFilter(SearchFilterMixin):
     product: Optional[ProductFilter]
     view: Optional[SalesChannelViewFilter]
     value: auto
+    type: auto
+    created_asin: auto
 
 
 @filter(AmazonGtinExemption)

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -108,6 +108,9 @@ class AmazonExternalProductIdOrder:
     id: auto
     product: Optional[ProductOrder]
     view: Optional[AmazonSalesChannelViewOrder]
+    value: auto
+    type: auto
+    created_asin: auto
 
 
 @order(AmazonGtinExemption)

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
@@ -129,7 +129,7 @@ class AmazonProductTestMixin:
             multi_tenant_company=self.multi_tenant_company,
             product=self.product,
             view=self.view,
-            asin="ASIN123",
+            value="ASIN123",
         )
 
         SalesChannelViewAssign.objects.create(
@@ -960,7 +960,7 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
             multi_tenant_company=self.multi_tenant_company,
             product=self.product,
             view=fr_view,
-            asin="ASIN123",
+            value="ASIN123",
         )
 
         mock_instance = mock_listings.return_value
@@ -1426,7 +1426,7 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
         with self.assertRaises(ValueError) as ctx:
             fac.run()
 
-        self.assertIn("ASIN or EAN", str(ctx.exception))
+        self.assertIn("external product id or EAN", str(ctx.exception))
         mock_listings.return_value.put_listings_item.assert_not_called()
 
     @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
@@ -2414,7 +2414,7 @@ class AmazonConfigurableProductFlowTest(DisableWooCommerceSignalsMixin, Transact
             multi_tenant_company=self.multi_tenant_company,
             product=self.child,
             view=self.view,
-            asin="ASINCHILD",
+            value="ASINCHILD",
         )
 
         self.child_remote = AmazonProduct.objects.create(
@@ -2531,7 +2531,7 @@ class AmazonConfigurableProductFlowTest(DisableWooCommerceSignalsMixin, Transact
             multi_tenant_company=self.multi_tenant_company,
             product=simple,
             view=self.view,
-            asin="ASINSIMPLE",
+            value="ASINSIMPLE",
         )
         simple_remote = AmazonProduct.objects.create(
             multi_tenant_company=self.multi_tenant_company,

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py
@@ -60,9 +60,9 @@ query ($remoteProduct: GlobalID!) {
 }
 """
 
-AMAZON_MERCHANT_ASIN_FILTER_BY_PRODUCT = """
+AMAZON_EXTERNAL_PRODUCT_ID_FILTER_BY_PRODUCT = """
 query ($product: GlobalID!) {
-  amazonMerchantAsins(filters: {product: {id: {exact: $product}}}) {
+  amazonExternalProductIds(filters: {product: {id: {exact: $product}}}) {
     edges {
       node {
         id

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/tests_queries.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_schemas/tests_queries.py
@@ -24,7 +24,7 @@ from .queries import (
     AMAZON_PRODUCT_PROPERTY_FILTER_BY_LOCAL_INSTANCE,
     AMAZON_PRODUCT_PROPERTY_FILTER_BY_REMOTE_SELECT_VALUE,
     AMAZON_PRODUCT_PROPERTY_FILTER_BY_REMOTE_PRODUCT,
-    AMAZON_MERCHANT_ASIN_FILTER_BY_PRODUCT,
+    AMAZON_EXTERNAL_PRODUCT_ID_FILTER_BY_PRODUCT,
     AMAZON_GTIN_EXEMPTION_FILTER_BY_PRODUCT,
     AMAZON_VARIATION_THEME_FILTER_BY_PRODUCT,
 )
@@ -213,16 +213,16 @@ class AmazonExternalProductIdQueryTest(TransactionTestCaseMixin, TransactionTest
             product=self.product,
             view=self.view,
             multi_tenant_company=self.multi_tenant_company,
-            asin="ASIN123",
+            value="ASIN123",
         )
 
     def test_filter_by_product(self):
         resp = self.strawberry_test_client(
-            query=AMAZON_MERCHANT_ASIN_FILTER_BY_PRODUCT,
+            query=AMAZON_EXTERNAL_PRODUCT_ID_FILTER_BY_PRODUCT,
             variables={"product": self.to_global_id(self.product)},
         )
         self.assertTrue(resp.errors is None)
-        edges = resp.data["amazonMerchantAsins"]["edges"]
+        edges = resp.data["amazonExternalProductIds"]["edges"]
         self.assertEqual(len(edges), 1)
         self.assertEqual(edges[0]["node"]["id"], self.to_global_id(self.asin))
 


### PR DESCRIPTION
## Summary
- support multiple external product ID types (ASIN, UPC, ISBN, GCID, GTIN, JAN)
- adjust Amazon product factories to use external IDs and capture created ASIN
- expand GraphQL filters/ordering and add migration support
- rename GraphQL endpoints to `amazon_external_product_id` variants
- drop generated migration so maintainers can recreate it

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/schema/queries.py OneSila/sales_channels/integrations/amazon/schema/mutations.py OneSila/sales_channels/integrations/amazon/tests/tests_schemas/queries.py OneSila/sales_channels/integrations/amazon/tests/tests_schemas/tests_queries.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_schemas.tests_queries.AmazonExternalProductIdQueryTest --verbosity=2` *(fails: connection to server at "localhost" (::1), port 5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bb46665c832ea362a5400daa312a

## Summary by Sourcery

Introduce a generic external product ID model for Amazon integrating multiple identifier types and update related factories, imports, GraphQL schema, and tests to use the new model and naming conventions.

New Features:
- Support multiple Amazon external product ID types (ASIN, UPC, ISBN, GCID, GTIN, JAN) in a new AmazonExternalProductId model.
- Expand GraphQL schema to use amazon_external_product_id naming, filters, and ordering on type, value, and created_asin.

Enhancements:
- Refactor Amazon product factories and import logic to use generic external product IDs, emit appropriate payloads for ASIN vs other types, and capture created ASIN.
- Rename GraphQL mutations and queries from merchant_asin to external_product_id variants across schema and update filters to align with new model.

Tests:
- Update tests to reference the new value field and external_product_id naming in factories and GraphQL queries.

Chores:
- Remove auto-generated migration to allow maintainers to regenerate it.