### PR TITLE
Add webhook delivery replay utility and tests

### DIFF
--- a/OneSila/webhooks/factories/__init__.py
+++ b/OneSila/webhooks/factories/__init__.py
@@ -1,0 +1,1 @@
+from .replay_delivery import ReplayDelivery

--- a/OneSila/webhooks/factories/replay_delivery.py
+++ b/OneSila/webhooks/factories/replay_delivery.py
@@ -1,0 +1,36 @@
+from django.utils import timezone
+
+from integrations.tasks import add_task_to_queue
+
+from webhooks.models import WebhookDelivery
+
+
+class ReplayDelivery:
+    """Utility to replay a webhook delivery."""
+
+    def __init__(self, delivery: WebhookDelivery) -> None:
+        self.delivery = delivery
+
+    def _reset(self) -> None:
+        self.delivery.status = WebhookDelivery.PENDING
+        self.delivery.attempt += 1
+        self.delivery.save(update_fields=["status", "attempt"])
+
+    def _log_attempt(self) -> None:
+        self.delivery.attempts.create(
+            number=self.delivery.attempt,
+            sent_at=timezone.now(),
+            multi_tenant_company=self.delivery.multi_tenant_company,
+        )
+
+    def _enqueue(self) -> None:
+        add_task_to_queue(
+            integration_id=self.delivery.webhook_integration_id,
+            task_func_path="webhooks.tasks.process_delivery",
+            task_kwargs={"delivery_id": self.delivery.id},
+        )
+
+    def run(self) -> None:
+        self._reset()
+        self._log_attempt()
+        self._enqueue()

--- a/OneSila/webhooks/tests.py
+++ b/OneSila/webhooks/tests.py
@@ -1,8 +1,12 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase, TransactionTestCase
+from django.utils import timezone
+from unittest.mock import patch
 
 from core.models import MultiTenantCompany
-from .models import WebhookIntegration
+from .models import WebhookIntegration, WebhookOutbox, WebhookDelivery
+from .constants import ACTION_CREATE
+from .factories import ReplayDelivery
 from core.tests.tests_schemas.tests_queries import TransactionTestCaseMixin
 
 
@@ -57,3 +61,49 @@ class WebhookIntegrationMutationTests(TransactionTestCaseMixin, TransactionTestC
         self.assertTrue(resp.errors is None)
         new_secret = resp.data["regenerateWebhookIntegrationSecret"]["secret"]
         self.assertNotEqual(old_secret, new_secret)
+
+
+class ReplayWebhookDeliveryTests(TestCase):
+    def setUp(self):
+        self.company = MultiTenantCompany.objects.create(name="TestCo")
+        self.integration = WebhookIntegration.objects.create(
+            multi_tenant_company=self.company,
+            hostname="https://example.com",
+            topic="product",
+            url="https://webhook.example.com",
+        )
+        self.outbox = WebhookOutbox.objects.create(
+            multi_tenant_company=self.company,
+            webhook_integration=self.integration,
+            topic="product",
+            action=ACTION_CREATE,
+            subject_type="product",
+            subject_id="1",
+            payload={},
+        )
+
+    @patch("webhooks.factories.replay_delivery.add_task_to_queue")
+    def test_replay_creates_additional_attempt(self, mock_queue):
+        delivery = WebhookDelivery.objects.create(
+            multi_tenant_company=self.company,
+            outbox=self.outbox,
+            webhook_integration=self.integration,
+            status=WebhookDelivery.FAILED,
+            attempt=1,
+        )
+        delivery.attempts.create(
+            number=1,
+            sent_at=timezone.now(),
+            multi_tenant_company=self.company,
+        )
+
+        ReplayDelivery(delivery).run()
+
+        delivery.refresh_from_db()
+        self.assertEqual(delivery.status, WebhookDelivery.PENDING)
+        self.assertEqual(delivery.attempt, 2)
+        self.assertEqual(delivery.attempts.count(), 2)
+        last_attempt = delivery.attempts.order_by("number").last()
+        self.assertEqual(last_attempt.number, 2)
+        self.assertEqual(last_attempt.delivery_id, delivery.id)
+        mock_queue.assert_called_once()


### PR DESCRIPTION
## Summary
- add `replay_delivery` factory to reset status, increment attempts, and queue processing
- test that replaying a delivery records a new attempt and resets state
- refactor replay utility into a `ReplayDelivery` class

## Testing
- `python manage.py test webhooks -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b088d4abc8832e9f2ad46d1ce6992f

## Summary by Sourcery

New Features:
- Add ReplayDelivery utility class to reset status, increment attempts, log retries, and requeue failed webhook deliveries