### PR TITLE
Add admin interface for webhook delivery attempts

### DIFF
--- a/OneSila/webhooks/admin.py
+++ b/OneSila/webhooks/admin.py
@@ -2,7 +2,12 @@ from django.contrib import admin
 
 from core.admin import ModelAdmin
 
-from .models import WebhookIntegration, WebhookOutbox, WebhookDelivery
+from .models import (
+    WebhookDelivery,
+    WebhookDeliveryAttempt,
+    WebhookIntegration,
+    WebhookOutbox,
+)
 
 
 @admin.register(WebhookIntegration)
@@ -39,6 +44,20 @@ def replay_deliveries(modeladmin, request, queryset):
     )
 
 
+class WebhookDeliveryAttemptInline(admin.TabularInline):
+    model = WebhookDeliveryAttempt
+    extra = 0
+    readonly_fields = [
+        "number",
+        "sent_at",
+        "response_code",
+        "response_ms",
+        "response_body_snippet",
+        "error_text",
+        "error_traceback",
+    ]
+
+
 @admin.register(WebhookDelivery)
 class WebhookDeliveryAdmin(ModelAdmin):
     list_display = [
@@ -51,3 +70,10 @@ class WebhookDeliveryAdmin(ModelAdmin):
     ]
     list_filter = ["status", "webhook_integration", "response_code"]
     actions = [replay_deliveries]
+    inlines = [WebhookDeliveryAttemptInline]
+
+
+@admin.register(WebhookDeliveryAttempt)
+class WebhookDeliveryAttemptAdmin(ModelAdmin):
+    list_display = ["delivery", "number", "sent_at", "response_code"]
+    list_filter = ["response_code"]


### PR DESCRIPTION
## Summary
- expose WebhookDeliveryAttempt in admin
- show delivery attempts inline on WebhookDelivery detail view

## Testing
- `python OneSila/manage.py test webhooks` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b15ebe3efc832eb9a29292ce51c3fd