### PR TITLE
Handle None when deriving configurable variation keys

### DIFF
--- a/OneSila/products/models.py
+++ b/OneSila/products/models.py
@@ -264,7 +264,10 @@ class Product(TranslatedModelMixin, models.Model):
         seen_keys = set()
         unique_variations_ids = set()
         for variation in configurable_variations:
-            key = tuple(sorted(getattr(prop, 'value_select_id', None) for prop in variation.relevant_properties))
+            key = tuple(sorted(
+                (getattr(prop, 'value_select_id', None) for prop in variation.relevant_properties),
+                key=lambda v: (v is None, v),
+            ))
 
             if key not in seen_keys or attributes_len != len(key):
                 seen_keys.add(key)


### PR DESCRIPTION
## Summary
- prevent TypeError when sorting configurable variation attributes that include `None`

## Testing
- `pre-commit run --files OneSila/products/models.py`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b029235154832ebbea967c018f2b6b

## Summary by Sourcery

Bug Fixes:
- Prevent TypeError when sorting variation property values that include None by providing a custom sort key in get_unique_configurable_variations