### PR TITLE
Limit Amazon inspector blocks to ERROR severity issues

### DIFF
--- a/OneSila/products_inspector/factories/inspector_block.py
+++ b/OneSila/products_inspector/factories/inspector_block.py
@@ -469,6 +469,7 @@ class AmazonValidationIssuesInspectorBlockFactory(InspectorBlockFactory):
         if AmazonProductIssue.objects.filter_multi_tenant(self.multi_tenant_company).filter(
             remote_product__local_instance=self.product,
             is_validation_issue=True,
+            severity="ERROR",
         ).exists():
             raise InspectorBlockFailed("Product has amazon validation issues.")
 
@@ -489,5 +490,6 @@ class AmazonRemoteIssuesInspectorBlockFactory(InspectorBlockFactory):
         if AmazonProductIssue.objects.filter_multi_tenant(self.multi_tenant_company).filter(
             remote_product__local_instance=self.product,
             is_validation_issue=False,
+            severity="ERROR",
         ).exists():
             raise InspectorBlockFailed("Product on amazon has remote issues.")


### PR DESCRIPTION
## Summary
- only consider Amazon product issues with severity ERROR when checking validation or remote issues

## Testing
- `python manage.py test products_inspector` *(fails: connection to server at "localhost" port 5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1dc022f8832eb7c46147986debe5

## Summary by Sourcery

Enhancements:
- Only consider Amazon product issues with severity ERROR when checking for both validation and remote issues.