### PR TITLE
feat: allow duplicating product as alias

### DIFF
--- a/OneSila/products/schema/mutations/mutation_type.py
+++ b/OneSila/products/schema/mutations/mutation_type.py
@@ -133,11 +133,18 @@ class ProductsMutation:
         return ProductVariationsTaskResponse(success=True)
 
     @strawberry_django.mutation(handle_django_errors=False, extensions=default_extensions)
-    def duplicate_product(self, info: Info, product: ProductPartialInput, sku: str | None = None) -> ProductType:
+    def duplicate_product(
+        self,
+        info: Info,
+        product: ProductPartialInput,
+        sku: str | None = None,
+        create_as_alias: bool = False,
+    ) -> ProductType:
         multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
-        instance =  Product.objects.get(id=product.id.node_id)
+        instance = Product.objects.get(id=product.id.node_id)
         if instance.multi_tenant_company != multi_tenant_company:
             raise PermissionError("Invalid company")
-        duplicated = Product.objects.duplicate_product(instance, sku=sku)
+        duplicated = Product.objects.duplicate_product(
+            instance, sku=sku, create_as_alias=create_as_alias
+        )
         return duplicated
-

--- a/OneSila/products/tests/tests_models.py
+++ b/OneSila/products/tests/tests_models.py
@@ -9,6 +9,7 @@ from products.models import (
     BundleVariation,
     AliasProduct,
     ProductTranslation,
+    Product,
 )
 from media.models import Media, MediaProductThrough
 from properties.models import Property, PropertyTranslation, ProductProperty, ProductPropertyTextTranslation
@@ -135,6 +136,13 @@ class DuplicateProductTestCase(TestCase):
     def test_duplicate_product_existing_sku_error(self):
         with self.assertRaises(Exception):
             SimpleProduct.objects.duplicate_product(self.product, sku=self.product.sku)
+
+    def test_duplicate_product_manager_as_alias(self):
+        duplicate = SimpleProduct.objects.duplicate_product(
+            self.product, create_as_alias=True
+        )
+        self.assertEqual(duplicate.type, Product.ALIAS)
+        self.assertEqual(duplicate.alias_parent_product, self.product)
 
 
 class ProductTranslationModelTest(TestCase):

--- a/OneSila/products/tests/tests_schemas/tests_mutations.py
+++ b/OneSila/products/tests/tests_schemas/tests_mutations.py
@@ -2,12 +2,12 @@ from django.test import TransactionTestCase
 from model_bakery import baker
 
 from core.tests.tests_schemas.tests_queries import TransactionTestCaseMixin
-from products.models import SimpleProduct, ProductTranslation
+from products.models import SimpleProduct, ProductTranslation, Product
 
 
 DUPLICATE_PRODUCT_MUTATION = """
-    mutation($product: ProductPartialInput!, $sku: String) {
-      duplicateProduct(product: $product, sku: $sku) {
+    mutation($product: ProductPartialInput!, $sku: String, $createAsAlias: Boolean) {
+      duplicateProduct(product: $product, sku: $sku, createAsAlias: $createAsAlias) {
         id
         sku
       }
@@ -29,7 +29,7 @@ class DuplicateProductMutationTestCase(TransactionTestCaseMixin, TransactionTest
     def test_duplicate_product_mutation(self):
         resp = self.strawberry_test_client(
             query=DUPLICATE_PRODUCT_MUTATION,
-            variables={"product": {"id": self.to_global_id(self.product)}, "sku": None},
+            variables={"product": {"id": self.to_global_id(self.product)}, "sku": None, "createAsAlias": False},
         )
 
         self.assertIsNone(resp.errors)
@@ -39,8 +39,20 @@ class DuplicateProductMutationTestCase(TransactionTestCaseMixin, TransactionTest
     def test_duplicate_product_mutation_existing_sku(self):
         resp = self.strawberry_test_client(
             query=DUPLICATE_PRODUCT_MUTATION,
-            variables={"product": {"id": self.to_global_id(self.product)}, "sku": self.product.sku},
+            variables={"product": {"id": self.to_global_id(self.product)}, "sku": self.product.sku, "createAsAlias": False},
             asserts_errors=False,
         )
 
         self.assertTrue(resp.errors is not None)
+
+    def test_duplicate_product_mutation_create_as_alias(self):
+        resp = self.strawberry_test_client(
+            query=DUPLICATE_PRODUCT_MUTATION,
+            variables={"product": {"id": self.to_global_id(self.product)}, "sku": None, "createAsAlias": True},
+        )
+
+        self.assertIsNone(resp.errors)
+        data = resp.data["duplicateProduct"]
+        new_product = Product.objects.get(id=self.from_global_id(data["id"]))
+        self.assertEqual(new_product.type, Product.ALIAS)
+        self.assertEqual(new_product.alias_parent_product, self.product)


### PR DESCRIPTION
## Summary
- support optional createAsAlias when duplicating products
- create alias copy with type ALIAS and parent reference
- test duplication as alias and update mutation tests

## Testing
- `pre-commit run --files OneSila/products/managers.py OneSila/products/schema/mutations/mutation_type.py OneSila/products/tests/tests_models.py OneSila/products/tests/tests_schemas/tests_mutations.py`
- `python OneSila/manage.py test products.tests.tests_models.DuplicateProductTestCase.test_duplicate_product_manager` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68aeda62604c832e972892bf50a31af3