### PR TITLE
feat: add amazon issues inspector blocks

### DIFF
--- a/OneSila/products_inspector/constants.py
+++ b/OneSila/products_inspector/constants.py
@@ -34,6 +34,8 @@ ITEMS_MISSING_MANDATORY_INFORMATION_ERROR = 120
 VARIATIONS_MISSING_MANDATORY_INFORMATION_ERROR = 121
 DUPLICATE_VARIATIONS_ERROR = 123
 NON_CONFIGURABLE_RULE_ERROR = 124
+AMAZON_VALIDATION_ISSUES_ERROR = 125
+AMAZON_REMOTE_ISSUES_ERROR = 126
 
 ERROR_TYPES = (
     (HAS_IMAGES_ERROR, _('Product is missing required images')),
@@ -52,6 +54,8 @@ ERROR_TYPES = (
     (VARIATIONS_MISSING_MANDATORY_INFORMATION_ERROR, _('Variations have inspectors missing mandatory information')),
     (DUPLICATE_VARIATIONS_ERROR, _('Configurable product has duplicate variations')),
     (NON_CONFIGURABLE_RULE_ERROR, _('Configurable product has no applicable configurator rules')),
+    (AMAZON_VALIDATION_ISSUES_ERROR, _('Product has amazon validation issues')),
+    (AMAZON_REMOTE_ISSUES_ERROR, _('Product on amazon has remote issues')),
 )
 
 
@@ -216,6 +220,26 @@ non_configurable_rule_block = {
     'supplier_product_applicability': NONE,
 }
 
+amazon_validation_issues_block = {
+    'error_code': AMAZON_VALIDATION_ISSUES_ERROR,
+    'simple_product_applicability': OPTIONAL,
+    'configurable_product_applicability': OPTIONAL,
+    'manufacturable_product_applicability': OPTIONAL,
+    'bundle_product_applicability': OPTIONAL,
+    'dropship_product_applicability': OPTIONAL,
+    'supplier_product_applicability': NONE,
+}
+
+amazon_remote_issues_block = {
+    'error_code': AMAZON_REMOTE_ISSUES_ERROR,
+    'simple_product_applicability': OPTIONAL,
+    'configurable_product_applicability': OPTIONAL,
+    'manufacturable_product_applicability': OPTIONAL,
+    'bundle_product_applicability': OPTIONAL,
+    'dropship_product_applicability': OPTIONAL,
+    'supplier_product_applicability': NONE,
+}
+
 
 blocks = [
     has_image_block,
@@ -233,5 +257,7 @@ blocks = [
     items_missing_mandatory_information_block,
     variations_missing_mandatory_information_block,
     duplicate_variations_block,
-    non_configurable_rule_block
+    non_configurable_rule_block,
+    amazon_validation_issues_block,
+    amazon_remote_issues_block
 ]

--- a/OneSila/products_inspector/managers.py
+++ b/OneSila/products_inspector/managers.py
@@ -177,3 +177,21 @@ class NonConfigurableRuleInspectorBlockQuerySet(QuerySetProxyModelMixin, Inspect
 class NonConfigurableRuleInspectorBlockManager(InspectorBlockManager):
     def get_queryset(self):
         return NonConfigurableRuleInspectorBlockQuerySet(self.model, using=self._db)
+
+
+class AmazonValidationIssuesQuerySet(QuerySetProxyModelMixin, InspectorBlockQuerySet):
+    pass
+
+
+class AmazonValidationIssuesInspectorBlockManager(InspectorBlockManager):
+    def get_queryset(self):
+        return AmazonValidationIssuesQuerySet(self.model, using=self._db)
+
+
+class AmazonRemoteIssuesQuerySet(QuerySetProxyModelMixin, InspectorBlockQuerySet):
+    pass
+
+
+class AmazonRemoteIssuesInspectorBlockManager(InspectorBlockManager):
+    def get_queryset(self):
+        return AmazonRemoteIssuesQuerySet(self.model, using=self._db)

--- a/OneSila/products_inspector/models.py
+++ b/OneSila/products_inspector/models.py
@@ -9,7 +9,8 @@ from products_inspector.managers import InspectorBlockHasImagesManager, Inspecto
     MissingProductTypeInspectorBlockManager, MissingRequiredPropertiesInspectorBlockManager, MissingOptionalPropertiesInspectorBlockManager, \
     MissingStockManager, MissingManualPriceListOverrideManager, VariationMismatchProductTypeManager, \
     ItemsMismatchProductTypeManager, ItemsMissingMandatoryInformationManager, VariationsMissingMandatoryInformationManager, \
-    DuplicateVariationsManager, NonConfigurableRuleInspectorBlockManager
+    DuplicateVariationsManager, NonConfigurableRuleInspectorBlockManager, AmazonValidationIssuesInspectorBlockManager, \
+    AmazonRemoteIssuesInspectorBlockManager
 
 
 class Inspector(models.Model):
@@ -285,3 +286,25 @@ class NonConfigurableRuleInspectorBlock(InspectorBlock):
     class Meta:
         proxy = True
         verbose_name = _("Inspector Block Non-Configurable Rule")
+
+
+class AmazonValidationIssuesInspectorBlock(InspectorBlock):
+    from .constants import amazon_validation_issues_block
+
+    objects = AmazonValidationIssuesInspectorBlockManager()
+    proxy_filter_fields = amazon_validation_issues_block
+
+    class Meta:
+        proxy = True
+        verbose_name = _("Inspector Block Amazon Validation Issues")
+
+
+class AmazonRemoteIssuesInspectorBlock(InspectorBlock):
+    from .constants import amazon_remote_issues_block
+
+    objects = AmazonRemoteIssuesInspectorBlockManager()
+    proxy_filter_fields = amazon_remote_issues_block
+
+    class Meta:
+        proxy = True
+        verbose_name = _("Inspector Block Amazon Remote Issues")

--- a/OneSila/products_inspector/signals.py
+++ b/OneSila/products_inspector/signals.py
@@ -102,3 +102,9 @@ inspector_duplicate_variations_success = ModelSignal(use_caching=True)
 # signals for configurable product with wrong rule
 inspector_non_configurable_rule_success = ModelSignal(use_caching=True)
 inspector_non_configurable_rule_failed = ModelSignal(use_caching=True)
+
+# signals for amazon issues
+inspector_amazon_validation_issues_failed = ModelSignal(use_caching=True)
+inspector_amazon_validation_issues_success = ModelSignal(use_caching=True)
+inspector_amazon_remote_issues_failed = ModelSignal(use_caching=True)
+inspector_amazon_remote_issues_success = ModelSignal(use_caching=True)

--- a/OneSila/products_inspector/tests/tests_models.py
+++ b/OneSila/products_inspector/tests/tests_models.py
@@ -1248,3 +1248,95 @@ class InspectorBlockDuplicateVariationsTest(TestCase):
 
         # The inspector block should now pass since there is only one variation left
         self.assertTrue(inspector_block.successfully_checked)
+
+
+class AmazonValidationIssuesInspectorBlockTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        from sales_channels.integrations.amazon.models import (
+            AmazonSalesChannel,
+            AmazonSalesChannelView,
+            AmazonProduct,
+        )
+
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="GB",
+        )
+        self.product = SimpleProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.remote_product = AmazonProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+            remote_sku="SKU1",
+        )
+
+    def test_validation_issue_block(self):
+        from sales_channels.integrations.amazon.factories.sales_channels.issues import FetchRemoteValidationIssueFactory
+        from products_inspector.constants import AMAZON_VALIDATION_ISSUES_ERROR
+
+        inspector_block = self.product.inspector.blocks.get(error_code=AMAZON_VALIDATION_ISSUES_ERROR)
+        self.assertTrue(inspector_block.successfully_checked)
+
+        issues = [{"code": "V", "message": "bad", "severity": "ERROR"}]
+        FetchRemoteValidationIssueFactory(remote_product=self.remote_product, view=self.view, issues=issues).run()
+
+        inspector_block.refresh_from_db()
+        self.assertFalse(inspector_block.successfully_checked)
+
+        FetchRemoteValidationIssueFactory(remote_product=self.remote_product, view=self.view, issues=[]).run()
+        inspector_block.refresh_from_db()
+        self.assertTrue(inspector_block.successfully_checked)
+
+
+class AmazonRemoteIssuesInspectorBlockTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        from sales_channels.integrations.amazon.models import (
+            AmazonSalesChannel,
+            AmazonSalesChannelView,
+            AmazonProduct,
+        )
+
+        self.sales_channel = AmazonSalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="SELLER",
+        )
+        self.view = AmazonSalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="GB",
+        )
+        self.product = SimpleProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.remote_product = AmazonProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+            remote_sku="SKU1",
+        )
+
+    def test_remote_issue_block(self):
+        from sales_channels.integrations.amazon.factories.sales_channels.issues import FetchRemoteIssuesFactory
+        from products_inspector.constants import AMAZON_REMOTE_ISSUES_ERROR
+
+        inspector_block = self.product.inspector.blocks.get(error_code=AMAZON_REMOTE_ISSUES_ERROR)
+        self.assertTrue(inspector_block.successfully_checked)
+
+        response = {"issues": [{"code": "X", "message": "bad", "severity": "ERROR"}]}
+        FetchRemoteIssuesFactory(remote_product=self.remote_product, view=self.view, response_data=response).run()
+        inspector_block.refresh_from_db()
+        self.assertFalse(inspector_block.successfully_checked)
+
+        response = {"issues": []}
+        FetchRemoteIssuesFactory(remote_product=self.remote_product, view=self.view, response_data=response).run()
+        inspector_block.refresh_from_db()
+        self.assertTrue(inspector_block.successfully_checked)


### PR DESCRIPTION
## Summary
- add inspector blocks for Amazon validation and remote issues
- trigger Amazon issue checks after remote issue factories run
- test Amazon issue inspector blocks

## Testing
- `pre-commit run --files OneSila/products_inspector/constants.py OneSila/products_inspector/factories/inspector_block.py OneSila/products_inspector/managers.py OneSila/products_inspector/models.py OneSila/products_inspector/signals.py OneSila/products_inspector/tests/tests_models.py OneSila/sales_channels/integrations/amazon/factories/sales_channels/issues.py`
- `python manage.py test products_inspector.tests.tests_models.AmazonValidationIssuesInspectorBlockTestCase products_inspector.tests.tests_models.AmazonRemoteIssuesInspectorBlockTestCase` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bf14963684832e90b334add7047f2d