### PR TITLE
Handle variation theme name attrs only when present in variation theme

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/products.py
@@ -570,8 +570,9 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
         if theme:
             parts = [p.lower() for p in theme.split("/")]
             for part in parts:
-                base = part.replace("_name", "")
-                base_attr = base
+                if "_name" not in part:
+                    continue
+                base_attr = part.replace("_name", "")
                 name_attr = f"{base_attr}_name"
                 if base_attr in self.attributes and name_attr not in self.attributes:
                     attrs[name_attr] = self.attributes[base_attr]


### PR DESCRIPTION
## Summary
- avoid auto-adding *_name attributes for variation themes that don't include `_name`

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/products/products.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5cd835a54832e80323e1a52d480a6