### PR TITLE
Add view to assignment signals and handle Amazon product assignments

### DIFF
--- a/OneSila/sales_channels/receivers.py
+++ b/OneSila/sales_channels/receivers.py
@@ -617,10 +617,11 @@ def sales_channel_view_assign__post_create_receiver(sender, instance, **kwargs):
         return
 
     if product_assign_count == 1:
-        create_remote_product.send(sender=instance.__class__, instance=instance)
+        create_remote_product.send(sender=instance.__class__, instance=instance, view=instance.sales_channel_view)
     else:
         # Otherwise, send sales_view_assign_updated signal
-        sales_view_assign_updated.send(sender=instance.product.__class__, instance=instance.product, sales_channel=instance.sales_channel)
+        sales_view_assign_updated.send(sender=instance.product.__class__, instance=instance.product,
+                                       sales_channel=instance.sales_channel, view=instance.sales_channel_view)
 
 
 @receiver(post_delete, sender='sales_channels.SalesChannelViewAssign')
@@ -651,7 +652,8 @@ def sales_channel_view_assign__post_delete_receiver(sender, instance, **kwargs):
         delete_remote_product.send(sender=instance.__class__, instance=instance, is_variation=is_variation)
     else:
         # Otherwise, send sales_view_assign_updated signal
-        sales_view_assign_updated.send(sender=instance.product.__class__, instance=instance.product, sales_channel=instance.sales_channel)
+        sales_view_assign_updated.send(sender=instance.product.__class__, instance=instance.product,
+                                       sales_channel=instance.sales_channel, view=instance.sales_channel_view)
 
 
 @receiver(post_update, sender='products.Product')


### PR DESCRIPTION
## Summary
- Include view in create and update assignment signals
- Add Amazon receivers to create or update product listings for active channels

## Testing
- `pre-commit run --files OneSila/sales_channels/receivers.py OneSila/sales_channels/integrations/amazon/receivers.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_models.SalesChannelViewAssignValidationTest.test_first_assign_requires_browse_node` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a6413d1c30832ea6d9e6c35e762275