### PR TITLE
Add mutation to upload images from URLs

### DIFF
--- a/OneSila/media/schema/mutations/mutation_type.py
+++ b/OneSila/media/schema/mutations/mutation_type.py
@@ -6,6 +6,13 @@ from ..types.types import MediaType, ImageType, VideoType, MediaProductThroughTy
 from ..types.input import MediaInput, ImageInput, VideoInput, MediaProductThroughInput, \
     FileInput, FilePartialInput, MediaPartialInput, ImagePartialInput, \
     VideoPartialInput, MediaProductThroughPartialInput
+import strawberry_django
+from strawberry.types import Info
+from core.schema.core.extensions import default_extensions
+from core.schema.core.helpers import get_multi_tenant_company
+from strawberry_django.auth.utils import get_current_user
+from imports_exports.factories.media import ImportImageInstance
+from types import SimpleNamespace
 
 
 @type(name="Mutation")
@@ -39,3 +46,18 @@ class MediaMutation:
     update_mediaproducthrough: MediaProductThroughType = update(MediaProductThroughPartialInput)
     delete_mediaproducthrough: MediaProductThroughType = delete()
     delete_mediaproducthroughs: List[MediaProductThroughType] = delete()
+
+    @strawberry_django.mutation(handle_django_errors=True, extensions=default_extensions)
+    def upload_images_from_urls(self, urls: List[str], info: Info) -> List[ImageType]:
+        multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
+        user = get_current_user(info)
+        import_process = SimpleNamespace(multi_tenant_company=multi_tenant_company)
+        images = []
+        for url in urls:
+            importer = ImportImageInstance({'image_url': url}, import_process=import_process)
+            importer.process()
+            if importer.instance:
+                importer.instance.owner = user
+                importer.instance.save()
+                images.append(importer.instance)
+        return images

--- a/OneSila/media/tests/tests_schemas/tests_mutations.py
+++ b/OneSila/media/tests/tests_schemas/tests_mutations.py
@@ -1,0 +1,25 @@
+from django.test import TransactionTestCase
+from unittest.mock import patch, Mock
+import base64
+from media.models import Image
+from core.tests.tests_schemas.tests_queries import TransactionTestCaseMixin
+
+
+class UploadImagesFromUrlsTestCase(TransactionTestCaseMixin, TransactionTestCase):
+    def test_upload_images_from_urls(self):
+        url = "https://example.com/test.png"
+        mutation = """
+            mutation($urls: [String!]!) {
+              uploadImagesFromUrls(urls: $urls) { id }
+            }
+        """
+        img_data = base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=")
+        mock_response = Mock()
+        mock_response.iter_content = lambda chunk_size: [img_data]
+        mock_response.headers = {"Content-Type": "image/png"}
+        mock_response.raise_for_status = lambda: None
+        with patch("imports_exports.factories.media.requests.get", return_value=mock_response):
+            resp = self.strawberry_test_client(query=mutation, variables={"urls": [url]})
+        self.assertIsNone(resp.errors)
+        self.assertEqual(len(resp.data["uploadImagesFromUrls"]), 1)
+        self.assertEqual(Image.objects.filter(owner=self.user).count(), 1)


### PR DESCRIPTION
## Summary
- add `upload_images_from_urls` mutation to create images from remote URLs
- cover URL upload workflow with a schema test

## Testing
- `pre-commit run --files OneSila/media/schema/mutations/mutation_type.py OneSila/media/tests/tests_schemas/tests_mutations.py`
- `python manage.py test media.tests.tests_schemas.tests_mutations.UploadImagesFromUrlsTestCase.test_upload_images_from_urls` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0af8115c832e97b8e538cd1937b6