### PR TITLE
Fix test receiver debug flag

### DIFF
--- a/OneSila/webhooks/views.py
+++ b/OneSila/webhooks/views.py
@@ -22,7 +22,7 @@ def _get_bool(value, default=False):
 
 
 def test_receiver(request):
-    if getattr(settings, "DEBUGG", False):
+    if getattr(settings, "DEBUG", False):
         return HttpResponse(status=200)
 
     token = request.headers.get("X-Test-Token")


### PR DESCRIPTION
## Summary
- use Django's DEBUG setting in webhook test receiver

## Testing
- `coverage run --source='.' OneSila/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a1b5b280832e8648d9a4e58b2df3