### PR TITLE
Fix transaction rollback during PropertySelectValue merge

### DIFF
--- a/OneSila/properties/managers.py
+++ b/OneSila/properties/managers.py
@@ -275,7 +275,8 @@ class PropertySelectValueQuerySet(MultiTenantQuerySet):
                         for obj in qs:
                             setattr(obj, relation.field.name, target)
                             try:
-                                obj.save()
+                                with transaction.atomic():
+                                    obj.save()
                             except IntegrityError:
                                 obj.delete()
                     elif relation.many_to_many:
@@ -285,7 +286,8 @@ class PropertySelectValueQuerySet(MultiTenantQuerySet):
                         for through_obj in through.filter(**{source_field: source.pk}):
                             setattr(through_obj, source_field, target.pk)
                             try:
-                                through_obj.save()
+                                with transaction.atomic():
+                                    through_obj.save()
                             except IntegrityError:
                                 through_obj.delete()
                 source.delete(force_delete=True)


### PR DESCRIPTION
## Summary
- Roll back partial saves during PropertySelectValue merge using nested transactions

## Testing
- `python OneSila/manage.py test properties.tests.tests_models.PropertySelectValueMergeRemoteTestCase.test_merge_when_remote_select_value_exists -v 2` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*
- `apt-get install -y postgresql` *(fails: Unable to locate package postgresql)*

------
https://chatgpt.com/codex/tasks/task_e_68b822474728832eb0088a48db139571