### PR TITLE
Add bulk update mutation for product properties

### DIFF
--- a/OneSila/properties/schema/mutations/fields.py
+++ b/OneSila/properties/schema/mutations/fields.py
@@ -1,9 +1,9 @@
 from typing import List
 
 from properties.schema.mutations.mutation_classes import CompleteCreateProductPropertiesRule, \
-    CompleteUpdateProductPropertiesRule, BulkCreateProductProperties, BulkUpdateProductProperties
+    CompleteUpdateProductPropertiesRule, BulkCreateProductProperties
 from properties.schema.types.input import PropertyInput, PropertySelectValueInput, ProductPropertiesRuleInput, \
-    ProductPropertiesRulePartialInput, BulkProductPropertyInput, BulkProductPropertyPartialInput
+    ProductPropertiesRulePartialInput, BulkProductPropertyInput
 from properties.models import PropertyTranslation, PropertySelectValueTranslation
 from properties.signals import property_created, property_select_value_created
 from translations.schema.mutations import TranslatableCreateMutation
@@ -42,8 +42,3 @@ def complete_update_product_properties_rule():
 def bulk_create_product_properties():
     extensions = []
     return BulkCreateProductProperties(List[BulkProductPropertyInput], extensions=extensions)
-
-
-def bulk_update_product_properties():
-    extensions = []
-    return BulkUpdateProductProperties(List[BulkProductPropertyPartialInput], extensions=extensions)

--- a/OneSila/properties/schema/mutations/mutation_type.py
+++ b/OneSila/properties/schema/mutations/mutation_type.py
@@ -1,17 +1,19 @@
 from core.schema.core.mutations import create, update, delete, type, List
+from typing import List as TypingList
 from strawberry import Info
 import strawberry_django
 from core.schema.core.extensions import default_extensions
-from core.schema.core.helpers import get_multi_tenant_company
+from core.schema.core.helpers import get_multi_tenant_company, get_current_user
 from .fields import complete_create_product_properties_rule, complete_update_product_properties_rule, \
-    bulk_create_product_properties, bulk_update_product_properties, create_property, create_property_select_value
+    bulk_create_product_properties, create_property, create_property_select_value
 from ..types.types import PropertyType, PropertyTranslationType, PropertySelectValueType, ProductPropertyType, ProductPropertyTextTranslationType, \
     PropertySelectValueTranslationType, ProductPropertiesRuleType, ProductPropertiesRuleItemType, PropertyDuplicatesType, PropertySelectValueDuplicatesType
-from properties.models import Property, PropertySelectValue
+from properties.models import Property, PropertySelectValue, ProductProperty, ProductPropertyTextTranslation
 from ..types.input import PropertyInput, PropertyTranslationInput, PropertySelectValueInput, ProductPropertyInput, \
     PropertyPartialInput, PropertyTranslationPartialInput, PropertySelectValuePartialInput, ProductPropertyPartialInput, ProductPropertyTextTranslationInput, \
     PropertySelectValueTranslationInput, PropertySelectValueTranslationPartialInput, ProductPropertyTextTranslationPartialInput, ProductPropertiesRuleInput, \
-    ProductPropertiesRulePartialInput, ProductPropertiesRuleItemInput, ProductPropertiesRuleItemPartialInput
+    ProductPropertiesRulePartialInput, ProductPropertiesRuleItemInput, ProductPropertiesRuleItemPartialInput, BulkProductPropertyPartialInput
+from strawberry_django.mutations.types import UNSET
 
 
 @type(name="Mutation")
@@ -37,10 +39,67 @@ class PropertiesMutation:
     create_product_property: ProductPropertyType = create(ProductPropertyInput)
     create_product_properties: List[ProductPropertyType] = create(ProductPropertyInput)
     bulk_create_product_properties: List[ProductPropertyType] = bulk_create_product_properties()
-    bulk_update_product_properties: List[ProductPropertyType] = bulk_update_product_properties()
     update_product_property: ProductPropertyType = update(ProductPropertyPartialInput)
     delete_product_property: ProductPropertyType = delete()
     delete_product_properties: List[ProductPropertyType] = delete()
+
+    @strawberry_django.mutation(handle_django_errors=False, extensions=default_extensions)
+    def bulk_update_product_properties(
+        self,
+        info: Info,
+        product_properties: TypingList[BulkProductPropertyPartialInput],
+    ) -> TypingList[ProductPropertyType]:
+        multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
+        multi_tenant_user = get_current_user(info)
+        updated: list[ProductProperty] = []
+        for item in product_properties:
+            item_data = vars(item).copy()
+            obj_id = item_data.pop("id").node_id
+            translation_data = item_data.pop("translation", None)
+            value_multi_select = item_data.pop("value_multi_select", UNSET)
+            value_select = item_data.pop("value_select", UNSET)
+            obj = ProductProperty.objects.get(id=obj_id)
+            if obj.multi_tenant_company != multi_tenant_company:
+                raise PermissionError("Invalid company")
+            for field, value in item_data.items():
+                if value is not UNSET:
+                    setattr(obj, field, value)
+            obj.last_update_by_multi_tenant_user = multi_tenant_user
+            obj.save()
+            if value_select is not UNSET:
+                if value_select is None:
+                    obj.value_select = None
+                else:
+                    obj.value_select_id = value_select.id.node_id
+                obj.save()
+            if value_multi_select is not UNSET:
+                values: list[int] = []
+                if value_multi_select is not None:
+                    values = [v.id.node_id for v in value_multi_select]
+                obj.value_multi_select.set(values)
+            if translation_data:
+                language_code = translation_data.language_code
+                try:
+                    translation = ProductPropertyTextTranslation.objects.get(
+                        product_property=obj,
+                        language=language_code,
+                    )
+                    translation.last_update_by_multi_tenant_user = multi_tenant_user
+                except ProductPropertyTextTranslation.DoesNotExist:
+                    translation = ProductPropertyTextTranslation(
+                        product_property=obj,
+                        language=language_code,
+                        multi_tenant_company=multi_tenant_company,
+                        created_by_multi_tenant_user=multi_tenant_user,
+                        last_update_by_multi_tenant_user=multi_tenant_user,
+                    )
+                if translation_data.value_text is not None:
+                    translation.value_text = translation_data.value_text
+                if translation_data.value_description is not None:
+                    translation.value_description = translation_data.value_description
+                translation.save()
+            updated.append(obj)
+        return updated
 
     create_product_property_text_translation: ProductPropertyTextTranslationType = create(ProductPropertyTextTranslationInput)
     create_product_property_text_translations: List[ProductPropertyTextTranslationType] = create(ProductPropertyTextTranslationInput)


### PR DESCRIPTION
## Summary
- implement bulk update mutation for product properties supporting translations
- streamline mutation fields by removing unused bulk update helper

## Testing
- `python manage.py test properties` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68aca87fccc8832eb154b8edfe9695ac

## Summary by Sourcery

Add a new bulk update GraphQL mutation for product properties that supports multi-tenant permissions, select and multi-select fields, and translations, and remove the obsolete helper function.

New Features:
- Add bulk_update_product_properties mutation to batch update product properties with field, select, multi-select, and translation handling under multi-tenant context.

Enhancements:
- Remove unused bulk_update_product_properties helper definition from schema fields.