### PR TITLE
Add mutation to regenerate webhook secret

### DIFF
--- a/OneSila/webhooks/schema/mutations.py
+++ b/OneSila/webhooks/schema/mutations.py
@@ -29,3 +29,15 @@ class WebhooksMutation:
 
         print(f"Retrying webhook delivery {instance.id.node_id}")
         return WebhookDelivery.objects.get(id=instance.id.node_id)
+
+    @strawberry_django.mutation(
+        handle_django_errors=True, extensions=default_extensions
+    )
+    def regenerate_webhook_integration_secret(
+        self, instance: WebhookIntegrationPartialInput, info: Info
+    ) -> WebhookIntegrationType:
+        from webhooks.models import WebhookIntegration
+
+        integration = WebhookIntegration.objects.get(id=instance.id.node_id)
+        integration.regenerate_secret()
+        return integration

--- a/OneSila/webhooks/tests.py
+++ b/OneSila/webhooks/tests.py
@@ -1,8 +1,9 @@
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 
 from core.models import MultiTenantCompany
 from .models import WebhookIntegration
+from core.tests.tests_schemas.tests_queries import TransactionTestCaseMixin
 
 
 class WebhookIntegrationModelTests(TestCase):
@@ -30,3 +31,29 @@ class WebhookIntegrationModelTests(TestCase):
         )
         integration.save(force_save=True)
         self.assertIsNotNone(integration.id)
+
+
+class WebhookIntegrationMutationTests(TransactionTestCaseMixin, TransactionTestCase):
+    def test_regenerate_secret(self):
+        integration = WebhookIntegration.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            hostname="https://example.com",
+            topic="product",
+            url="https://webhook.example.com",
+        )
+        old_secret = integration.secret
+        mutation = """
+            mutation($id: GlobalID!){
+              regenerateWebhookIntegrationSecret(instance: {id: $id}){
+                secret
+              }
+            }
+        """
+        resp = self.strawberry_test_client(
+            query=mutation,
+            variables={"id": self.to_global_id(integration)},
+            asserts_errors=False,
+        )
+        self.assertTrue(resp.errors is None)
+        new_secret = resp.data["regenerateWebhookIntegrationSecret"]["secret"]
+        self.assertNotEqual(old_secret, new_secret)


### PR DESCRIPTION
## Summary
- add mutation to regenerate webhook integration secret
- cover webhook secret regeneration via GraphQL test

## Testing
- `python OneSila/manage.py test webhooks -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b05f47a8fc832e8dfd4404413eb5c9

## Summary by Sourcery

Introduce a GraphQL mutation to regenerate webhook integration secrets and add a TransactionTestCase-based test to ensure the mutation updates the secret correctly.

New Features:
- Add regenerateWebhookIntegrationSecret GraphQL mutation for WebhookIntegration

Tests:
- Add GraphQL integration test to verify webhook secret regeneration