### PR TITLE
Replace duplicate Amazon product property entries on select value auto-import

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/auto_import.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/auto_import.py
@@ -45,5 +45,13 @@ class AmazonAutoImportSelectValueFactory:
                 if self.select_value.local_instance not in pp.value_multi_select.all():
                     pp.value_multi_select.add(self.select_value.local_instance)
 
+            duplicates = AmazonProductProperty.objects.filter(
+                remote_product=app.remote_product,
+                local_instance=pp,
+            ).exclude(id=app.id)
+
+            if duplicates.exists():
+                duplicates.delete()
+
             app.local_instance = pp
             app.save(update_fields=["local_instance"])


### PR DESCRIPTION
## Summary
- remove existing AmazonProductProperty duplicates before mapping select values

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/auto_import.py`
- `pytest OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_auto_import_select_value_factory.py` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68bffc4bacfc832e883f489b0bc0021b

## Summary by Sourcery

Bug Fixes:
- Remove existing duplicate AmazonProductProperty entries based on remote_product and local_instance