### PR TITLE
Extend webhook KPI metrics

### DIFF
--- a/OneSila/webhooks/schema/types/reports.py
+++ b/OneSila/webhooks/schema/types/reports.py
@@ -83,6 +83,7 @@ class WebhookReportsKPIType:
     latency_p50: int
     latency_p95: int
     latency_p99: int
+    latency_avg: int
     rate_429: float
     rate_5xx: float
     avg_attempts: float
@@ -96,5 +97,9 @@ class WebhookDeliveryStatsType:
     success_rate: float
     median_latency: int
     p95_latency: int
+    p99_latency: int
     rate_429: float
+    rate_5xx: float
+    avg_attempts: float
+    avg_response_ms: int
     queue_depth: int


### PR DESCRIPTION
## Summary
- expose avg latency and extended rate metrics in webhook KPI report
- include p99 latency, 5xx rate, avg attempts and response time in delivery stats

## Testing
- `python manage.py test webhooks` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b84fe9925c832eb04883c0d13cedb6