### PR TITLE
Add periodic webhook delivery pruning

### DIFF
--- a/OneSila/webhooks/factories/__init__.py
+++ b/OneSila/webhooks/factories/__init__.py
@@ -1,1 +1,2 @@
 from .replay_delivery import ReplayDelivery
+from .prune_deliveries import WebhookPruneFactory

--- a/OneSila/webhooks/factories/prune_deliveries.py
+++ b/OneSila/webhooks/factories/prune_deliveries.py
@@ -1,0 +1,54 @@
+from datetime import timedelta
+
+from django.db.models import Count
+from django.utils import timezone
+
+from webhooks.constants import RETENTION_3M, RETENTION_6M, RETENTION_12M
+from webhooks.models import (
+    WebhookDelivery,
+    WebhookDeliveryAttempt,
+    WebhookIntegration,
+    WebhookOutbox,
+)
+
+
+class WebhookPruneFactory:
+    def __init__(self, integration: WebhookIntegration) -> None:
+        self.integration = integration
+
+    def _get_cutoff(self):
+        now = timezone.now()
+        policy = self.integration.retention_policy
+        if policy == RETENTION_3M:
+            delta = timedelta(days=90)
+        elif policy == RETENTION_6M:
+            delta = timedelta(days=180)
+        else:
+            delta = timedelta(days=365)
+        return now - delta
+
+    def run(self):
+        cutoff = self._get_cutoff()
+        deliveries_qs = WebhookDelivery.objects.filter(
+            webhook_integration=self.integration,
+            status=WebhookDelivery.DELIVERED,
+            sent_at__lt=cutoff,
+        )
+        delivery_ids = list(deliveries_qs.values_list("id", flat=True))
+        outbox_ids = list(deliveries_qs.values_list("outbox_id", flat=True))
+        deliveries_count = deliveries_qs.count()
+        attempts_count = WebhookDeliveryAttempt.objects.filter(
+            delivery_id__in=delivery_ids
+        ).count()
+        deliveries_qs.delete()
+        outboxes_deleted, _ = (
+            WebhookOutbox.objects.filter(id__in=outbox_ids)
+            .annotate(del_count=Count("deliveries"))
+            .filter(del_count=0)
+            .delete()
+        )
+        return {
+            "deliveries": deliveries_count,
+            "attempts": attempts_count,
+            "outboxes": outboxes_deleted,
+        }


### PR DESCRIPTION
## Summary
- add WebhookPruneFactory to purge delivered webhook deliveries past retention
- run daily task to prune old webhook deliveries per integration
- test factory pruning behavior and cascading deletions

## Testing
- `python manage.py test webhooks.tests.WebhookPruneFactoryTests -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b09c0def78832ea15544e104bd2e67

## Summary by Sourcery

Introduce retention-based pruning for delivered webhook deliveries with a daily scheduled task that runs per active integration and logs removal counts.

New Features:
- Add WebhookPruneFactory to remove delivered webhook deliveries, their attempts, and orphaned outboxes past the configured retention period
- Schedule a daily db_periodic_task to run pruning across all active webhook integrations

Enhancements:
- Log pruning results including integration ID and counts of deliveries, attempts, and outboxes removed

Tests:
- Add WebhookPruneFactoryTests to verify retention-based pruning and cascading deletions