### PR TITLE
Skip merging translations when combining property select values

### DIFF
--- a/OneSila/properties/managers.py
+++ b/OneSila/properties/managers.py
@@ -219,6 +219,8 @@ class PropertySelectValueQuerySet(MultiTenantQuerySet):
         with transaction.atomic():
             for source in sources:
                 for relation in PropertySelectValue._meta.related_objects:
+                    if relation.related_model.__name__ == "PropertySelectValueTranslation":
+                        continue
                     if relation.one_to_many or relation.one_to_one:
                         relation.related_model._default_manager.filter(
                             **{relation.field.name: source}


### PR DESCRIPTION
## Summary
- avoid merging PropertySelectValueTranslation records to prevent duplicate translations

## Testing
- `pycodestyle OneSila/properties/managers.py`
- `python OneSila/manage.py test properties -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68af7e3744fc832e946388d6a02b7b7e

## Summary by Sourcery

Bug Fixes:
- Omit PropertySelectValueTranslation relations during merge to avoid duplicate translations