### PR TITLE
Add Amazon import broken record GraphQL query with custom filter

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/queries.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/queries.py
@@ -17,6 +17,7 @@ from sales_channels.integrations.amazon.schema.types.types import (
     AmazonExternalProductIdType,
     AmazonGtinExemptionType,
     AmazonVariationThemeType,
+    AmazonImportBrokenRecordType,
 )
 
 
@@ -72,3 +73,6 @@ class AmazonSalesChannelsQuery:
 
     amazon_variation_theme: AmazonVariationThemeType = node()
     amazon_variation_themes: DjangoListConnection[AmazonVariationThemeType] = connection()
+
+    amazon_import_broken_record: AmazonImportBrokenRecordType = node()
+    amazon_import_broken_records: DjangoListConnection[AmazonImportBrokenRecordType] = connection()

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -24,6 +24,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonExternalProductId,
     AmazonGtinExemption,
     AmazonVariationTheme,
+    AmazonImportBrokenRecord,
 )
 from properties.schema.types.filters import (
     PropertyFilter,
@@ -38,6 +39,7 @@ from sales_channels.schema.types.filters import (
     SalesChannelViewFilter,
     RemoteProductFilter,
 )
+from imports_exports.schema.types.filters import ImportFilter
 from sales_channels.integrations.amazon.models import AmazonSalesChannelView
 
 
@@ -228,3 +230,17 @@ class AmazonVariationThemeFilter(SearchFilterMixin):
     product: Optional[ProductFilter]
     view: Optional[SalesChannelViewFilter]
     theme: auto
+
+
+@filter(AmazonImportBrokenRecord)
+class AmazonImportBrokenRecordFilter(SearchFilterMixin):
+    id: auto
+    import_process: Optional[ImportFilter]
+
+    @custom_filter
+    def exclude_unknown_issues(
+        self, queryset, value: bool, prefix: str
+    ) -> tuple[QuerySet, Q]:
+        if value not in (None, UNSET, False):
+            queryset = queryset.exclude(record__code="UNKNOWN_ERROR")
+        return queryset, Q()

--- a/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/ordering.py
@@ -20,9 +20,11 @@ from sales_channels.integrations.amazon.models import (
     AmazonExternalProductId,
     AmazonGtinExemption,
     AmazonVariationTheme,
+    AmazonImportBrokenRecord,
 )
 from properties.schema.types.ordering import ProductPropertyOrder
 from products.schema.types.ordering import ProductOrder
+from imports_exports.schema.types.ordering import ImportOrder
 
 
 @order(AmazonSalesChannel)
@@ -125,3 +127,9 @@ class AmazonVariationThemeOrder:
     id: auto
     product: Optional[ProductOrder]
     view: Optional[AmazonSalesChannelViewOrder]
+
+
+@order(AmazonImportBrokenRecord)
+class AmazonImportBrokenRecordOrder:
+    id: auto
+    import_process: Optional[ImportOrder]

--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -28,6 +28,7 @@ from sales_channels.integrations.amazon.models import (
     AmazonExternalProductId,
     AmazonGtinExemption,
     AmazonVariationTheme,
+    AmazonImportBrokenRecord,
 )
 from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonSalesChannelFilter,
@@ -37,10 +38,17 @@ from sales_channels.integrations.amazon.schema.types.filters import (
     AmazonProductPropertyFilter,
     AmazonProductTypeFilter,
     AmazonProductTypeItemFilter,
-    AmazonSalesChannelImportFilter, AmazonDefaultUnitConfiguratorFilter,
-    AmazonRemoteLogFilter, AmazonSalesChannelViewFilter, AmazonProductIssueFilter,
-    AmazonBrowseNodeFilter, AmazonProductBrowseNodeFilter,
-    AmazonExternalProductIdFilter, AmazonGtinExemptionFilter, AmazonVariationThemeFilter,
+    AmazonSalesChannelImportFilter,
+    AmazonDefaultUnitConfiguratorFilter,
+    AmazonRemoteLogFilter,
+    AmazonSalesChannelViewFilter,
+    AmazonProductIssueFilter,
+    AmazonBrowseNodeFilter,
+    AmazonProductBrowseNodeFilter,
+    AmazonExternalProductIdFilter,
+    AmazonGtinExemptionFilter,
+    AmazonVariationThemeFilter,
+    AmazonImportBrokenRecordFilter,
 )
 from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonSalesChannelOrder,
@@ -52,9 +60,15 @@ from sales_channels.integrations.amazon.schema.types.ordering import (
     AmazonProductTypeItemOrder,
     AmazonSalesChannelImportOrder,
     AmazonDefaultUnitConfiguratorOrder,
-    AmazonRemoteLogOrder, AmazonSalesChannelViewOrder, AmazonProductIssueOrder,
-    AmazonBrowseNodeOrder, AmazonProductBrowseNodeOrder,
-    AmazonExternalProductIdOrder, AmazonGtinExemptionOrder, AmazonVariationThemeOrder,
+    AmazonRemoteLogOrder,
+    AmazonSalesChannelViewOrder,
+    AmazonProductIssueOrder,
+    AmazonBrowseNodeOrder,
+    AmazonProductBrowseNodeOrder,
+    AmazonExternalProductIdOrder,
+    AmazonGtinExemptionOrder,
+    AmazonVariationThemeOrder,
+    AmazonImportBrokenRecordOrder,
 )
 from sales_channels.schema.types.types import FormattedIssueType
 
@@ -444,6 +458,20 @@ class AmazonVariationThemeType(relay.Node, GetQuerysetMultiTenantMixin):
     view: Annotated[
         'AmazonSalesChannelViewType',
         lazy("sales_channels.integrations.amazon.schema.types.types")
+    ]
+
+
+@type(
+    AmazonImportBrokenRecord,
+    filters=AmazonImportBrokenRecordFilter,
+    order=AmazonImportBrokenRecordOrder,
+    pagination=True,
+    fields="__all__",
+)
+class AmazonImportBrokenRecordType(relay.Node, GetQuerysetMultiTenantMixin):
+    import_process: Annotated[
+        'ImportType',
+        lazy("imports_exports.schema.queries")
     ]
 
 


### PR DESCRIPTION
## Summary
- add GraphQL type, filter, and order for AmazonImportBrokenRecord
- expose Amazon import broken record queries
- allow excluding UNKNOWN_ERROR issues via exclude_unknown_issues filter

## Testing
- `pytest OneSila/sales_channels/integrations/amazon/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8bd56e5e4832ea457b0038fbf46f3

## Summary by Sourcery

Add GraphQL support for querying Amazon import broken records with filtering, ordering, and pagination

New Features:
- Add AmazonImportBrokenRecordFilter with id and import_process filters and a custom exclude_unknown_issues flag
- Introduce AmazonImportBrokenRecordType GraphQL node with full fields, pagination, filtering, and ordering
- Create AmazonImportBrokenRecordOrder to enable sorting by id and import_process
- Expose amazon_import_broken_record and amazon_import_broken_records root queries