### PR TITLE
Add code filter for Amazon broken records

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -238,6 +238,12 @@ class AmazonImportBrokenRecordFilter(SearchFilterMixin):
     import_process: Optional[ImportFilter]
 
     @custom_filter
+    def code(self, queryset, value: str, prefix: str) -> tuple[QuerySet, Q]:
+        if value not in (None, UNSET):
+            queryset = queryset.filter(record__code=value)
+        return queryset, Q()
+
+    @custom_filter
     def exclude_unknown_issues(
         self, queryset, value: bool, prefix: str
     ) -> tuple[QuerySet, Q]:


### PR DESCRIPTION
## Summary
- add custom filter `code` to query Amazon broken records by error code

## Testing
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c8e51190832e98ac67c35a2483f8

## Summary by Sourcery

New Features:
- Add 'code' custom filter to AmazonImportBrokenRecordFilter for filtering by error code