### PR TITLE
Add image type option to uploadImagesFromUrls

### DIFF
--- a/OneSila/media/schema/types/input.py
+++ b/OneSila/media/schema/types/input.py
@@ -1,4 +1,4 @@
-from core.schema.core.types.input import NodeInput, input, partial
+from core.schema.core.types.input import NodeInput, input, partial, strawberry_input
 from media.models import Media, Image, Video, MediaProductThrough, File
 
 
@@ -50,3 +50,9 @@ class MediaProductThroughInput:
 @partial(MediaProductThrough, fields="__all__")
 class MediaProductThroughPartialInput(NodeInput):
     pass
+
+
+@strawberry_input
+class ImageUrlInput:
+    url: str
+    type: str

--- a/OneSila/media/tests/tests_schemas/tests_mutations.py
+++ b/OneSila/media/tests/tests_schemas/tests_mutations.py
@@ -9,8 +9,8 @@ class UploadImagesFromUrlsTestCase(TransactionTestCaseMixin, TransactionTestCase
     def test_upload_images_from_urls(self):
         url = "https://example.com/test.png"
         mutation = """
-            mutation($urls: [String!]!) {
-              uploadImagesFromUrls(urls: $urls) { id }
+            mutation($imageUrls: [ImageUrlInput!]!) {
+              uploadImagesFromUrls(urls: $imageUrls) { id }
             }
         """
         img_data = base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=")
@@ -19,7 +19,7 @@ class UploadImagesFromUrlsTestCase(TransactionTestCaseMixin, TransactionTestCase
         mock_response.headers = {"Content-Type": "image/png"}
         mock_response.raise_for_status = lambda: None
         with patch("imports_exports.factories.media.requests.get", return_value=mock_response):
-            resp = self.strawberry_test_client(query=mutation, variables={"urls": [url]})
+            resp = self.strawberry_test_client(query=mutation, variables={"imageUrls": [{"url": url, "type": Image.PACK_SHOT}]})
         self.assertIsNone(resp.errors)
         self.assertEqual(len(resp.data["uploadImagesFromUrls"]), 1)
         self.assertEqual(Image.objects.filter(owner=self.user).count(), 1)


### PR DESCRIPTION
## Summary
- extend uploadImagesFromUrls mutation to accept image URL objects with type
- expose new ImageUrlInput for providing url and image type
- update tests for new image URL input

## Testing
- ⚠️ `python manage.py test media.tests.tests_schemas.tests_mutations.UploadImagesFromUrlsTestCase.test_upload_images_from_urls -v 2` (database connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68bf1c506c78832e873dd001a58bb095