### PR TITLE
Serialize webhook task payloads to handle datetimes

### DIFF
--- a/OneSila/webhooks/factories/send_integrations_webhooks.py
+++ b/OneSila/webhooks/factories/send_integrations_webhooks.py
@@ -1,5 +1,7 @@
 from django.db import transaction
 from django.db.models import Q
+import json
+from django.core.serializers.json import DjangoJSONEncoder
 
 from integrations.tasks import add_task_to_queue
 from webhooks.constants import ACTION_UPDATE, TOPIC_MAP
@@ -17,7 +19,9 @@ class SendIntegrationsWebhooksFactory:
 
     def set_dirty_fields(self):
         if self.action == ACTION_UPDATE:
-            self.dirty_fields = self.instance.get_dirty_fields()
+            self.dirty_fields = json.loads(
+                json.dumps(self.instance.get_dirty_fields(), cls=DjangoJSONEncoder)
+            )
         else:
             self.dirty_fields = {}
 

--- a/OneSila/webhooks/factories/send_webhook.py
+++ b/OneSila/webhooks/factories/send_webhook.py
@@ -8,6 +8,7 @@ from django.apps import apps
 from django.db import transaction
 from django.forms.models import model_to_dict
 from django.utils import timezone
+from django.core.serializers.json import DjangoJSONEncoder
 
 from webhooks.models import WebhookDelivery, WebhookDeliveryAttempt
 from webhooks.utils import signing
@@ -51,7 +52,9 @@ class SendWebhookDeliveryFactory:
             model = apps.get_model(self.outbox.subject_type)
             instance = model.objects.filter(id=self.outbox.subject_id).first()
             if instance is not None:
-                self.payload = model_to_dict(instance)
+                self.payload = json.loads(
+                    json.dumps(model_to_dict(instance), cls=DjangoJSONEncoder)
+                )
             else:
                 self.payload = {}
         except Exception:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- ensure task queue args/kwargs use DjangoJSONEncoder
- serialize dirty fields when enqueuing webhook deliveries
- JSON-encode model payloads for webhook delivery factory

## Testing
- `pre-commit run --files OneSila/integrations/factories/task_queue.py OneSila/webhooks/factories/send_integrations_webhooks.py OneSila/webhooks/factories/send_webhook.py`
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b15edd26d0832eb44ad7b00bde0759

## Summary by Sourcery

Serialize task queue arguments, webhook payloads, and dirty fields using DjangoJSONEncoder to ensure datetime objects can be JSON-encoded

Enhancements:
- Add a helper method to JSON-serialize task queue args and kwargs with DjangoJSONEncoder
- Apply JSON serialization to task_args and task_kwargs when creating IntegrationTaskQueue items
- JSON-encode dirty_fields in the send_integrations_webhooks factory
- JSON-serialize model_to_dict payloads in the send_webhook factory