### PR TITLE
Add PropertySelectValue merge functionality

### DIFF
--- a/OneSila/properties/tests/tests_schemas/tests_mutations.py
+++ b/OneSila/properties/tests/tests_schemas/tests_mutations.py
@@ -1,6 +1,13 @@
 from django.test import TransactionTestCase
 from core.tests.tests_schemas.tests_queries import TransactionTestCaseMixin
-from properties.models import Property, PropertyTranslation, PropertySelectValue, PropertySelectValueTranslation
+from properties.models import (
+    ProductProperty,
+    Property,
+    PropertySelectValue,
+    PropertySelectValueTranslation,
+    PropertyTranslation,
+)
+from products.models import Product
 
 
 class CheckPropertyForDuplicatesTestCase(TransactionTestCaseMixin, TransactionTestCase):
@@ -49,6 +56,83 @@ class CheckPropertyForDuplicatesTestCase(TransactionTestCaseMixin, TransactionTe
         data = resp.data["checkPropertyForDuplicates"]
         self.assertFalse(data["duplicateFound"])
         self.assertEqual(len(data["duplicates"]), 0)
+
+
+class MergePropertySelectValueMutationTestCase(TransactionTestCaseMixin, TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.prop = Property.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.SELECT,
+        )
+        PropertyTranslation.objects.create(
+            property=self.prop,
+            language=self.multi_tenant_company.language,
+            name="Color",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.value1 = PropertySelectValue.objects.create(
+            property=self.prop,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.value2 = PropertySelectValue.objects.create(
+            property=self.prop,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.target = PropertySelectValue.objects.create(
+            property=self.prop,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertySelectValueTranslation.objects.create(
+            propertyselectvalue=self.value1,
+            language=self.multi_tenant_company.language,
+            value="Red",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertySelectValueTranslation.objects.create(
+            propertyselectvalue=self.value2,
+            language=self.multi_tenant_company.language,
+            value="Blue",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.product = Product.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            type=Product.SIMPLE,
+        )
+        self.product_property = ProductProperty.objects.create(
+            product=self.product,
+            property=self.prop,
+            multi_tenant_company=self.multi_tenant_company,
+            value_select=self.value1,
+        )
+        self.product_property.value_multi_select.add(self.value1, self.value2)
+
+    def test_merge(self):
+        mutation = """
+            mutation($sources: [PropertySelectValuePartialInput!]!, $target: PropertySelectValuePartialInput!) {
+              mergePropertySelectValue(sources: $sources, target: $target) { id }
+            }
+        """
+        variables = {
+            "sources": [
+                {"id": self.to_global_id(self.value1)},
+                {"id": self.to_global_id(self.value2)},
+            ],
+            "target": {"id": self.to_global_id(self.target)},
+        }
+        resp = self.strawberry_test_client(query=mutation, variables=variables)
+
+        self.assertIsNone(resp.errors)
+        self.assertEqual(
+            resp.data["mergePropertySelectValue"]["id"],
+            self.to_global_id(self.target),
+        )
+        self.assertFalse(
+            PropertySelectValue.objects.filter(id__in=[self.value1.id, self.value2.id]).exists()
+        )
+        self.product_property.refresh_from_db()
+        self.assertEqual(self.product_property.value_select_id, self.target.id)
+        self.assertListEqual(list(self.product_property.value_multi_select.all()), [self.target])
 
 
 class CheckPropertySelectValueForDuplicatesTestCase(TransactionTestCaseMixin, TransactionTestCase):


### PR DESCRIPTION
## Summary
- allow merging multiple PropertySelectValue records into a single target
- expose `mergePropertySelectValue` mutation that accepts a list of sources
- test multi-source merging via manager and GraphQL mutation

## Testing
- `pre-commit run --files OneSila/properties/managers.py OneSila/properties/schema/mutations/mutation_type.py OneSila/properties/tests/tests_models.py OneSila/properties/tests/tests_schemas/tests_mutations.py`
- `python OneSila/manage.py test properties.tests.tests_models.PropertySelectValueMergeTestCase properties.tests.tests_schemas.tests_mutations.MergePropertySelectValueMutationTestCase -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68af44e0074c832e955619451fc2afb1

## Summary by Sourcery

Introduce merge functionality for PropertySelectValue to consolidate multiple select values into a single target both at the model level and via the GraphQL API, ensuring related records and translations are reassigned correctly and invalid merges are prevented.

New Features:
- Add merge() method on PropertySelectValue QuerySet to reassign relations and delete sources when merging into a target
- Add merge() helper on PropertySelectValue Manager to merge using a list of source IDs
- Expose mergePropertySelectValue Strawberry GraphQL mutation to perform multi-source merging through the API

Tests:
- Add unit tests for PropertySelectValue.merge() covering translation retention, relation reassignment, and cross-property validation
- Add schema tests for mergePropertySelectValue mutation to verify API merge behavior and related data updates