### PR TITLE
Expose SalesChannelImport ID in Amazon import GraphQL type

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -198,6 +198,11 @@ class AmazonSalesChannelImportType(relay.Node, GetQuerysetMultiTenantMixin):
     def import_id(self, info) -> str:
         return to_base64(ImportType, self.pk)
 
+    @field()
+    def proxy_id(self, info) -> str:
+        from sales_channels.schema.types.types import SalesChannelImportType
+
+        return to_base64(SalesChannelImportType, self.pk)
 
 @type(
     AmazonProductTypeItem,


### PR DESCRIPTION
## Summary
- add `proxy_id` field to `AmazonSalesChannelImportType` returning global ID of `SalesChannelImport`

## Testing
- `python manage.py test sales_channels.integrations.amazon -v 2` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*
- `python -m py_compile sales_channels/integrations/amazon/schema/types/types.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8c82f8b08832e9821d00c9c760000