### PR TITLE
Prevent infinite create/sync loops

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/products.py
@@ -498,7 +498,8 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
                                           view=self.view,
                                           parent_local_instance=self.parent_local_instance,
                                           remote_parent_product=self.remote_parent_product,
-                                          force_validation_only=self.force_validation_only)
+                                          force_validation_only=self.force_validation_only,
+                                          is_switched=True)
         fac.run()
         self.remote_instance = fac.remote_instance
 
@@ -517,7 +518,8 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
             parent_local_instance=self.parent_local_instance,
             remote_parent_product=self.remote_parent_product,
             api=self.api,
-            view=self.view
+            view=self.view,
+            is_switched=True
         )
         sync_factory.run()
 

--- a/OneSila/sales_channels/integrations/shopify/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/shopify/factories/products/products.py
@@ -422,10 +422,16 @@ class ShopifyProductSyncFactory(GetShopifyApiMixin, RemoteProductSyncFactory):
 
         except SwitchedToCreateException as stc:
             logger.debug(stc)
+            if self.is_switched:
+                raise stc
+            self.is_switched = True
             self.run_create_flow()
 
         except SwitchedToSyncException as sts:
             logger.debug(sts)
+            if self.is_switched:
+                raise sts
+            self.is_switched = True
             self.run_sync_flow()
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- add `is_switched` flag to product factories
- guard against multiple create/sync switches and propagate switch state

## Testing
- `python -m py_compile OneSila/sales_channels/factories/products/products.py OneSila/sales_channels/integrations/amazon/factories/products/products.py OneSila/sales_channels/integrations/shopify/factories/products/products.py`
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b18b2dd940832eae6245812876b3d8

## Summary by Sourcery

Prevent infinite create/sync loops in product factories by introducing an is_switched flag and guarding against repeated switches, propagating this state to nested factory invocations.

Bug Fixes:
- Add is_switched flag to product sync/create factories to stop endless create/sync recursion.

Enhancements:
- Propagate the is_switched state to nested create and sync factory instances via constructor parameters.