### PR TITLE
Add query annotation tests for product and property querysets

### DIFF
--- a/OneSila/products/tests/tests_querysets.py
+++ b/OneSila/products/tests/tests_querysets.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+
+from core.tests import TestCase
+from core.schema.core.mixins import GetProductQuerysetMultiTenantMixin
+from products.models import SimpleProduct, ProductTranslation, Product
+
+
+class GetProductQuerysetMultiTenantMixinTest(TestCase):
+    def test_translated_name_access_single_query(self):
+        products = []
+        for i in range(2):
+            product = SimpleProduct.objects.create(multi_tenant_company=self.multi_tenant_company)
+            ProductTranslation.objects.create(
+                product=product,
+                language=self.multi_tenant_company.language,
+                name=f"Product {i}",
+                multi_tenant_company=self.multi_tenant_company,
+            )
+            products.append(product)
+
+        info = SimpleNamespace(context=SimpleNamespace(request=SimpleNamespace(user=self.user)))
+        qs = GetProductQuerysetMultiTenantMixin.get_queryset(Product.objects.all(), info)
+
+        with self.assertNumQueries(1):
+            names = [p.name for p in qs]
+
+        self.assertEqual(set(names), {"Product 0", "Product 1"})
+
+    def test_plain_all_translated_name_multiple_queries(self):
+        products = []
+        for i in range(2):
+            product = SimpleProduct.objects.create(multi_tenant_company=self.multi_tenant_company)
+            ProductTranslation.objects.create(
+                product=product,
+                language=self.multi_tenant_company.language,
+                name=f"Product {i}",
+                multi_tenant_company=self.multi_tenant_company,
+            )
+            products.append(product)
+
+        qs = Product.objects.all()
+
+        with self.assertNumQueries(1 + len(products)):
+            names = [p.name for p in qs]
+
+        self.assertEqual(set(names), {"Product 0", "Product 1"})

--- a/OneSila/properties/tests/tests_querysets.py
+++ b/OneSila/properties/tests/tests_querysets.py
@@ -1,0 +1,127 @@
+from core.tests import TestCase
+from properties.models import (
+    Property,
+    PropertyTranslation,
+    PropertySelectValue,
+    PropertySelectValueTranslation,
+)
+
+
+class PropertyQuerySetTest(TestCase):
+    def test_with_translated_name_single_query(self):
+        props = []
+        for i in range(2):
+            prop = Property.objects.create(
+                type=Property.TYPES.TEXT,
+                multi_tenant_company=self.multi_tenant_company,
+            )
+            PropertyTranslation.objects.create(
+                property=prop,
+                language=self.multi_tenant_company.language,
+                name=f"Prop {i}",
+                multi_tenant_company=self.multi_tenant_company,
+            )
+            props.append(prop)
+
+        qs = Property.objects.filter(
+            multi_tenant_company=self.multi_tenant_company
+        ).with_translated_name(language_code=self.multi_tenant_company.language)
+
+        with self.assertNumQueries(1):
+            names = [p.name for p in qs]
+
+        self.assertEqual(set(names), {"Prop 0", "Prop 1"})
+
+    def test_all_translated_name_multiple_queries(self):
+        props = []
+        for i in range(2):
+            prop = Property.objects.create(
+                type=Property.TYPES.TEXT,
+                multi_tenant_company=self.multi_tenant_company,
+            )
+            PropertyTranslation.objects.create(
+                property=prop,
+                language=self.multi_tenant_company.language,
+                name=f"Prop {i}",
+                multi_tenant_company=self.multi_tenant_company,
+            )
+            props.append(prop)
+
+        qs = Property.objects.filter(
+            multi_tenant_company=self.multi_tenant_company
+        ).all()
+
+        with self.assertNumQueries(1 + len(props)):
+            names = [p.name for p in qs]
+
+        self.assertEqual(set(names), {"Prop 0", "Prop 1"})
+
+
+class PropertySelectValueQuerySetTest(TestCase):
+    def test_with_translated_value_single_query(self):
+        prop = Property.objects.create(
+            type=Property.TYPES.SELECT,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertyTranslation.objects.create(
+            property=prop,
+            language=self.multi_tenant_company.language,
+            name="PT",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        values = []
+        for i in range(2):
+            val = PropertySelectValue.objects.create(
+                property=prop,
+                multi_tenant_company=self.multi_tenant_company,
+            )
+            PropertySelectValueTranslation.objects.create(
+                propertyselectvalue=val,
+                language=self.multi_tenant_company.language,
+                value=f"Val {i}",
+                multi_tenant_company=self.multi_tenant_company,
+            )
+            values.append(val)
+
+        qs = PropertySelectValue.objects.filter(
+            property=prop
+        ).with_translated_value(language_code=self.multi_tenant_company.language)
+
+        with self.assertNumQueries(1):
+            vals = [v.value for v in qs]
+
+        self.assertEqual(set(vals), {"Val 0", "Val 1"})
+
+    def test_all_translated_value_multiple_queries(self):
+        prop = Property.objects.create(
+            type=Property.TYPES.SELECT,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        PropertyTranslation.objects.create(
+            property=prop,
+            language=self.multi_tenant_company.language,
+            name="PT",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+        values = []
+        for i in range(2):
+            val = PropertySelectValue.objects.create(
+                property=prop,
+                multi_tenant_company=self.multi_tenant_company,
+            )
+            PropertySelectValueTranslation.objects.create(
+                propertyselectvalue=val,
+                language=self.multi_tenant_company.language,
+                value=f"Val {i}",
+                multi_tenant_company=self.multi_tenant_company,
+            )
+            values.append(val)
+
+        qs = PropertySelectValue.objects.filter(property=prop).all()
+
+        with self.assertNumQueries(1 + len(values)):
+            vals = [v.value for v in qs]
+
+        self.assertEqual(set(vals), {"Val 0", "Val 1"})


### PR DESCRIPTION
## Summary
- add tests confirming product queryset mixin fetches translated names without extra queries
- add tests ensuring property and select-value querysets fetch translations in a single query
- include baseline `.all()` tests demonstrating extra queries without translation helpers

## Testing
- `python OneSila/manage.py test products.tests.tests_querysets properties.tests.tests_querysets` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c484339c832eb6849c2cbfa6e179

## Summary by Sourcery

Add test suites to verify that product, property, and select-value querysets fetch multilingual translations efficiently by performing a single query when using translation helpers and demonstrating baseline multiple queries when using plain .all().

Tests:
- Add tests confirming GetProductQuerysetMultiTenantMixin loads translated product names in a single query and baseline all() triggers per-object queries
- Add tests confirming PropertyQuerySet.with_translated_name loads translated property names in a single query and baseline all() triggers per-object queries
- Add tests confirming PropertySelectValueQuerySet.with_translated_value loads translated select-value translations in a single query and baseline all() triggers per-object queries