### PR TITLE
Add custom webhook signals and sequence handling

### DIFF
--- a/OneSila/products/schema/mutations/fields.py
+++ b/OneSila/products/schema/mutations/fields.py
@@ -1,6 +1,7 @@
 from products.models import ProductTranslation
 from products.schema.mutations.mutation_classes import AliasProductCreateMutation
 from products.schema.types.input import ProductInput
+from products.signals import product_created
 
 
 def create_product():
@@ -10,5 +11,6 @@ def create_product():
         extensions=extensions,
         translation_model=ProductTranslation,
         translation_field='name',
-        translation_model_to_model_field='product'
+        translation_model_to_model_field='product',
+        signal=product_created,
     )

--- a/OneSila/products/signals.py
+++ b/OneSila/products/signals.py
@@ -1,0 +1,3 @@
+from django.db.models.signals import ModelSignal
+
+product_created = ModelSignal(use_caching=True)

--- a/OneSila/webhooks/signals.py
+++ b/OneSila/webhooks/signals.py
@@ -1,6 +1,18 @@
 from django.db.models.signals import post_delete as django_post_delete
-
 from core.signals import post_create, post_update
+from properties.signals import (
+    property_created,
+    property_select_value_created,
+    product_properties_rule_created,
+    product_properties_rule_updated,
+)
+from products.signals import product_created
+from properties.models import (
+    Property,
+    PropertySelectValue,
+    ProductPropertiesRule,
+)
+from products.models import Product
 from webhooks.constants import (
     ACTION_CREATE,
     ACTION_UPDATE,
@@ -22,8 +34,18 @@ def _post_delete(sender, instance, **kwargs):
     SendIntegrationsWebhooksFactory(instance=instance, action=ACTION_DELETE).run()
 
 
+EXCLUDED_CREATE_MODELS = {Property, PropertySelectValue, ProductPropertiesRule, Product}
+EXCLUDED_UPDATE_MODELS = {ProductPropertiesRule}
+
 for model in TOPIC_MAP.keys():
-    post_create.connect(_post_create, sender=model)
-    post_update.connect(_post_update, sender=model)
+    if model not in EXCLUDED_CREATE_MODELS:
+        post_create.connect(_post_create, sender=model)
+    if model not in EXCLUDED_UPDATE_MODELS:
+        post_update.connect(_post_update, sender=model)
     django_post_delete.connect(_post_delete, sender=model)
 
+property_created.connect(_post_create, sender=Property)
+property_select_value_created.connect(_post_create, sender=PropertySelectValue)
+product_properties_rule_created.connect(_post_create, sender=ProductPropertiesRule)
+product_properties_rule_updated.connect(_post_update, sender=ProductPropertiesRule)
+product_created.connect(_post_create, sender=Product)


### PR DESCRIPTION
## Summary
- add dedicated signal for product creation and wire into mutation
- handle webhook sequence numbers per integration and action
- persist outbox payloads reliably and connect custom signals to webhook sender
- refine webhook signal exclusions and remove redundant force save on payload

## Testing
- `pre-commit run --files OneSila/webhooks/factories/send_webhook.py OneSila/webhooks/signals.py`


------
https://chatgpt.com/codex/tasks/task_e_68b15ec951a8832eaffade2c1ceb5528

## Summary by Sourcery

Add custom webhook signals and improve webhook outbox handling

New Features:
- Define and register dedicated Django signals for property, property select value, product properties rule, and product creation/update events
- Introduce per-integration, per-topic, and per-action sequence numbering when creating webhook outbox entries
- Integrate the custom product_created signal into the product creation mutation

Enhancements:
- Refine default signal connections by excluding specific models from create/update hooks
- Persist webhook outbox payloads reliably and remove redundant force save operations