### PR TITLE
Use sales channel translations for product name

### DIFF
--- a/OneSila/sales_channels/factories/products/products.py
+++ b/OneSila/sales_channels/factories/products/products.py
@@ -324,7 +324,8 @@ class RemoteProductSyncFactory(IntegrationInstanceOperationMixin, EanCodeValueMi
         Sets the name for the product or variation in the payload.
         For variations, it delegates to set_variation_name.
         """
-        self.name = self.local_instance.name
+        self.name = self.local_instance._get_translated_value(
+            field_name='name', related_name='translations', sales_channel=self.sales_channel)
 
         if self.is_variation:
             self.set_variation_name()
@@ -337,7 +338,8 @@ class RemoteProductSyncFactory(IntegrationInstanceOperationMixin, EanCodeValueMi
         This method can be overridden for custom naming logic for variations.
         """
         if self.is_variation and self.sales_channel.use_configurable_name:
-            self.name = self.parent_local_instance.name
+            self.name = self.parent_local_instance._get_translated_value(
+                field_name='name', related_name='translations', sales_channel=self.sales_channel)
 
     def set_sku(self):
         """Sets the SKU for the product or variation in the payload."""


### PR DESCRIPTION
## Summary
- Use sales-channel specific translations for product names
- Use parent product's translated name for variations when configured

## Testing
- `pre-commit run --files OneSila/sales_channels/factories/products/products.py`
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b258ad1c832eb75da83a2db53cac

## Summary by Sourcery

Use sales-channel translations for product and variation names in payloads

Enhancements:
- Retrieve product name via _get_translated_value based on sales channel
- Retrieve parent product’s translated name for variations when use_configurable_name is enabled