### PR TITLE
Expose detailed webhook report KPIs

### DIFF
--- a/OneSila/webhooks/schema/queries.py
+++ b/OneSila/webhooks/schema/queries.py
@@ -122,17 +122,17 @@ def webhook_reports_kpi_resolver(
     )
 
     return WebhookReportsKPIType(
-        total_deliveries=total,
+        deliveries=total,
         delivered=delivered,
         failed=failed,
         success_rate=success_rate,
-        latency_p50=int(p50),
-        latency_p95=int(p95),
-        latency_p99=int(p99),
-        latency_avg=int(avg_latency),
+        p50_latency=int(p50),
+        p95_latency=int(p95),
+        p99_latency=int(p99),
         rate_429=rate_429,
         rate_5xx=rate_5xx,
         avg_attempts=avg_attempts,
+        avg_solve_ms=int(avg_latency),
     )
 
 

--- a/OneSila/webhooks/schema/types/reports.py
+++ b/OneSila/webhooks/schema/types/reports.py
@@ -76,17 +76,17 @@ class WebhookReportsSeriesType:
 
 @strawberry_type
 class WebhookReportsKPIType:
-    total_deliveries: int
+    deliveries: int
     delivered: int
     failed: int
     success_rate: float
-    latency_p50: int
-    latency_p95: int
-    latency_p99: int
-    latency_avg: int
+    p50_latency: int
+    p95_latency: int
+    p99_latency: int
     rate_429: float
     rate_5xx: float
     avg_attempts: float
+    avg_solve_ms: int
 
 
 @strawberry_type


### PR DESCRIPTION
## Summary
- Rename KPI fields to match GraphQL expectations
- Update webhook KPI resolver to return new metrics

## Testing
- `pre-commit run --files OneSila/webhooks/schema/types/reports.py OneSila/webhooks/schema/queries.py`
- `python manage.py test webhooks` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b853df6d98832ebb312d4208d0dcef