### PR TITLE
Handle manual extraction for Amazon item name and GTIN exemption

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -415,7 +415,16 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
         product_type_code = summary.get("product_type")
         product_attrs = product_data.get("attributes") or {}
 
-        name = extract_amazon_attribute_value(product_attrs, "item_name") or summary.get("item_name")
+        name_entry = product_attrs.get("item_name")
+        if isinstance(name_entry, list):
+            name_entry = name_entry[0] if name_entry else None
+        if isinstance(name_entry, dict):
+            name = name_entry.get("value") or name_entry.get("name")
+        else:
+            name = None
+
+        if not name:
+            name = summary.get("item_name")
 
         # it seems that sometimes the name can be None coming from Amazon. IN that case we fallback to sku
         if name is None:
@@ -481,9 +490,15 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
         if amazon_theme:
             structured["__amazon_theme"] = amazon_theme
 
-        gtin_exemption = extract_amazon_attribute_value(
-            product_attrs, "supplier_declared_has_product_identifier_exemption"
+        gtin_entry = product_attrs.get(
+            "supplier_declared_has_product_identifier_exemption"
         )
+        if isinstance(gtin_entry, list):
+            gtin_entry = gtin_entry[0] if gtin_entry else None
+        if isinstance(gtin_entry, dict):
+            gtin_exemption = gtin_entry.get("value")
+        else:
+            gtin_exemption = None
         if gtin_exemption is not None:
             structured["__gtin_exemption"] = bool(gtin_exemption)
 


### PR DESCRIPTION
## Summary
- manually parse `item_name` from Amazon attributes with fallback to summary
- manually parse `supplier_declared_has_product_identifier_exemption` to set GTIN exemption flag

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a5da17ded8832e8aaafb077ac75a03

## Summary by Sourcery

Improve Amazon product data extraction by manually parsing item_name and GTIN exemption attributes to handle nested list/dict structures and provide proper fallbacks

Enhancements:
- Manually parse item_name attribute from Amazon attributes with list/dict handling and fallback to summary
- Manually parse supplier_declared_has_product_identifier_exemption attribute with list/dict handling and set the GTIN exemption flag