### PR TITLE
Fetch Amazon listing summaries to store created ASIN

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/sales_channels/issues.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sales_channels/issues.py
@@ -29,13 +29,36 @@ class FetchRemoteIssuesFactory(GetAmazonAPIMixin):
             response = self.get_listing_item(
                 self.remote_product.remote_sku,
                 self.view.remote_id,
-                included_data=["issues"],
+                included_data=["issues", "summaries"],
             )
 
         if isinstance(response, dict):
             issues_data = response.get("issues", []) or []
+            summaries = response.get("summaries", []) or []
         else:
             issues_data = getattr(response, "issues", []) or []
+            summaries = getattr(response, "summaries", []) or []
+
+        if summaries:
+            summary = summaries[0]
+            asin = summary.get("asin") if isinstance(summary, dict) else getattr(summary, "asin", None)
+            if asin and getattr(self.remote_product, "local_instance", None):
+                from sales_channels.integrations.amazon.models import AmazonExternalProductId
+
+                product = self.remote_product.local_instance
+                try:
+                    ext = AmazonExternalProductId.objects.get(product=product, view=self.view)
+                    if ext.created_asin != asin:
+                        ext.created_asin = asin
+                        ext.save(update_fields=["created_asin"])
+                except AmazonExternalProductId.DoesNotExist:
+                    AmazonExternalProductId.objects.create(
+                        product=product,
+                        view=self.view,
+                        type=AmazonExternalProductId.TYPE_ASIN,
+                        value=asin,
+                        created_asin=asin,
+                    )
 
         for issue in issues_data:
             data = ensure_serializable(

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_issues_factory.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_issues_factory.py
@@ -1,0 +1,59 @@
+from core.tests import TestCase
+from model_bakery import baker
+from sales_channels.integrations.amazon.factories.sales_channels.issues import FetchRemoteIssuesFactory
+from sales_channels.integrations.amazon.models import (
+    AmazonExternalProductId,
+    AmazonProduct,
+    AmazonSalesChannel,
+    AmazonSalesChannelView,
+)
+
+
+class FetchRemoteIssuesFactoryExternalIdTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="GB",
+        )
+        self.product = baker.make(
+            "products.Product",
+            multi_tenant_company=self.multi_tenant_company,
+            type="SIMPLE",
+        )
+        self.remote_product = AmazonProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+            remote_sku="SKU123",
+            ean_code="EAN123",
+        )
+
+    def test_updates_existing_external_product_id(self):
+        AmazonExternalProductId.objects.create(
+            product=self.product,
+            view=self.view,
+            type=AmazonExternalProductId.TYPE_GTIN,
+            value="EAN123",
+        )
+        response = {"summaries": [{"asin": "ASIN123"}], "issues": []}
+        FetchRemoteIssuesFactory(
+            remote_product=self.remote_product, view=self.view, response_data=response
+        ).run()
+        ext = AmazonExternalProductId.objects.get(product=self.product, view=self.view)
+        self.assertEqual(ext.created_asin, "ASIN123")
+
+    def test_creates_external_product_id_if_missing(self):
+        response = {"summaries": [{"asin": "ASIN999"}], "issues": []}
+        FetchRemoteIssuesFactory(
+            remote_product=self.remote_product, view=self.view, response_data=response
+        ).run()
+        ext = AmazonExternalProductId.objects.get(product=self.product, view=self.view)
+        self.assertEqual(ext.created_asin, "ASIN999")
+        self.assertEqual(ext.value, "ASIN999")
+        self.assertEqual(ext.type, AmazonExternalProductId.TYPE_ASIN)


### PR DESCRIPTION
## Summary
- include listing summaries when fetching remote issues
- persist created ASIN on AmazonExternalProductId, creating ASIN records when needed
- add tests for FetchRemoteIssuesFactory external product ID

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_issues_factory` (fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/sales_channels/issues.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_issues_factory.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5c6c3a8e4832e90715f3550fb0b74

## Summary by Sourcery

Fetch Amazon listing summaries alongside issues, and store the returned ASIN on the associated product by updating or creating an AmazonExternalProductId entry; include tests to cover creation and update scenarios.

New Features:
- Fetch and include Amazon listing summaries in FetchRemoteIssuesFactory

Enhancements:
- Persist the created ASIN to AmazonExternalProductId by updating or creating records

Tests:
- Add tests for FetchRemoteIssuesFactory to verify updating existing and creating new external product ID records from listing summaries