### PR TITLE
Validate webhook rate limit

### DIFF
--- a/OneSila/webhooks/models.py
+++ b/OneSila/webhooks/models.py
@@ -3,6 +3,7 @@ import secrets
 
 from django.conf import settings
 from django.db.models import Q
+from django.core.exceptions import ValidationError
 
 from core import models
 from integrations.models import Integration
@@ -50,6 +51,11 @@ class WebhookIntegration(Integration):
 
     def clean(self):
         models.Model.clean(self)
+
+    def save(self, *args, force_save=False, **kwargs):
+        if self.requests_per_minute > 120:
+            raise ValidationError({"requests_per_minute": "Ensure this value is less than or equal to 120."})
+        super().save(*args, force_save=force_save, **kwargs)
 
     def regenerate_secret(self):
         self.secret = generate_secret()

--- a/OneSila/webhooks/tests.py
+++ b/OneSila/webhooks/tests.py
@@ -1,3 +1,32 @@
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-# Create your tests here.
+from core.models import MultiTenantCompany
+from .models import WebhookIntegration
+
+
+class WebhookIntegrationModelTests(TestCase):
+    def setUp(self):
+        self.company = MultiTenantCompany.objects.create(name="TestCo")
+
+    def test_requests_per_minute_cannot_exceed_120(self):
+        integration = WebhookIntegration(
+            multi_tenant_company=self.company,
+            hostname="https://example.com",
+            topic="product",
+            url="https://webhook.example.com",
+            requests_per_minute=121,
+        )
+        with self.assertRaises(ValidationError):
+            integration.save(force_save=True)
+
+    def test_requests_per_minute_allows_120(self):
+        integration = WebhookIntegration(
+            multi_tenant_company=self.company,
+            hostname="https://example.com",
+            topic="product",
+            url="https://webhook.example.com",
+            requests_per_minute=120,
+        )
+        integration.save(force_save=True)
+        self.assertIsNotNone(integration.id)


### PR DESCRIPTION
## Summary
- enforce a maximum of 120 requests per minute on WebhookIntegration saves
- test that values above 120 raise a validation error

## Testing
- `pre-commit run --files OneSila/webhooks/models.py OneSila/webhooks/tests.py`
- `python OneSila/manage.py test webhooks` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b055869230832ea53d266d73aa2181