### PR TITLE
Prioritize default marketplace language in Amazon issue locale

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -326,9 +326,14 @@ class GetAmazonAPIMixin:
         from sales_channels.integrations.amazon.models import AmazonRemoteLanguage
 
         lang = self.sales_channel.multi_tenant_company.language
-        remote_lang = AmazonRemoteLanguage.objects.filter(
-            local_instance=lang, sales_channel_view__sales_channel=self.sales_channel
-        ).first()
+        remote_lang = (
+            AmazonRemoteLanguage.objects.filter(
+                local_instance=lang,
+                sales_channel_view__sales_channel=self.sales_channel,
+            )
+            .order_by("-sales_channel_view__is_default")
+            .first()
+        )
         return remote_lang.remote_code if remote_lang else None
 
     def _build_common_body(self, product_type, attributes):


### PR DESCRIPTION
## Summary
- prioritize Amazon remote language tied to default marketplace when determining issue locale

## Testing
- `python manage.py test sales_channels.integrations.amazon -v 2` *(failed: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68be9bd8f760832eada4c8ec79c01803

## Summary by Sourcery

Enhancements:
- Add ordering on sales_channel_view__is_default to prefer default marketplace remote language in _get_issue_locale