### PR TITLE
feat: support sales channel translations

### DIFF
--- a/OneSila/llm/factories/translations.py
+++ b/OneSila/llm/factories/translations.py
@@ -7,12 +7,13 @@ class StringTranslationLLM(AskGPTMixin, CalculateCostMixin, CreateTransactionMix
     The from_language_code is given for guardrails.
     """
 
-    def __init__(self, to_translate, from_language_code, to_language_code, multi_tenant_company=None):
+    def __init__(self, to_translate, from_language_code, to_language_code, multi_tenant_company=None, sales_channel=None):
         super().__init__()
         self.to_translate = to_translate
         self.from_language_code = from_language_code
         self.to_language_code = to_language_code
         self.multi_tenant_company = multi_tenant_company
+        self.sales_channel = sales_channel
 
     @property
     def system_prompt(self):

--- a/OneSila/llm/schema/mutations.py
+++ b/OneSila/llm/schema/mutations.py
@@ -16,6 +16,7 @@ from .types.types import BrandCustomPromptType
 from .types.input import BrandCustomPromptInput, BrandCustomPromptPartialInput
 from core.schema.core.helpers import get_multi_tenant_company
 from products.models import Product
+from sales_channels.models import SalesChannel
 
 
 @type(name="Mutation")
@@ -69,6 +70,11 @@ class LlmMutation:
         if instance.product:
             product = Product.objects.get(id=instance.product.id.node_id, multi_tenant_company=multi_tenant_company)
 
+        sales_channel = None
+        if instance.sales_channel:
+            sales_channel = SalesChannel.objects.get(id=instance.sales_channel.id.node_id,
+                                                     multi_tenant_company=multi_tenant_company)
+
         content_type = instance.product_content_type
 
         content_generator = AITranslateContentFlow(multi_tenant_company=multi_tenant_company,
@@ -76,7 +82,8 @@ class LlmMutation:
                                                    from_language_code=instance.from_language_code,
                                                    to_language_code=instance.to_language_code,
                                                    product=product,
-                                                   content_type=content_type)
+                                                   content_type=content_type,
+                                                   sales_channel=sales_channel)
         content_generator.flow()
 
         return AiContent(content=content_generator.translated_content, points=content_generator.used_points)

--- a/OneSila/llm/schema/types/input.py
+++ b/OneSila/llm/schema/types/input.py
@@ -16,6 +16,7 @@ from properties.schema.types.input import (
     PropertySelectValuePartialInput,
 )
 from llm.models import BrandCustomPrompt
+from sales_channels.schema.types.input import SalesChannelPartialInput
 
 
 class ContentAiGenerateType(Enum):
@@ -45,6 +46,7 @@ class AITranslationInput:
     to_language_code: str
     product: Optional[ProductPartialInput] = None
     product_content_type: Optional[ContentAiGenerateType] = None
+    sales_channel: Optional[SalesChannelPartialInput] = None
 
 
 @strawberry_input


### PR DESCRIPTION
## Summary
- allow specifying a sales channel when requesting AI translations
- select source translations by sales channel with company language fallback
- plumb sales channel through translation flow and factory

## Testing
- `python -m py_compile OneSila/llm/schema/types/input.py OneSila/llm/schema/mutations.py OneSila/llm/flows/translate_ai_content.py OneSila/llm/factories/translations.py`
- `PYTHONPATH=OneSila pytest -q --ds=OneSila.settings` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68aede457990832ea5f879534f422dab