### PR TITLE
feat: run property select value merge via task

### DIFF
--- a/OneSila/properties/factories/merge_property_select_value.py
+++ b/OneSila/properties/factories/merge_property_select_value.py
@@ -1,0 +1,19 @@
+from properties.models import PropertySelectValue
+
+
+class MergePropertySelectValueFactory:
+    def __init__(self, *, multi_tenant_company_id, source_ids, target_id):
+        self.multi_tenant_company_id = multi_tenant_company_id
+        self.source_ids = source_ids
+        self.target_id = target_id
+
+    def run(self):
+        source_qs = PropertySelectValue.objects.filter(
+            id__in=self.source_ids,
+            multi_tenant_company_id=self.multi_tenant_company_id,
+        )
+        target_instance = PropertySelectValue.objects.get(
+            id=self.target_id,
+            multi_tenant_company_id=self.multi_tenant_company_id,
+        )
+        return source_qs.merge(target_instance)

--- a/OneSila/properties/schema/mutations/mutation_type.py
+++ b/OneSila/properties/schema/mutations/mutation_type.py
@@ -9,6 +9,7 @@ from .fields import complete_create_product_properties_rule, complete_update_pro
 from ..types.types import PropertyType, PropertyTranslationType, PropertySelectValueType, ProductPropertyType, ProductPropertyTextTranslationType, \
     PropertySelectValueTranslationType, ProductPropertiesRuleType, ProductPropertiesRuleItemType, PropertyDuplicatesType, PropertySelectValueDuplicatesType
 from properties.models import Property, PropertySelectValue, ProductProperty, ProductPropertyTextTranslation
+from properties.tasks import merge_property_select_value_db_task
 from ..types.input import PropertyInput, PropertyTranslationInput, PropertySelectValueInput, ProductPropertyInput, \
     PropertyPartialInput, PropertyTranslationPartialInput, PropertySelectValuePartialInput, ProductPropertyPartialInput, ProductPropertyTextTranslationInput, \
     PropertySelectValueTranslationInput, PropertySelectValueTranslationPartialInput, ProductPropertyTextTranslationPartialInput, ProductPropertiesRuleInput, \
@@ -45,15 +46,12 @@ class PropertiesMutation:
     ) -> PropertySelectValueType:
         multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
         source_ids = [s.id.node_id for s in sources]
-        source_qs = PropertySelectValue.objects.filter(
-            id__in=source_ids,
-            multi_tenant_company=multi_tenant_company,
+        target_id = target.id.node_id
+        return merge_property_select_value_db_task(
+            multi_tenant_company_id=multi_tenant_company.id,
+            source_ids=source_ids,
+            target_id=target_id,
         )
-        target_instance = PropertySelectValue.objects.get(
-            id=target.id.node_id,
-            multi_tenant_company=multi_tenant_company,
-        )
-        return source_qs.merge(target_instance)
 
     create_product_property: ProductPropertyType = create(ProductPropertyInput)
     create_product_properties: List[ProductPropertyType] = create(ProductPropertyInput)

--- a/OneSila/properties/tasks.py
+++ b/OneSila/properties/tasks.py
@@ -1,0 +1,13 @@
+from huey.contrib.djhuey import db_task
+
+
+@db_task()
+def merge_property_select_value_db_task(multi_tenant_company_id, source_ids, target_id):
+    from .factories.merge_property_select_value import MergePropertySelectValueFactory
+
+    factory = MergePropertySelectValueFactory(
+        multi_tenant_company_id=multi_tenant_company_id,
+        source_ids=source_ids,
+        target_id=target_id,
+    )
+    return factory.run()


### PR DESCRIPTION
## Summary
- run merge of property select values inside a db task calling a factory

## Testing
- `python manage.py test properties.tests.tests_schemas.tests_mutations.MergePropertySelectValueMutationTestCase -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0ab7e05c832ead3c20ba9f322d5a