### PR TITLE
Restrict fields in WebhookDeliveryAttempt inline

### DIFF
--- a/OneSila/webhooks/admin.py
+++ b/OneSila/webhooks/admin.py
@@ -47,7 +47,7 @@ def replay_deliveries(modeladmin, request, queryset):
 class WebhookDeliveryAttemptInline(admin.TabularInline):
     model = WebhookDeliveryAttempt
     extra = 0
-    readonly_fields = [
+    fields = readonly_fields = [
         "number",
         "sent_at",
         "response_code",


### PR DESCRIPTION
## Summary
- limit WebhookDeliveryAttempt inline to relevant fields

## Testing
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b72292dd8c832eb9584ee7acfb1698

## Summary by Sourcery

Enhancements:
- Limit WebhookDeliveryAttemptInline to display only the specified readonly fields in the Django admin.