### PR TITLE
Add bulk update product properties mutation

### DIFF
--- a/OneSila/properties/schema/mutations/fields.py
+++ b/OneSila/properties/schema/mutations/fields.py
@@ -1,9 +1,9 @@
 from typing import List
 
 from properties.schema.mutations.mutation_classes import CompleteCreateProductPropertiesRule, \
-    CompleteUpdateProductPropertiesRule, BulkCreateProductProperties
+    CompleteUpdateProductPropertiesRule, BulkCreateProductProperties, BulkUpdateProductProperties
 from properties.schema.types.input import PropertyInput, PropertySelectValueInput, ProductPropertiesRuleInput, \
-    ProductPropertiesRulePartialInput, BulkProductPropertyInput
+    ProductPropertiesRulePartialInput, BulkProductPropertyInput, BulkProductPropertyPartialInput
 from properties.models import PropertyTranslation, PropertySelectValueTranslation
 from properties.signals import property_created, property_select_value_created
 from translations.schema.mutations import TranslatableCreateMutation
@@ -42,3 +42,8 @@ def complete_update_product_properties_rule():
 def bulk_create_product_properties():
     extensions = []
     return BulkCreateProductProperties(List[BulkProductPropertyInput], extensions=extensions)
+
+
+def bulk_update_product_properties():
+    extensions = []
+    return BulkUpdateProductProperties(List[BulkProductPropertyPartialInput], extensions=extensions)

--- a/OneSila/properties/schema/mutations/mutation_type.py
+++ b/OneSila/properties/schema/mutations/mutation_type.py
@@ -4,7 +4,7 @@ import strawberry_django
 from core.schema.core.extensions import default_extensions
 from core.schema.core.helpers import get_multi_tenant_company
 from .fields import complete_create_product_properties_rule, complete_update_product_properties_rule, \
-    bulk_create_product_properties, create_property, create_property_select_value
+    bulk_create_product_properties, bulk_update_product_properties, create_property, create_property_select_value
 from ..types.types import PropertyType, PropertyTranslationType, PropertySelectValueType, ProductPropertyType, ProductPropertyTextTranslationType, \
     PropertySelectValueTranslationType, ProductPropertiesRuleType, ProductPropertiesRuleItemType, PropertyDuplicatesType, PropertySelectValueDuplicatesType
 from properties.models import Property, PropertySelectValue
@@ -37,6 +37,7 @@ class PropertiesMutation:
     create_product_property: ProductPropertyType = create(ProductPropertyInput)
     create_product_properties: List[ProductPropertyType] = create(ProductPropertyInput)
     bulk_create_product_properties: List[ProductPropertyType] = bulk_create_product_properties()
+    bulk_update_product_properties: List[ProductPropertyType] = bulk_update_product_properties()
     update_product_property: ProductPropertyType = update(ProductPropertyPartialInput)
     delete_product_property: ProductPropertyType = delete()
     delete_product_properties: List[ProductPropertyType] = delete()

--- a/OneSila/properties/schema/types/input.py
+++ b/OneSila/properties/schema/types/input.py
@@ -102,3 +102,15 @@ class BulkProductPropertyInput:
     language_code: Optional[str] = None
     translated_value: Optional[str] = None
     override_if_exists: Optional[bool] = False
+
+
+@strawberry.input
+class BulkProductPropertyTranslationInput:
+    language_code: str
+    value_text: Optional[str] = None
+    value_description: Optional[str] = None
+
+
+@strawberry.input
+class BulkProductPropertyPartialInput(ProductPropertyPartialInput):
+    translation: Optional[BulkProductPropertyTranslationInput] = None


### PR DESCRIPTION
## Summary
- add translation-aware partial input for bulk updates
- support numeric and select values in bulk property updates

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a599fc08832eafa099aaf7999b89