### PR TITLE
Add webhook report queries for KPI and series data

### DIFF
--- a/OneSila/webhooks/schema/queries.py
+++ b/OneSila/webhooks/schema/queries.py
@@ -1,4 +1,40 @@
-from core.schema.core.queries import node, connection, DjangoListConnection, type
+from core.schema.core.queries import (
+    node,
+    connection,
+    DjangoListConnection,
+    type,
+    field,
+    Info,
+)
+from statistics import quantiles, median
+from typing import List, Optional
+from collections import defaultdict
+from datetime import datetime
+from urllib.parse import urlparse
+from strawberry.relay import from_base64
+from django.db.models import Count, Avg, Q, Case, When, Value, CharField, F
+from django.db.models.functions import (
+    TruncHour,
+    TruncDay,
+    TruncWeek,
+    ExtractWeekDay,
+    ExtractHour,
+)
+
+from webhooks.models import WebhookDelivery, WebhookIntegration
+from .types.reports import (
+    WebhookReportsKPIType,
+    WebhookReportsSeriesType,
+    DeliveryOutcomeBucket,
+    LatencyBucket,
+    TopicBreakdown,
+    ResponseCodeBreakdown,
+    RetriesDistribution,
+    HeatmapEntry,
+    TopOffender,
+    QueuePressureEntry,
+)
+from .types.input import WebhookIntegrationPartialInput
 
 from .types.types import (
     WebhookIntegrationType,
@@ -6,6 +42,281 @@ from .types.types import (
     WebhookDeliveryType,
     WebhookDeliveryAttemptType,
 )
+
+
+def _decode_id(global_id: str) -> int:
+    _, pk = from_base64(global_id)
+    return pk
+
+
+def _apply_filters(
+    qs,
+    integration: WebhookIntegrationPartialInput,
+    time_from: datetime,
+    time_to: datetime,
+    topics: Optional[List[str]] = None,
+    actions: Optional[List[str]] = None,
+    statuses: Optional[List[str]] = None,
+):
+    qs = qs.filter(
+        webhook_integration_id=_decode_id(integration.id),
+        created_at__gte=time_from,
+        created_at__lte=time_to,
+    ).select_related("outbox")
+    if topics:
+        qs = qs.filter(outbox__topic__in=topics)
+    if actions:
+        qs = qs.filter(outbox__action__in=actions)
+    if statuses:
+        qs = qs.filter(status__in=statuses)
+    return qs
+
+
+def webhook_reports_kpi_resolver(
+    info: Info,
+    integration: WebhookIntegrationPartialInput,
+    time_from: datetime,
+    time_to: datetime,
+    topics: Optional[List[str]] = None,
+    actions: Optional[List[str]] = None,
+    statuses: Optional[List[str]] = None,
+) -> WebhookReportsKPIType:
+    qs = _apply_filters(
+        WebhookDelivery.objects.all(), integration, time_from, time_to, topics, actions, statuses
+    )
+
+    total = qs.count()
+    delivered = qs.filter(status=WebhookDelivery.DELIVERED).count()
+    failed = qs.filter(status=WebhookDelivery.FAILED).count()
+    success_rate = delivered / total * 100 if total else 0.0
+
+    latencies = list(
+        qs.filter(response_ms__isnull=False).values_list("response_ms", flat=True)
+    )
+    latencies.sort()
+    if latencies:
+        if len(latencies) == 1:
+            p50 = p95 = p99 = latencies[0]
+        else:
+            qs_percentiles = quantiles(latencies, n=100)
+            p50 = qs_percentiles[49]
+            p95 = qs_percentiles[94]
+            p99 = qs_percentiles[98]
+    else:
+        p50 = p95 = p99 = 0
+
+    rate_429 = qs.filter(response_code=429).count() / total * 100 if total else 0.0
+    rate_5xx = (
+        qs.filter(response_code__gte=500, response_code__lt=600).count() / total * 100
+        if total
+        else 0.0
+    )
+    avg_attempts = qs.aggregate(avg_attempts=Avg("attempt"))["avg_attempts"] or 0.0
+
+    return WebhookReportsKPIType(
+        total_deliveries=total,
+        delivered=delivered,
+        failed=failed,
+        success_rate=success_rate,
+        latency_p50=int(p50),
+        latency_p95=int(p95),
+        latency_p99=int(p99),
+        rate_429=rate_429,
+        rate_5xx=rate_5xx,
+        avg_attempts=avg_attempts,
+    )
+
+
+def webhook_reports_series_resolver(
+    info: Info,
+    integration: WebhookIntegrationPartialInput,
+    time_from: datetime,
+    time_to: datetime,
+    topics: Optional[List[str]] = None,
+    actions: Optional[List[str]] = None,
+    statuses: Optional[List[str]] = None,
+    bucket: str = "day",
+) -> WebhookReportsSeriesType:
+    qs = _apply_filters(
+        WebhookDelivery.objects.all(), integration, time_from, time_to, topics, actions, statuses
+    )
+
+    trunc_map = {
+        "hour": TruncHour,
+        "week": TruncWeek,
+        "day": TruncDay,
+    }
+    trunc = trunc_map.get(bucket, TruncDay)("created_at")
+
+    delivery_qs = (
+        qs.annotate(ts=trunc)
+        .values("ts")
+        .annotate(
+            delivered=Count("id", filter=Q(status=WebhookDelivery.DELIVERED)),
+            failed=Count("id", filter=Q(status=WebhookDelivery.FAILED)),
+            pending=Count("id", filter=Q(status=WebhookDelivery.PENDING)),
+            sending=Count("id", filter=Q(status=WebhookDelivery.SENDING)),
+        )
+        .order_by("ts")
+    )
+    delivery_outcome_buckets = [
+        DeliveryOutcomeBucket(
+            timestamp=entry["ts"],
+            delivered=entry["delivered"],
+            failed=entry["failed"],
+            pending=entry["pending"],
+            sending=entry["sending"],
+        )
+        for entry in delivery_qs
+    ]
+
+    latency_dict: dict = defaultdict(list)
+    for item in (
+        qs.filter(response_ms__isnull=False)
+        .annotate(ts=trunc)
+        .values("ts", "response_ms")
+        .order_by("ts")
+    ):
+        latency_dict[item["ts"]].append(item["response_ms"])
+
+    latency_buckets = []
+    for ts in sorted(latency_dict):
+        values = sorted(latency_dict[ts])
+        if len(values) == 1:
+            p50 = p95 = values[0]
+        else:
+            qs_percentiles = quantiles(values, n=100)
+            p50 = qs_percentiles[49]
+            p95 = qs_percentiles[94]
+        latency_buckets.append(LatencyBucket(timestamp=ts, p50=int(p50), p95=int(p95)))
+
+    topic_qs = (
+        qs.annotate(topic=F("outbox__topic"))
+        .values("topic")
+        .annotate(
+            deliveries=Count("id"),
+            delivered=Count("id", filter=Q(status=WebhookDelivery.DELIVERED)),
+            failed=Count("id", filter=Q(status=WebhookDelivery.FAILED)),
+        )
+        .order_by("-deliveries")
+    )
+    topics_breakdown = [
+        TopicBreakdown(
+            topic=entry["topic"],
+            deliveries=entry["deliveries"],
+            delivered=entry["delivered"],
+            failed=entry["failed"],
+            success_rate=(
+                entry["delivered"] / entry["deliveries"] * 100 if entry["deliveries"] else 0
+            ),
+        )
+        for entry in topic_qs
+    ]
+
+    code_qs = (
+        qs.annotate(
+            code_bucket=Case(
+                When(response_code=429, then=Value("429")),
+                When(response_code__gte=200, response_code__lt=300, then=Value("2xx")),
+                When(response_code__gte=400, response_code__lt=500, then=Value("4xx")),
+                When(response_code__gte=500, response_code__lt=600, then=Value("5xx")),
+                default=Value("timeout"),
+                output_field=CharField(),
+            )
+        )
+        .values("code_bucket")
+        .annotate(count=Count("id"))
+    )
+    response_codes_breakdown = [
+        ResponseCodeBreakdown(code_bucket=entry["code_bucket"], count=entry["count"])
+        for entry in code_qs
+    ]
+
+    retries_distribution = [
+        RetriesDistribution(attempts=entry["attempt"], count=entry["count"])
+        for entry in qs.values("attempt").annotate(count=Count("id")).order_by("attempt")
+    ]
+
+    heatmap_dict: dict = defaultdict(lambda: {"failures": 0, "latencies": []})
+    for d in qs.only("created_at", "status", "response_ms"):
+        weekday = d.created_at.isoweekday()
+        hour = d.created_at.hour
+        key = (weekday, hour)
+        if d.status == WebhookDelivery.FAILED:
+            heatmap_dict[key]["failures"] += 1
+        if d.response_ms is not None:
+            heatmap_dict[key]["latencies"].append(d.response_ms)
+
+    heatmap = []
+    for (weekday, hour), data in heatmap_dict.items():
+        med_latency = int(median(data["latencies"])) if data["latencies"] else 0
+        heatmap.append(
+            HeatmapEntry(
+                weekday=weekday,
+                hour=hour,
+                failures=data["failures"],
+                median_latency=med_latency,
+            )
+        )
+    heatmap.sort(key=lambda x: (x.weekday, x.hour))
+
+    top_qs = (
+        qs.values("webhook_integration_id")
+        .annotate(
+            deliveries=Count("id"),
+            failed=Count("id", filter=Q(status=WebhookDelivery.FAILED)),
+        )
+        .order_by("-failed")[:10]
+    )
+    top_offenders = []
+    for entry in top_qs:
+        integration_obj = WebhookIntegration.objects.get(pk=entry["webhook_integration_id"])
+        lat_values = list(
+            qs.filter(webhook_integration_id=integration_obj.pk, response_ms__isnull=False)
+            .values_list("response_ms", flat=True)
+        )
+        lat_values.sort()
+        if lat_values:
+            if len(lat_values) == 1:
+                p95 = lat_values[0]
+            else:
+                p95 = quantiles(lat_values, n=100)[94]
+        else:
+            p95 = 0
+        hostname = urlparse(integration_obj.url).hostname or ""
+        failure_rate = (
+            entry["failed"] / entry["deliveries"] * 100 if entry["deliveries"] else 0
+        )
+        top_offenders.append(
+            TopOffender(
+                integration_id=integration_obj.pk,
+                integration_hostname=hostname,
+                failure_rate=failure_rate,
+                latency_p95=int(p95),
+            )
+        )
+
+    queue_qs = (
+        qs.annotate(ts=trunc)
+        .values("ts")
+        .annotate(pending=Count("id", filter=Q(status=WebhookDelivery.PENDING)))
+        .order_by("ts")
+    )
+    queue_pressure = [
+        QueuePressureEntry(timestamp=entry["ts"], pending=entry["pending"])
+        for entry in queue_qs
+    ]
+
+    return WebhookReportsSeriesType(
+        delivery_outcome_buckets=delivery_outcome_buckets,
+        latency_buckets=latency_buckets,
+        topics_breakdown=topics_breakdown,
+        response_codes_breakdown=response_codes_breakdown,
+        retries_distribution=retries_distribution,
+        heatmap=heatmap,
+        top_offenders=top_offenders,
+        queue_pressure=queue_pressure,
+    )
 
 
 @type(name="Query")
@@ -21,3 +332,10 @@ class WebhooksQuery:
 
     webhook_delivery_attempt: WebhookDeliveryAttemptType = node()
     webhook_delivery_attempts: DjangoListConnection[WebhookDeliveryAttemptType] = connection()
+
+    webhook_reports_kpi: WebhookReportsKPIType = field(
+        resolver=webhook_reports_kpi_resolver
+    )
+    webhook_reports_series: WebhookReportsSeriesType = field(
+        resolver=webhook_reports_series_resolver
+    )

--- a/OneSila/webhooks/schema/types/reports.py
+++ b/OneSila/webhooks/schema/types/reports.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+from typing import List, Optional
+from core.schema.core.types.types import strawberry_type
+
+
+@strawberry_type
+class DeliveryOutcomeBucket:
+    timestamp: datetime
+    delivered: int
+    failed: int
+    pending: int
+    sending: int
+
+
+@strawberry_type
+class LatencyBucket:
+    timestamp: datetime
+    p50: int
+    p95: int
+
+
+@strawberry_type
+class TopicBreakdown:
+    topic: str
+    deliveries: int
+    delivered: int
+    failed: int
+    success_rate: float
+
+
+@strawberry_type
+class ResponseCodeBreakdown:
+    code_bucket: str
+    count: int
+
+
+@strawberry_type
+class RetriesDistribution:
+    attempts: int
+    count: int
+
+
+@strawberry_type
+class HeatmapEntry:
+    weekday: int
+    hour: int
+    failures: int
+    median_latency: int
+
+
+@strawberry_type
+class TopOffender:
+    integration_id: int
+    integration_hostname: str
+    failure_rate: float
+    latency_p95: int
+
+
+@strawberry_type
+class QueuePressureEntry:
+    timestamp: datetime
+    pending: int
+
+
+@strawberry_type
+class WebhookReportsSeriesType:
+    delivery_outcome_buckets: List[DeliveryOutcomeBucket]
+    latency_buckets: List[LatencyBucket]
+    topics_breakdown: List[TopicBreakdown]
+    response_codes_breakdown: List[ResponseCodeBreakdown]
+    retries_distribution: List[RetriesDistribution]
+    heatmap: List[HeatmapEntry]
+    top_offenders: List[TopOffender]
+    queue_pressure: Optional[List[QueuePressureEntry]] = None
+
+
+@strawberry_type
+class WebhookReportsKPIType:
+    total_deliveries: int
+    delivered: int
+    failed: int
+    success_rate: float
+    latency_p50: int
+    latency_p95: int
+    latency_p99: int
+    rate_429: float
+    rate_5xx: float
+    avg_attempts: float


### PR DESCRIPTION
## Summary
- add `webhook_reports_kpi` and `webhook_reports_series` queries with filters for integration, time range, topics, actions and statuses
- expose KPI metrics and time‑series breakdowns via new report types

## Testing
- `pre-commit run --files OneSila/webhooks/schema/types/reports.py OneSila/webhooks/schema/queries.py`
- `pytest OneSila/webhooks`


------
https://chatgpt.com/codex/tasks/task_e_68b08b61101c832ebdbed82b2f65d4f5

## Summary by Sourcery

Introduce new GraphQL report queries to expose webhook delivery KPIs and detailed time-series breakdowns with flexible filtering.

New Features:
- Add webhook_reports_kpi query to fetch aggregated delivery metrics including totals, success rates, latency percentiles, error rates, and average attempts
- Add webhook_reports_series query to produce time-bucketed breakdowns of delivery outcomes, latency trends, topic performance, response code distributions, retry distributions, heatmaps, top offenders, and queue pressure

Enhancements:
- Support filtering by integration, time range, topics, actions, and statuses for both report queries