### PR TITLE
Add WebhookIntegration support

### DIFF
--- a/OneSila/integrations/constants.py
+++ b/OneSila/integrations/constants.py
@@ -3,17 +3,20 @@ from sales_channels.integrations.magento2.models import MagentoSalesChannel
 from sales_channels.integrations.shopify.models import ShopifySalesChannel
 from sales_channels.integrations.woocommerce.models import WoocommerceSalesChannel
 from sales_channels.integrations.amazon.models import AmazonSalesChannel
+from webhooks.models import WebhookIntegration
 
 MAGENTO_INTEGRATION = 'magento'
 SHOPIFY_INTEGRATION = 'shopify'
 WOOCOMMERCE_INTEGRATION = 'woocommerce'
 AMAZON_INTEGRATION = 'amazon'
+WEBHOOK_INTEGRATION = 'webhook'
 
 INTEGRATIONS_TYPES = (
     (MAGENTO_INTEGRATION, _('Magento')),
     (SHOPIFY_INTEGRATION, _('Shopify')),
     (WOOCOMMERCE_INTEGRATION, _('WooCommerce')),
     (AMAZON_INTEGRATION, _('Amazon')),
+    (WEBHOOK_INTEGRATION, _('Webhook')),
 )
 
 INTEGRATIONS_TYPES_MAP = {
@@ -21,4 +24,5 @@ INTEGRATIONS_TYPES_MAP = {
     ShopifySalesChannel: SHOPIFY_INTEGRATION,
     WoocommerceSalesChannel: WOOCOMMERCE_INTEGRATION,
     AmazonSalesChannel: AMAZON_INTEGRATION,
+    WebhookIntegration: WEBHOOK_INTEGRATION,
 }

--- a/OneSila/integrations/schema/types/types.py
+++ b/OneSila/integrations/schema/types/types.py
@@ -19,6 +19,7 @@ class IntegrationType(relay.Node, GetQuerysetMultiTenantMixin):
         from sales_channels.integrations.shopify.models import ShopifySalesChannel
         from sales_channels.integrations.woocommerce.models import WoocommerceSalesChannel
         from sales_channels.integrations.amazon.models import AmazonSalesChannel
+        from webhooks.models import WebhookIntegration
 
         if isinstance(self, MagentoSalesChannel):
             return True
@@ -28,6 +29,8 @@ class IntegrationType(relay.Node, GetQuerysetMultiTenantMixin):
             return bool(self.api_key and self.api_secret)
         elif isinstance(self, AmazonSalesChannel):
             return self.access_token is not None
+        elif isinstance(self, WebhookIntegration):
+            return True
 
         raise NotImplementedError(f"Integration type {self.__class__} not implemented")
 
@@ -41,6 +44,8 @@ class IntegrationType(relay.Node, GetQuerysetMultiTenantMixin):
         from sales_channels.integrations.woocommerce.schema.types.types import WoocommerceSalesChannelType
         from sales_channels.integrations.amazon.models import AmazonSalesChannel
         from sales_channels.integrations.amazon.schema.types.types import AmazonSalesChannelType
+        from webhooks.models import WebhookIntegration
+        from webhooks.schema.types.types import WebhookIntegrationType
 
         if isinstance(self, MagentoSalesChannel):
             graphql_type = MagentoSalesChannelType
@@ -50,6 +55,8 @@ class IntegrationType(relay.Node, GetQuerysetMultiTenantMixin):
             graphql_type = WoocommerceSalesChannelType
         elif isinstance(self, AmazonSalesChannel):
             graphql_type = AmazonSalesChannelType
+        elif isinstance(self, WebhookIntegration):
+            graphql_type = WebhookIntegrationType
         else:
             raise NotImplementedError(f"Integration type {self.__class__} not implemented")
 


### PR DESCRIPTION
## Summary
- map WebhookIntegration to new `webhook` integration type
- expose WebhookIntegration as connected and proxyable in GraphQL

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b064a77654832ea9efdc4d150867f0