### PR TITLE
Propagate Amazon browse nodes to variations

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
@@ -11,8 +11,9 @@ from sales_channels.integrations.amazon.models import (
     AmazonPropertySelectValue,
     AmazonProductType,
     AmazonRemoteLanguage,
+    AmazonProductBrowseNode,
 )
-from products.models import Product
+from products.models import Product, ConfigurableVariation
 from sales_channels.signals import manual_sync_remote_product, update_remote_product
 from sales_channels.integrations.amazon.tasks import resync_amazon_product_db_task
 from .helpers import DisableWooCommerceSignalsMixin
@@ -240,3 +241,53 @@ class AmazonSelectValueTranslationReceiverTest(TestCase):
         task_mock.assert_not_called()
         val.refresh_from_db()
         self.assertEqual(val.translated_remote_name, "Deutschland")
+
+
+class AmazonProductBrowseNodeReceiversTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="VIEW",
+        )
+        self.parent = Product.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Product.CONFIGURABLE,
+        )
+        self.var1 = Product.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Product.SIMPLE,
+        )
+        self.var2 = Product.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Product.SIMPLE,
+        )
+        ConfigurableVariation.objects.create(parent=self.parent, variation=self.var1)
+        ConfigurableVariation.objects.create(parent=self.parent, variation=self.var2)
+
+    def test_propagates_to_variations(self):
+        AmazonProductBrowseNode.objects.create(
+            product=self.parent,
+            sales_channel=self.sales_channel,
+            view=self.view,
+            recommended_browse_node_id="BN1",
+        )
+        self.assertTrue(
+            AmazonProductBrowseNode.objects.filter(
+                product=self.var1,
+                view=self.view,
+                recommended_browse_node_id="BN1",
+            ).exists()
+        )
+        self.assertTrue(
+            AmazonProductBrowseNode.objects.filter(
+                product=self.var2,
+                view=self.view,
+                recommended_browse_node_id="BN1",
+            ).exists()
+        )


### PR DESCRIPTION
## Summary
- propagate configurable product browse node mapping to all variations
- test browse node propagation

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/receivers.py OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_receivers.AmazonProductBrowseNodeReceiversTest.test_propagates_to_variations -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cbd4e364832e9af20ae12657858b

## Summary by Sourcery

Add a post_create signal handler for AmazonProductBrowseNode to propagate browse node mappings from configurable parent products to their active variations, and include tests to verify this behavior.

New Features:
- Auto-propagate AmazonProductBrowseNode entries to all active variations of a configurable product.

Tests:
- Add a test to confirm that creating a browse node record for a parent configurable product also creates corresponding records for its variations.