### PR TITLE
Add configurable webhook test receiver view

### DIFF
--- a/OneSila/OneSila/settings/local_template.py
+++ b/OneSila/OneSila/settings/local_template.py
@@ -113,3 +113,4 @@ SHOPIFY_TEST_REDIRECT_URI = "https://dcfa-79-118-110-129.ngrok-free.app/integrat
 AMAZON_CLIENT_ID = None
 AMAZON_CLIENT_SECRET = None
 AMAZON_APP_ID = None
+TEST_WEBHOOK_SECRET = "test-secret"

--- a/OneSila/OneSila/urls.py
+++ b/OneSila/OneSila/urls.py
@@ -20,6 +20,7 @@ from django.urls import include, path
 from strawberry.django.views import AsyncGraphQLView
 from .schema import schema
 from django.conf.urls.static import static
+from webhooks.views import test_receiver
 
 urlpatterns = [
     path('', include('core.urls')),
@@ -40,6 +41,7 @@ urlpatterns = [
     path('direct/integrations/shopify/', include('sales_channels.integrations.shopify.urls')),
     path('direct/integrations/amazon/', include('sales_channels.integrations.amazon.urls')),
     path('integrations/', include('integrations.urls')),
+    path('webhooks/test-receiver/', test_receiver),
     path('graphql/',
         AsyncGraphQLView.as_view(
             schema=schema,

--- a/OneSila/webhooks/views.py
+++ b/OneSila/webhooks/views.py
@@ -1,3 +1,94 @@
-from django.shortcuts import render
+import hashlib
+import hmac
+import logging
+import time
 
-# Create your views here.
+from django.conf import settings
+from django.http import HttpResponse, JsonResponse
+
+logger = logging.getLogger(__name__)
+
+
+def _get_param(request, name, default=None):
+    if name in request.GET:
+        return request.GET.get(name)
+    return request.headers.get(name, default)
+
+
+def _get_bool(value, default=False):
+    if value is None:
+        return default
+    return str(value).lower() in {"1", "true", "yes"}
+
+
+def test_receiver(request):
+    if getattr(settings, "DEBUGG", False):
+        return HttpResponse(status=200)
+
+    token = request.headers.get("X-Test-Token")
+    if token != getattr(settings, "TEST_WEBHOOK_SECRET", ""):
+        return HttpResponse(status=401)
+
+    raw_body = request.body
+    logger.info("webhook test receiver", extra={"headers": dict(request.headers), "body": raw_body})
+
+    mode = _get_param(request, "mode", "success")
+    delay_ms = _get_param(request, "delay_ms")
+    delay_ms = int(delay_ms) if delay_ms else 0
+    retry_after = _get_param(request, "retry_after")
+    retry_after = int(retry_after) if retry_after else 0
+    validate_signature = _get_bool(_get_param(request, "validate_signature", "true"), True)
+    secret = _get_param(request, "secret_override", getattr(settings, "TEST_WEBHOOK_SECRET", ""))
+    echo_headers = _get_bool(_get_param(request, "echo_headers"))
+    echo_body = _get_bool(_get_param(request, "echo_body"))
+
+    if mode == "fail_signature":
+        return HttpResponse(status=401)
+
+    if mode != "timeout" and delay_ms:
+        time.sleep(delay_ms / 1000)
+
+    if validate_signature:
+        signature_header = request.headers.get("X-OneSila-Signature", "")
+        parts = dict(part.split("=") for part in signature_header.split(",") if "=" in part)
+        timestamp = parts.get("t")
+        signature = parts.get("v1")
+        valid = False
+        try:
+            timestamp_int = int(timestamp)
+            payload = f"{timestamp}.".encode() + raw_body
+            expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+            skew = abs(time.time() - timestamp_int) <= 300
+            valid = hmac.compare_digest(expected, signature or "") and skew
+        except Exception:
+            valid = False
+        if not valid:
+            return HttpResponse(status=401)
+
+    data = {"mode": mode}
+
+    if echo_headers:
+        safe_headers = {k: v for k, v in request.headers.items() if k.lower() not in {"authorization", "x-test-token"}}
+        data["headers"] = safe_headers
+    if echo_body:
+        data["body"] = raw_body[:2048].decode("utf-8", errors="replace")
+
+    if mode == "client_error":
+        return JsonResponse(data, status=400)
+    if mode == "server_error":
+        return JsonResponse(data, status=500)
+    if mode == "rate_limit":
+        response = JsonResponse(data, status=429)
+        response["Retry-After"] = str(retry_after or 1)
+        return response
+    if mode == "timeout":
+        time.sleep((delay_ms or 10000) / 1000)
+        return JsonResponse(data, status=200)
+    if mode == "slow_ok":
+        return JsonResponse(data, status=200)
+    if mode == "redirect":
+        response = JsonResponse(data, status=302)
+        response["Location"] = "/"
+        return response
+
+    return JsonResponse(data, status=200)


### PR DESCRIPTION
## Summary
- add `/webhooks/test-receiver/` endpoint with token auth, signature validation, and controllable behaviors
- expose test webhook secret in local settings

## Testing
- `pre-commit run --files OneSila/webhooks/views.py OneSila/OneSila/urls.py OneSila/OneSila/settings/local_template.py`
- `python OneSila/manage.py test webhooks`


------
https://chatgpt.com/codex/tasks/task_e_68b053321480832eb0a7a8898ac5fa88

## Summary by Sourcery

Add a new configurable test webhook receiver endpoint for local development and testing that supports token authentication, signature validation, custom response modes, delays, retries, and optional echoing of headers and body.

New Features:
- Introduce /webhooks/test-receiver/ endpoint with token-based authentication
- Implement HMAC signature validation with timestamp skew checks
- Enable configurable response behaviors via query parameters (mode, delay_ms, retry_after, secret_override, echo_headers, echo_body)

Enhancements:
- Log incoming webhook payloads and headers for debugging