### PR TITLE
Fallback to summary main image when missing Amazon locators

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -222,6 +222,17 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
                     "is_main_image": index == 0,
                 })
                 index += 1
+        if index == 0:
+            summaries = product.get("summaries") or []
+            if summaries:
+                main_image = summaries[0].get("main_image") or {}
+                link = main_image.get("link")
+                if link:
+                    images.append({
+                        "image_url": link,
+                        "sort_order": index,
+                        "is_main_image": index == 0,
+                    })
         return images
 
     @timeit_and_log(logger, "AmazonProductsImportProcessor._parse_attributes")


### PR DESCRIPTION
## Summary
- fall back to `summaries[0].main_image` when Amazon product attributes don't include image locators
- test image parsing for fallback and normal attribute scenarios

## Testing
- `python manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_products_imports.AmazonProductsImportProcessorImagesTest -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68c083c001e4832eac7e097e66634cfa

## Summary by Sourcery

Add logic in AmazonProductsImportProcessor to fall back to the first summary's main_image when no attribute-based image locators are found, and introduce tests to cover both fallback and non-fallback cases.

Enhancements:
- Implement fallback to use summary main_image when Amazon product attributes lack image locators

Tests:
- Add tests for image parsing fallback scenario and ensure no fallback when attributes present