### PR TITLE
Limit webhook timeout to 10 seconds

### DIFF
--- a/OneSila/webhooks/models.py
+++ b/OneSila/webhooks/models.py
@@ -4,6 +4,7 @@ import secrets
 from django.conf import settings
 from django.db.models import Q
 from django.core.exceptions import ValidationError
+from django.core.validators import MaxValueValidator
 
 from core import models
 from integrations.models import Integration
@@ -41,7 +42,9 @@ class WebhookIntegration(Integration):
     url = models.URLField()
     secret = models.CharField(max_length=128, default=generate_secret)
     user_agent = models.CharField(max_length=64, default="OneSila-Webhook/1.0")
-    timeout_ms = models.IntegerField(default=default_timeout_ms)
+    timeout_ms = models.IntegerField(
+        default=default_timeout_ms, validators=[MaxValueValidator(10000)]
+    )
     mode = models.CharField(max_length=5, choices=MODE_CHOICES, default=MODE_FULL)
     extra_headers = models.JSONField(default=dict, blank=True)
     config = models.JSONField(default=dict, blank=True)

--- a/OneSila/webhooks/tests.py
+++ b/OneSila/webhooks/tests.py
@@ -32,6 +32,28 @@ class WebhookIntegrationModelTests(TestCase):
         integration.save(force_save=True)
         self.assertIsNotNone(integration.id)
 
+    def test_timeout_ms_cannot_exceed_10000(self):
+        integration = WebhookIntegration(
+            multi_tenant_company=self.company,
+            hostname="https://example.com",
+            topic="product",
+            url="https://webhook.example.com",
+            timeout_ms=10001,
+        )
+        with self.assertRaises(ValidationError):
+            integration.full_clean()
+
+    def test_timeout_ms_allows_10000(self):
+        integration = WebhookIntegration(
+            multi_tenant_company=self.company,
+            hostname="https://example.com",
+            topic="product",
+            url="https://webhook.example.com",
+            timeout_ms=10000,
+        )
+        integration.full_clean()
+        integration.save(force_save=True)
+
 
 class WebhookIntegrationMutationTests(TransactionTestCaseMixin, TransactionTestCase):
     def test_regenerate_secret(self):


### PR DESCRIPTION
## Summary
- Restrict webhook timeout to 10,000ms using a MaxValueValidator
- Add tests ensuring timeout_ms respects the 10-second limit

## Testing
- `python manage.py test webhooks` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d6fa763c832e985b6e14dbe65d70

## Summary by Sourcery

Restrict webhook timeout to a 10-second maximum at the model level and add tests to verify the constraint

Enhancements:
- Enforce a maximum 10-second timeout on WebhookIntegration.timeout_ms using MaxValueValidator

Tests:
- Add test to ensure timeout_ms cannot exceed 10000ms
- Add test to confirm timeout_ms of 10000ms is valid and saves successfully