### PR TITLE
Propagate Amazon GTIN exemptions to configurable children

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/receivers.py
@@ -15,6 +15,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonPropertySelectValue,
     AmazonProductType,
     AmazonProductBrowseNode,
+    AmazonGtinExemption,
 )
 from sales_channels.integrations.amazon.factories.sync.rule_sync import (
     AmazonPropertyRuleItemSyncFactory,
@@ -199,6 +200,23 @@ def amazon__product_browse_node__propagate_to_variations(sender, instance, **kwa
             sales_channel=instance.sales_channel,
             view=instance.view,
             defaults={'recommended_browse_node_id': instance.recommended_browse_node_id},
+        )
+
+
+@receiver(post_create, sender='amazon.AmazonGtinExemption')
+@receiver(post_update, sender='amazon.AmazonGtinExemption')
+def amazon__gtin_exemption__propagate_to_variations(sender, instance, **kwargs):
+
+    if not instance.product.is_configurable():
+        return
+
+    variations = instance.product.get_configurable_variations(active_only=False)
+    for variation in variations:
+        AmazonGtinExemption.objects.get_or_create(
+            multi_tenant_company=instance.multi_tenant_company,
+            product=variation,
+            view=instance.view,
+            defaults={'value': instance.value},
         )
 
 

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_receivers.py
@@ -12,6 +12,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonProductType,
     AmazonRemoteLanguage,
     AmazonProductBrowseNode,
+    AmazonGtinExemption,
 )
 from products.models import Product, ConfigurableVariation
 from sales_channels.signals import manual_sync_remote_product, update_remote_product
@@ -290,5 +291,55 @@ class AmazonProductBrowseNodeReceiversTest(TestCase):
                 product=self.var2,
                 view=self.view,
                 recommended_browse_node_id="BN1",
+            ).exists()
+        )
+
+
+class AmazonGtinExemptionReceiversTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="VIEW",
+        )
+        self.parent = Product.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Product.CONFIGURABLE,
+        )
+        self.var1 = Product.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Product.SIMPLE,
+        )
+        self.var2 = Product.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Product.SIMPLE,
+        )
+        ConfigurableVariation.objects.create(parent=self.parent, variation=self.var1, multi_tenant_company=self.multi_tenant_company)
+        ConfigurableVariation.objects.create(parent=self.parent, variation=self.var2, multi_tenant_company=self.multi_tenant_company)
+
+    def test_propagates_to_variations(self):
+        AmazonGtinExemption.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            product=self.parent,
+            view=self.view,
+            value=True,
+        )
+        self.assertTrue(
+            AmazonGtinExemption.objects.filter(
+                product=self.var1,
+                view=self.view,
+                value=True,
+            ).exists()
+        )
+        self.assertTrue(
+            AmazonGtinExemption.objects.filter(
+                product=self.var2,
+                view=self.view,
+                value=True,
             ).exists()
         )


### PR DESCRIPTION
## Summary
- propagate GTIN exemption updates on configurable products to their variations
- allow per-variation overrides by using get_or_create
- cover GTIN exemption propagation with a receiver test

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_receivers.AmazonGtinExemptionReceiversTest.test_propagates_to_variations -v 2` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ad94a66228832e9abeca5f1fa039bf