### PR TITLE
Add webhook delivery stats query

### DIFF
--- a/OneSila/webhooks/schema/types/reports.py
+++ b/OneSila/webhooks/schema/types/reports.py
@@ -86,3 +86,15 @@ class WebhookReportsKPIType:
     rate_429: float
     rate_5xx: float
     avg_attempts: float
+
+
+@strawberry_type
+class WebhookDeliveryStatsType:
+    deliveries: int
+    delivered: int
+    failed: int
+    success_rate: float
+    median_latency: int
+    p95_latency: int
+    rate_429: float
+    queue_depth: int


### PR DESCRIPTION
## Summary
- add `WebhookDeliveryStatsType` for delivery metrics
- expose `webhookDeliveryStats` query to return delivery counts, latency, and rate metrics

## Testing
- `pre-commit run --files OneSila/webhooks/schema/types/reports.py OneSila/webhooks/schema/queries.py`
- `pytest OneSila/webhooks/tests.py --ds=OneSila.settings.base` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b8404df358832e9fa7bc96b45d4218

## Summary by Sourcery

Add a GraphQL query to fetch webhook delivery statistics including counts, latency metrics, and error rates

New Features:
- Define WebhookDeliveryStatsType to model delivery metrics
- Implement webhook_delivery_stats query resolver to compute total deliveries, delivered and failed counts, success rate, median and 95th percentile latencies, rate of 429 responses, and queue depth