### PR TITLE
Simplify Amazon listing requirements

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -349,13 +349,13 @@ class GetAmazonAPIMixin:
 
         pt_code = product_type.product_type_code
         has_asin = "merchant_suggested_asin" in (attributes or {})
-        force_listing = getattr(self, "force_listing_requirements", False)
         remote_product = getattr(self, "remote_product", getattr(self, "remote_instance", None))
-        product_owner = getattr(remote_product, "product_owner", False)
+        created = getattr(remote_product, "created_marketplaces", []) or []
 
-        is_new_listing = has_asin or force_listing
+        first_assign = not created
+        requirements = "LISTING" if first_assign and not has_asin else "LISTING_OFFER_ONLY"
 
-        if not (self.sales_channel.listing_owner or product_owner) and not is_new_listing:
+        if requirements == "LISTING_OFFER_ONLY":
             region = self.view.api_region_code
             allowed_keys = (
                 product_type.listing_offer_required_properties.get(region, [])
@@ -367,7 +367,7 @@ class GetAmazonAPIMixin:
 
         return {
             "productType": pt_code,
-            "requirements": "LISTING" if (self.sales_channel.listing_owner or product_owner or is_new_listing) else "LISTING_OFFER_ONLY",
+            "requirements": requirements,
             "attributes": clean(attributes),
         }
 

--- a/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
@@ -117,10 +117,7 @@ class AmazonPriceUpdateFactory(GetAmazonAPIMixin, RemotePriceUpdateFactory):
 
             purchasable_offer_values.append(offer_entry)
 
-            if (
-                self.sales_channel.listing_owner
-                or self.remote_product.product_owner
-            ) and full_price is not None:
+            if self.remote_product.product_owner and full_price is not None:
                 list_price_values.append({"currency": iso, value_key: full_price})
 
         if self.get_value_only:

--- a/OneSila/sales_channels/integrations/amazon/factories/products/content.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/content.py
@@ -44,7 +44,7 @@ class AmazonProductContentUpdateFactory(GetAmazonAPIMixin, RemoteProductContentU
         )
 
     def preflight_check(self):
-        if not self.sales_channel.listing_owner and not self.remote_product.product_owner:
+        if not self.remote_product.product_owner:
             return False
 
         return super().preflight_check()

--- a/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
@@ -194,7 +194,7 @@ class AmazonProductPropertyBaseMixin(GetAmazonAPIMixin, AmazonRemoteValueMixin):
         payload = self._replace_tokens(usage, self.local_instance.product)
 
         remote_prod = getattr(self, "remote_product", None)
-        if not self.sales_channel.listing_owner and not getattr(remote_prod, "product_owner", False):
+        if not getattr(remote_prod, "product_owner", False):
             allowed_properties = product_type.listing_offer_required_properties.get(self.view.api_region_code, [])
             if main_code not in allowed_properties:
                 return product_type, {}

--- a/OneSila/sales_channels/integrations/amazon/models/sales_channels.py
+++ b/OneSila/sales_channels/integrations/amazon/models/sales_channels.py
@@ -104,11 +104,6 @@ class AmazonSalesChannel(SalesChannel):
         blank=True,
         help_text="Stores the last OAuth connection failure traceback."
     )
-    listing_owner = models.BooleanField(
-        default=False,
-        help_text="Indicates if the sales channel have listing_owner status and can edit or create listings"
-    )
-
     class Meta:
         verbose_name = 'Amazon Sales Channel'
         verbose_name_plural = 'Amazon Sales Channels'

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py
@@ -251,17 +251,7 @@ class AmazonPriceUpdateRequirementsTest(DisableWooCommerceSignalsMixin, Transact
                 "body"
             )
 
-    def test_listing_owner_uses_listing_requirements(self):
-        self.sales_channel.listing_owner = True
-        self.sales_channel.save()
-        body = self._run_factory_and_get_body()
-        patches = body.get("patches", [])
-        list_price = self.get_patch_value(patches, "/attributes/list_price")
-        self.assertIsNotNone(list_price, "list_price patch is missing")
-
     def test_product_owner_uses_price_listing_requirements(self):
-        self.sales_channel.listing_owner = False
-        self.sales_channel.save()
         self.remote_product.product_owner = True
         self.remote_product.save()
         body = self._run_factory_and_get_body()
@@ -272,8 +262,6 @@ class AmazonPriceUpdateRequirementsTest(DisableWooCommerceSignalsMixin, Transact
         self.assertEqual(list_price[0]["value_with_tax"], 80.0)
 
     def test_missing_asin_still_uses_listing_requirements(self):
-        self.sales_channel.listing_owner = False
-        self.sales_channel.save()
         self.remote_product.product_owner = True
         self.remote_product.save()
         ProductProperty.objects.filter(

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_content_factories.py
@@ -35,7 +35,6 @@ class AmazonProductContentUpdateFactoryTest(DisableWooCommerceSignalsMixin, Test
         self.sales_channel = AmazonSalesChannel.objects.create(
             multi_tenant_company=self.multi_tenant_company,
             remote_id="SELLER123",
-            listing_owner=True
         )
         self.view = AmazonSalesChannelView.objects.create(
             multi_tenant_company=self.multi_tenant_company,
@@ -119,6 +118,8 @@ class AmazonProductContentUpdateFactoryTest(DisableWooCommerceSignalsMixin, Test
             local_instance=self.product,
             remote_sku="AMZSKU",
         )
+        self.remote_product.product_owner = True
+        self.remote_product.save()
         AmazonProductBrowseNode.objects.create(
             product=self.product,
             sales_channel=self.sales_channel,


### PR DESCRIPTION
## Summary
- simplify listing requirements logic for Amazon products
- allow external IDs with GTIN exemptions and ASIN creation tracking
- adjust Amazon product factory tests for new requirement rules
- remove redundant create check when determining listing requirements
- drop unused `listing_owner` flag from Amazon sales channels and related logic

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductCreateRequirementsTest -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e1058570832e88abc3627125334c