### PR TITLE
Add bullet point translation support

### DIFF
--- a/OneSila/llm/schema/types/input.py
+++ b/OneSila/llm/schema/types/input.py
@@ -23,6 +23,7 @@ class ContentAiGenerateType(Enum):
     DESCRIPTION = "description"
     SHORT_DESCRIPTION = "short_description"
     NAME = "name"
+    BULLET_POINTS = "bullet_points"
 
 
 class SalesChannelIntegrationType(Enum):


### PR DESCRIPTION
## Summary
- extend `ContentAiGenerateType` with `BULLET_POINTS`
- translate product bullet points individually and join with `__BULLET_SEPARATOR__`

## Testing
- `pre-commit run --files OneSila/llm/flows/translate_ai_content.py OneSila/llm/schema/types/input.py`
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68af04ec2f04832e94f97effb072e0ef

## Summary by Sourcery

Add support for translating bullet point content by extending the translation flow to process and merge individual points

New Features:
- Extend ContentAiGenerateType enum with BULLET_POINTS
- Implement individual bullet point translation and join results with a separator

Enhancements:
- Introduce BULLET_POINT_SEPARATOR constant
- Enhance validation to reject empty translation sources