### PR TITLE
Mock Amazon ReportsApi in browse node sync tests

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_browse_node_sync_factory.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_browse_node_sync_factory.py
@@ -21,8 +21,9 @@ class AmazonBrowseNodeSyncFactoryTest(TestCase):
             remote_id="GB",
         )
 
+    @patch("sales_channels.integrations.amazon.factories.recommended_browse_nodes.sync.ReportsApi", return_value=SimpleNamespace())
     @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
-    def test_sets_parent_node(self, _):
+    def test_sets_parent_node(self, _get_client, _reports_api):
         xml = """
         <Nodes>
             <Node>
@@ -53,8 +54,9 @@ class AmazonBrowseNodeSyncFactoryTest(TestCase):
         child = AmazonBrowseNode.objects.get(remote_id="2")
         self.assertEqual(child.parent_node, root)
 
+    @patch("sales_channels.integrations.amazon.factories.recommended_browse_nodes.sync.ReportsApi", return_value=SimpleNamespace())
     @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
-    def test_marks_root_when_parent_missing(self, _):
+    def test_marks_root_when_parent_missing(self, _get_client, _reports_api):
         xml = """
         <Nodes>
             <Node>


### PR DESCRIPTION
## Summary
- restore direct `ReportsApi` instantiation in `AmazonBrowseNodeSyncFactory`
- mock `ReportsApi` in browse node sync tests to prevent initialization errors

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/recommended_browse_nodes/sync.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_browse_node_sync_factory.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_browse_node_sync_factory.AmazonBrowseNodeSyncFactoryTest.test_marks_root_when_parent_missing -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a6071bb200832ebc9ca1ca73609ebd

## Summary by Sourcery

Mock ReportsApi in AmazonBrowseNodeSyncFactory tests to prevent real API instantiation and avoid test failures

Bug Fixes:
- Prevent initialization errors in browse node sync tests by mocking ReportsApi

Enhancements:
- Add ReportsApi patch decorator returning a dummy object in sync tests
- Update test method signatures to accept the ReportsApi mock parameter