### PR TITLE
feat: expose code and message on broken Amazon import records

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/types.py
@@ -204,6 +204,7 @@ class AmazonSalesChannelImportType(relay.Node, GetQuerysetMultiTenantMixin):
 
         return to_base64(SalesChannelImportType, self.pk)
 
+
 @type(
     AmazonProductTypeItem,
     filters=AmazonProductTypeItemFilter,
@@ -478,6 +479,14 @@ class AmazonImportBrokenRecordType(relay.Node, GetQuerysetMultiTenantMixin):
         'ImportType',
         lazy("imports_exports.schema.queries")
     ]
+
+    @field()
+    def code(self, info) -> str | None:
+        return self.record.get('code')
+
+    @field()
+    def message(self, info) -> str | None:
+        return self.record.get('message')
 
 
 @strawberry_type


### PR DESCRIPTION
## Summary
- add code and message fields to AmazonImportBrokenRecordType

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/schema/types/types.py`
- `DJANGO_SETTINGS_MODULE=OneSila.settings pytest` *(fails: django.db.utils.OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d0eeb390832ebeb7b81650221896