### PR TITLE
Pre-populate Amazon product owner and fix EAN code storage

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -378,14 +378,11 @@ class GetAmazonAPIMixin:
         body = self._build_common_body(product_type, attributes)
         listings = ListingsApi(self._get_client())
 
-        # @TODO: Add proper logger for this
-        print('--------------------------------------- ARGUMENTS')
-        print('mode')
-        print("VALIDATION_PREVIEW" if settings.DEBUG else None)
-        print('body')
-        import pprint
-        pprint.pprint(body)
-        print('-------------------------------------------------')
+        logger.debug(
+            "create_product arguments: mode=%s body=%s",
+            "VALIDATION_PREVIEW" if settings.DEBUG or force_validation_only else None,
+            body,
+        )
 
         response = listings.put_listings_item(
             seller_id=self.sales_channel.remote_id,
@@ -554,5 +551,3 @@ class EnsureMerchantSuggestedAsinMixin:
             local_property.save(update_fields=["non_deletable"])
 
         return remote_property
-
-

--- a/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
@@ -117,7 +117,7 @@ class AmazonPriceUpdateFactory(GetAmazonAPIMixin, RemotePriceUpdateFactory):
 
             purchasable_offer_values.append(offer_entry)
 
-            if self.remote_product.product_owner and full_price is not None:# @TODO: On create we need to pre populate product_owner not after
+            if self.remote_product.product_owner and full_price is not None:
                 list_price_values.append({"currency": iso, value_key: full_price})
 
         if self.get_value_only:

--- a/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
@@ -194,7 +194,7 @@ class AmazonProductPropertyBaseMixin(GetAmazonAPIMixin, AmazonRemoteValueMixin):
         payload = self._replace_tokens(usage, self.local_instance.product)
 
         remote_prod = getattr(self, "remote_product", None)
-        if not getattr(remote_prod, "product_owner", False): # @TODO: On create we need to pre populate product_owner not after
+        if not getattr(remote_prod, "product_owner", False):
             allowed_properties = product_type.listing_offer_required_properties.get(self.view.api_region_code, [])
             if main_code not in allowed_properties:
                 return product_type, {}


### PR DESCRIPTION
## Summary
- replace debug prints with structured logging for Amazon product creation
- set product owner before property processing
- persist product EAN in AmazonEanCode mirror
- only mark marketplace as created when validation passes

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/products/products.py`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a8284d79b0832ea871f6e000445740

## Summary by Sourcery

Improve Amazon product creation by adding structured logging, setting product_owner earlier, validating before marking marketplaces as created, and persisting EAN codes in a dedicated mirror model

New Features:
- Pre-populate Amazon product_owner flag before property processing
- Persist product EANs in a separate AmazonEanCode mirror model

Enhancements:
- Replace debug prints with structured structured logging in product creation
- Only mark marketplaces as created after passing validation

Chores:
- Remove outdated TODO comments around product_owner logic in pricing and property mixins