### PR TITLE
Index language field in TranslationFieldsMixin

### DIFF
--- a/OneSila/translations/models.py
+++ b/OneSila/translations/models.py
@@ -13,7 +13,7 @@ class TranslationFieldsMixin(models.Model):
     """
     LANGUAGES = get_languages()
 
-    language = models.CharField(max_length=7, choices=LANGUAGES, default=settings.LANGUAGE_CODE)
+    language = models.CharField(max_length=7, choices=LANGUAGES, default=settings.LANGUAGE_CODE, db_index=True)
 
     class Meta:
         abstract = True


### PR DESCRIPTION
## Summary
- add database index to TranslationFieldsMixin.language

## Testing
- `pre-commit run --files OneSila/translations/models.py` *(fails: autopep8 modified files)*
- `python OneSila/manage.py test translations` *(fails: connection to PostgreSQL at localhost:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a8ed5410832e97bcb007fdc48aec