### PR TITLE
Add webhook signal dispatchers

### DIFF
--- a/OneSila/webhooks/apps.py
+++ b/OneSila/webhooks/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class WebhooksConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'webhooks'
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/OneSila/webhooks/constants.py
+++ b/OneSila/webhooks/constants.py
@@ -1,3 +1,18 @@
+from products.models import Product
+from eancodes.models import EanCode
+from sales_prices.models import SalesPriceList, SalesPriceListItem
+from media.models import Media, MediaProductThrough
+from properties.models import (
+    Property,
+    PropertyTranslation,
+    PropertySelectValue,
+    PropertySelectValueTranslation,
+    ProductPropertiesRule,
+    ProductPropertiesRuleItem,
+    ProductProperty,
+)
+from sales_channels.models.sales_channels import SalesChannelViewAssign
+
 TOPIC_CHOICES = [
     ("product", "product"),
     ("ean_code", "ean_code"),
@@ -13,6 +28,23 @@ TOPIC_CHOICES = [
     ("sales_channel_view_assign", "sales_channel_view_assign"),
     ("all", "all"),
 ]
+
+TOPIC_MAP = {
+    Product: "product",
+    EanCode: "ean_code",
+    SalesPriceList: "price_list",
+    SalesPriceListItem: "price_list_item",
+    Media: "media",
+    MediaProductThrough: "media_through",
+    Property: "property",
+    PropertyTranslation: "property",
+    PropertySelectValue: "select_value",
+    PropertySelectValueTranslation: "select_value",
+    ProductPropertiesRule: "property_rule",
+    ProductPropertiesRuleItem: "property_rule_item",
+    ProductProperty: "product_property",
+    SalesChannelViewAssign: "sales_channel_view_assign",
+}
 
 ACTION_CREATE = "CREATE"
 ACTION_UPDATE = "UPDATE"

--- a/OneSila/webhooks/factories/send_integrations_webhooks.py
+++ b/OneSila/webhooks/factories/send_integrations_webhooks.py
@@ -1,0 +1,82 @@
+from django.db import transaction
+from django.db.models import Q
+from django.forms.models import model_to_dict
+
+from integrations.tasks import add_task_to_queue
+from webhooks.constants import ACTION_UPDATE, TOPIC_MAP
+from webhooks.models import WebhookIntegration, WebhookOutbox, WebhookDelivery
+
+
+class SendIntegrationsWebhooksFactory:
+    def __init__(self, *, instance, action):
+        self.instance = instance
+        self.action = action
+        self.multi_tenant_company = instance.multi_tenant_company
+
+    def set_topic(self):
+        self.topic = TOPIC_MAP.get(self.instance.__class__)
+
+    def set_dirty_fields(self):
+        if self.action == ACTION_UPDATE:
+            self.dirty_fields = self.instance.get_dirty_fields()
+        else:
+            self.dirty_fields = {}
+
+    def set_payload(self):
+        self.payload = model_to_dict(self.instance)
+
+    def set_subject(self):
+        self.subject_type = self.instance._meta.label_lower
+        self.subject_id = str(self.instance.pk)
+
+    def set_integrations(self):
+        self.integrations = WebhookIntegration.objects.filter(
+            active=True,
+            multi_tenant_company=self.multi_tenant_company,
+        ).filter(Q(topic=self.topic) | Q(topic="all"))
+
+    def create_outboxes(self):
+        for integration in self.integrations:
+            outbox = WebhookOutbox.objects.create(
+                webhook_integration=integration,
+                topic=self.topic,
+                action=self.action,
+                subject_type=self.subject_type,
+                subject_id=self.subject_id,
+                payload=self.payload,
+                multi_tenant_company=self.multi_tenant_company,
+            )
+
+            transaction.on_commit(
+                lambda lb_integration=integration, lb_outbox=outbox, lb_dirty_fields=self.dirty_fields: self._create_delivery_and_enqueue(
+                    lb_integration, lb_outbox, lb_dirty_fields
+                )
+            )
+
+    def _create_delivery_and_enqueue(self, integration, outbox, dirty_fields):
+        delivery = WebhookDelivery.objects.create(
+            outbox=outbox,
+            webhook_integration=integration,
+            status=WebhookDelivery.PENDING,
+            attempt=0,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        add_task_to_queue(
+            integration_id=integration.id,
+            task_func_path="webhooks.tasks.send_webhook_delivery",
+            task_kwargs={
+                "delivery_id": delivery.pk,
+                "outbox_id": outbox.pk,
+                "dirty_fields": dirty_fields,
+            },
+        )
+
+    def run(self):
+        self.set_topic()
+        if not self.topic:
+            return
+        self.set_dirty_fields()
+        self.set_payload()
+        self.set_subject()
+        self.set_integrations()
+        self.create_outboxes()

--- a/OneSila/webhooks/signals.py
+++ b/OneSila/webhooks/signals.py
@@ -1,0 +1,29 @@
+from django.db.models.signals import post_delete as django_post_delete
+
+from core.signals import post_create, post_update
+from webhooks.constants import (
+    ACTION_CREATE,
+    ACTION_UPDATE,
+    ACTION_DELETE,
+    TOPIC_MAP,
+)
+from webhooks.factories.send_integrations_webhooks import SendIntegrationsWebhooksFactory
+
+
+def _post_create(sender, instance, **kwargs):
+    SendIntegrationsWebhooksFactory(instance=instance, action=ACTION_CREATE).run()
+
+
+def _post_update(sender, instance, **kwargs):
+    SendIntegrationsWebhooksFactory(instance=instance, action=ACTION_UPDATE).run()
+
+
+def _post_delete(sender, instance, **kwargs):
+    SendIntegrationsWebhooksFactory(instance=instance, action=ACTION_DELETE).run()
+
+
+for model in TOPIC_MAP.keys():
+    post_create.connect(_post_create, sender=model)
+    post_update.connect(_post_update, sender=model)
+    django_post_delete.connect(_post_delete, sender=model)
+


### PR DESCRIPTION
## Summary
- refactor webhook signal handling into SendIntegrationsWebhooksFactory with run method to enqueue deliveries via send_webhook_delivery
- move SendIntegrationsWebhooksFactory into webhooks.factories module and import from signals

## Testing
- `python OneSila/manage.py test webhooks` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0888a8774832e95b204967fba0362

## Summary by Sourcery

Add webhook signal dispatchers to automatically enqueue webhook deliveries for model create, update, and delete events.

New Features:
- Define TOPIC_MAP in webhook constants to map Django model classes to webhook topic strings
- Introduce SendIntegrationsWebhooksFactory to generate outboxes and deliveries and enqueue webhook delivery tasks
- Connect post_create, post_update, and post_delete signals for mapped models to dispatch webhook events
- Load webhook signal registrations on application startup via WebhooksConfig.ready