### PR TITLE
Avoid fallback mapping for remote languages

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_language_pull_factory.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_language_pull_factory.py
@@ -1,0 +1,32 @@
+from core.tests import TestCase
+from sales_channels.integrations.amazon.factories.sales_channels.languages import AmazonRemoteLanguagePullFactory
+from sales_channels.integrations.amazon.models import (
+    AmazonSalesChannel,
+    AmazonSalesChannelView,
+    AmazonRemoteLanguage,
+)
+
+
+class AmazonRemoteLanguagePullFactoryTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.channel = AmazonSalesChannel.objects.create(
+            hostname="https://example.com",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            sales_channel=self.channel,
+            remote_id="VIEW1",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def test_no_default_local_language_mapping(self):
+        factory = AmazonRemoteLanguagePullFactory(sales_channel=self.channel)
+        factory.remote_instances = [{"code": "fr", "view_remote_id": "VIEW1"}]
+        factory.process_remote_instances()
+
+        remote_language = AmazonRemoteLanguage.objects.get(
+            sales_channel=self.channel,
+            remote_code="fr",
+        )
+        self.assertIsNone(remote_language.local_instance)

--- a/OneSila/sales_channels/models/sales_channels.py
+++ b/OneSila/sales_channels/models/sales_channels.py
@@ -2,7 +2,6 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 from core import models
 from polymorphic.models import PolymorphicModel
-from django.conf import settings
 from core.helpers import get_languages
 from integrations.models import Integration
 from sales_channels.models.mixins import RemoteObjectMixin
@@ -266,7 +265,8 @@ class RemoteLanguage(PolymorphicModel, RemoteObjectMixin, models.Model):
     local_instance = models.CharField(
         max_length=7,
         choices=LANGUAGE_CHOICES,
-        default=settings.LANGUAGE_CODE,
+        null=True,
+        blank=True,
         help_text="The local language code associated with this remote language."
     )
     remote_code = models.CharField(max_length=64, help_text="The language code in the remote system.")


### PR DESCRIPTION
## Summary
- Allow remote languages to remain unmapped by default
- Add regression test ensuring Amazon language pull leaves unmapped languages without fallback

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_language_pull_factory -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0b70df2c832eac6e9ecfe3f24554

## Summary by Sourcery

Remove default fallback local language mapping for remote languages and add a regression test for Amazon integration to ensure unmapped languages remain null.

Enhancements:
- Allow RemoteLanguage.local_instance to be null by removing the default language code and enabling null/blank values

Tests:
- Add a test in AmazonRemoteLanguagePullFactoryTest to verify that remote languages without explicit mappings have no default local_instance