### PR TITLE
Fix Amazon delete patch structure

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -50,7 +50,6 @@ class GetAmazonAPIMixin:
             if self.remote_product.id != self.remote_instance.id:
                 self.remote_product = self.remote_instance
 
-
         FetchRemoteValidationIssueFactory(
             remote_product=self.remote_product,
             view=self.view,
@@ -458,7 +457,8 @@ class GetAmazonAPIMixin:
 
             if new_value is None:
                 if key in current_attributes:
-                    patches.append({"op": "delete", "path": path})
+                    current_value = clean(current_value)
+                    patches.append({"op": "delete", "path": path, "value": current_value})
             else:
                 if key not in current_attributes:
                     patches.append({"op": "replace", "path": path, "value": new_value})
@@ -503,7 +503,6 @@ class GetAmazonAPIMixin:
 
         listings = ListingsApi(self._get_client())
         response = listings.patch_listings_item(**self._build_listing_kwargs(sku, marketplace_id, body, force_validation_only))
-
 
         if getattr(self, "remote_product", None):
             self.remote_product.last_sync_at = timezone.now()

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
@@ -611,7 +611,6 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
             ean_code="1234567890123",
         )
 
-
         fac = AmazonProductCreateFactory(
             sales_channel=self.sales_channel,
             local_instance=self.product,
@@ -641,6 +640,22 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
 
         body = mock_instance.patch_listings_item.call_args.kwargs.get("body")
         self.assertIsInstance(body, dict)
+
+    def test_build_patches_adds_value_for_delete(self):
+        mixin = GetAmazonAPIMixin()
+        current = {
+            "other_product_image_locator_1": [
+                {"marketplace_id": "GB", "media_location": "https://example.com/img.jpg"}
+            ]
+        }
+        new = {"other_product_image_locator_1": None}
+        patches = mixin._build_patches(current, new)
+        expected = {
+            "op": "delete",
+            "path": "/attributes/other_product_image_locator_1",
+            "value": current["other_product_image_locator_1"],
+        }
+        self.assertIn(expected, patches)
 
     @override_settings(DEBUG=False)
     @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
@@ -1543,7 +1558,6 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
             value=True,
             multi_tenant_company=self.multi_tenant_company,
         )
-
 
         mock_instance = mock_listings.return_value
         mock_instance.put_listings_item.return_value = self.get_put_and_patch_item_listing_mock_response()


### PR DESCRIPTION
## Summary
- include current value when building Amazon delete patches so API requires value field
- add test ensuring delete patches contain value

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/mixins.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductFactoriesTest.test_build_patches_adds_value_for_delete -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bffe658b7c832e82d0f2fa50d135c7