### PR TITLE
Add webhook models and admin

### DIFF
--- a/OneSila/webhooks/admin.py
+++ b/OneSila/webhooks/admin.py
@@ -1,3 +1,53 @@
 from django.contrib import admin
 
-# Register your models here.
+from core.admin import ModelAdmin
+
+from .models import WebhookIntegration, WebhookOutbox, WebhookDelivery
+
+
+@admin.register(WebhookIntegration)
+class WebhookIntegrationAdmin(ModelAdmin):
+    list_display = ["hostname", "url", "topic", "version", "active"]
+    list_filter = ["topic", "version", "active"]
+
+
+@admin.register(WebhookOutbox)
+class WebhookOutboxAdmin(ModelAdmin):
+    list_display = [
+        "webhook_id",
+        "webhook_integration",
+        "topic",
+        "action",
+        "subject_type",
+        "subject_id",
+        "created_at",
+    ]
+    list_filter = ["webhook_integration", "topic", "action", "subject_type"]
+
+
+@admin.action(description="Replay selected deliveries")
+def replay_deliveries(modeladmin, request, queryset):
+    queryset.update(
+        status=WebhookDelivery.PENDING,
+        attempt=0,
+        response_code=None,
+        response_ms=None,
+        response_body_snippet=None,
+        sent_at=None,
+        error_message=None,
+        error_traceback=None,
+    )
+
+
+@admin.register(WebhookDelivery)
+class WebhookDeliveryAdmin(ModelAdmin):
+    list_display = [
+        "webhook_id",
+        "webhook_integration",
+        "status",
+        "attempt",
+        "response_code",
+        "sent_at",
+    ]
+    list_filter = ["status", "webhook_integration", "response_code"]
+    actions = [replay_deliveries]

--- a/OneSila/webhooks/constants.py
+++ b/OneSila/webhooks/constants.py
@@ -1,0 +1,56 @@
+TOPIC_CHOICES = [
+    ("product", "product"),
+    ("ean_code", "ean_code"),
+    ("price_list", "price_list"),
+    ("price_list_item", "price_list_item"),
+    ("media", "media"),
+    ("media_through", "media_through"),
+    ("property", "property"),
+    ("select_value", "select_value"),
+    ("property_rule", "property_rule"),
+    ("property_rule_item", "property_rule_item"),
+    ("product_property", "product_property"),
+    ("sales_channel_view_assign", "sales_channel_view_assign"),
+    ("all", "all"),
+]
+
+ACTION_CREATE = "CREATE"
+ACTION_UPDATE = "UPDATE"
+ACTION_DELETE = "DELETE"
+ACTION_CHOICES = [
+    (ACTION_CREATE, ACTION_CREATE),
+    (ACTION_UPDATE, ACTION_UPDATE),
+    (ACTION_DELETE, ACTION_DELETE),
+]
+
+VERSION_2025_08_01 = "2025-08-01"
+VERSION_CHOICES = [
+    (VERSION_2025_08_01, VERSION_2025_08_01),
+]
+
+DELIVERY_PENDING = "PENDING"
+DELIVERY_SENDING = "SENDING"
+DELIVERY_DELIVERED = "DELIVERED"
+DELIVERY_FAILED = "FAILED"
+DELIVERY_STATUS_CHOICES = [
+    (DELIVERY_PENDING, DELIVERY_PENDING),
+    (DELIVERY_SENDING, DELIVERY_SENDING),
+    (DELIVERY_DELIVERED, DELIVERY_DELIVERED),
+    (DELIVERY_FAILED, DELIVERY_FAILED),
+]
+
+RETENTION_3M = "3m"
+RETENTION_6M = "6m"
+RETENTION_12M = "12m"
+RETENTION_CHOICES = [
+    (RETENTION_3M, RETENTION_3M),
+    (RETENTION_6M, RETENTION_6M),
+    (RETENTION_12M, RETENTION_12M),
+]
+
+MODE_FULL = "full"
+MODE_DELTA = "delta"
+MODE_CHOICES = [
+    (MODE_FULL, MODE_FULL),
+    (MODE_DELTA, MODE_DELTA),
+]

--- a/OneSila/webhooks/models.py
+++ b/OneSila/webhooks/models.py
@@ -1,3 +1,147 @@
-from django.db import models
+import uuid
+import secrets
 
