### PR TITLE
Set default Amazon marketplace based on store country

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/sales_channels/views.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/sales_channels/views.py
@@ -12,6 +12,7 @@ class AmazonSalesChannelViewPullFactory(GetAmazonAPIMixin, PullAmazonMixin, Pull
         'url': 'domain_name',
         'name': 'name',
         'api_region_code': 'api_region_code',
+        'is_default': 'is_default',
     }
     update_field_mapping = field_mapping
     get_or_create_fields = ['remote_id']
@@ -30,6 +31,7 @@ class AmazonSalesChannelViewPullFactory(GetAmazonAPIMixin, PullAmazonMixin, Pull
                 'name': f"{mp.store_name} {mp.marketplace.country_code}",
                 'domain_name': mp.marketplace.domain_name,
                 'api_region_code': f"{self.sales_channel.region}_{mp.marketplace.country_code}",
+                'is_default': mp.marketplace.country_code == self.sales_channel.country,
             }
             for mp in marketplaces
             if mp.participation.is_participating and self.is_real_amazon_marketplace(mp.marketplace)


### PR DESCRIPTION
## Summary
- mark default Amazon marketplace when its country matches the store's

## Testing
- `python manage.py test sales_channels.integrations.amazon.factories.sales_channels -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68bf195aef14832eb1ff2562cc4c5ce3

## Summary by Sourcery

Set the default Amazon marketplace based on the store country by introducing an is_default flag in the pull factory

New Features:
- Add is_default field to the AmazonSalesChannelViewPullFactory mapping
- Set is_default to true for marketplaces whose country code matches the store’s country