-# Create your models here.
+from django.conf import settings
+from django.db.models import Q
+
+from core import models
+from integrations.models import Integration
+
+from .constants import (
+    ACTION_CHOICES,
+    DELIVERY_DELIVERED,
+    DELIVERY_FAILED,
+    DELIVERY_PENDING,
+    DELIVERY_SENDING,
+    DELIVERY_STATUS_CHOICES,
+    MODE_CHOICES,
+    MODE_FULL,
+    RETENTION_6M,
+    RETENTION_CHOICES,
+    TOPIC_CHOICES,
+    VERSION_2025_08_01,
+    VERSION_CHOICES,
+)
+
+
+def generate_secret():
+    return secrets.token_hex(64)
+
+
+def default_timeout_ms():
+    return getattr(settings, "WEBHOOK_TIMEOUT_MS", 10000)
+
+
+class WebhookIntegration(Integration):
+    topic = models.CharField(max_length=32, choices=TOPIC_CHOICES)
+    version = models.CharField(
+        max_length=10, choices=VERSION_CHOICES, default=VERSION_2025_08_01
+    )
+    url = models.URLField()
+    secret = models.CharField(max_length=128, default=generate_secret)
+    user_agent = models.CharField(max_length=64, default="OneSila-Webhook/1.0")
+    timeout_ms = models.IntegerField(default=default_timeout_ms)
+    mode = models.CharField(max_length=5, choices=MODE_CHOICES, default=MODE_FULL)
+    extra_headers = models.JSONField(default=dict, blank=True)
+    config = models.JSONField(default=dict, blank=True)
+    retention_policy = models.CharField(
+        max_length=3, choices=RETENTION_CHOICES, default=RETENTION_6M
+    )
+
+    def clean(self):
+        models.Model.clean(self)
+
+    def regenerate_secret(self):
+        self.secret = generate_secret()
+        self.save(update_fields=["secret"])
+
+    class Meta:
+        indexes = [models.Index(fields=["topic"])]
+
+
+class WebhookOutbox(models.Model):
+    webhook_id = models.UUIDField(
+        default=uuid.uuid4, unique=True, db_index=True, editable=False
+    )
+    webhook_integration = models.ForeignKey(WebhookIntegration, on_delete=models.CASCADE)
+    topic = models.CharField(max_length=32, choices=TOPIC_CHOICES, db_index=True)
+    action = models.CharField(max_length=10, choices=ACTION_CHOICES, db_index=True)
+    subject_type = models.CharField(max_length=32, db_index=True)
+    subject_id = models.CharField(max_length=64, db_index=True)
+    sequence = models.BigIntegerField(null=True, blank=True)
+    payload = models.JSONField()
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["webhook_integration", "created_at"]),
+            models.Index(fields=["topic", "created_at"]),
+            models.Index(fields=["subject_type", "subject_id", "created_at"]),
+        ]
+
+
+class WebhookDelivery(models.Model):
+    PENDING = DELIVERY_PENDING
+    SENDING = DELIVERY_SENDING
+    DELIVERED = DELIVERY_DELIVERED
+    FAILED = DELIVERY_FAILED
+
+    webhook_id = models.UUIDField(
+        default=uuid.uuid4, unique=True, db_index=True, editable=False
+    )
+    outbox = models.ForeignKey(
+        WebhookOutbox, on_delete=models.CASCADE, related_name="deliveries"
+    )
+    webhook_integration = models.ForeignKey(
+        WebhookIntegration, on_delete=models.CASCADE, related_name="deliveries"
+    )
+    status = models.CharField(
+        max_length=10,
+        choices=DELIVERY_STATUS_CHOICES,
+        default=DELIVERY_PENDING,
+        db_index=True,
+    )
+    attempt = models.IntegerField(default=0, db_index=True)
+    response_code = models.IntegerField(null=True, blank=True, db_index=True)
+    response_ms = models.IntegerField(null=True, blank=True)
+    response_body_snippet = models.TextField(null=True, blank=True)
+    sent_at = models.DateTimeField(null=True, blank=True)
+    error_message = models.TextField(null=True, blank=True)
+    error_traceback = models.TextField(null=True, blank=True)
+
+    def save(self, *args, **kwargs):
+        if self.response_body_snippet and len(self.response_body_snippet) > 512:
+            self.response_body_snippet = self.response_body_snippet[:512]
+        super().save(*args, **kwargs)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["outbox"],
+                condition=Q(status=DELIVERY_DELIVERED),
+                name="webhook_delivery_unique_delivered_per_outbox",
+            )
+        ]
+
+
+class WebhookDeliveryAttempt(models.Model):
+    delivery = models.ForeignKey(
+        WebhookDelivery, on_delete=models.CASCADE, related_name="attempts"
+    )
+    number = models.IntegerField()
+    sent_at = models.DateTimeField()
+    response_code = models.IntegerField(null=True, blank=True)
+    response_ms = models.IntegerField(null=True, blank=True)
+    response_body_snippet = models.TextField(null=True, blank=True)
+    error_text = models.TextField(null=True, blank=True)
+    error_traceback = models.TextField(null=True, blank=True)
+
+    def save(self, *args, **kwargs):
+        if self.response_body_snippet and len(self.response_body_snippet) > 512:
+            self.response_body_snippet = self.response_body_snippet[:512]
+        super().save(*args, **kwargs)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["delivery", "number"]),
+            models.Index(fields=["delivery", "created_at"]),
+        ]


### PR DESCRIPTION
## Summary
- add webhook integration/outbox/delivery models
- register webhook models in admin with replay action
- centralize webhook constants
- use hostname as integration name and store webhook URL separately

## Testing
- `pre-commit run --files OneSila/webhooks/models.py OneSila/webhooks/admin.py`
- `python OneSila/manage.py test webhooks`


------
https://chatgpt.com/codex/tasks/task_e_68b04c255510832eb54842623df95206

## Summary by Sourcery

Implement a full webhook infrastructure by defining integration, event outbox, delivery, and attempt models, centralizing constants, and exposing these models in the Django admin with a replay action.

New Features:
- Add Django models for webhook integration, outbox, delivery, and delivery attempts
- Register webhook models in the admin with custom list displays, filters, and a replay action

Enhancements:
- Centralize webhook-related constants in a dedicated module
- Introduce secret generation, default timeout, and retention policy settings for webhook integrations