### PR TITLE
Expose configurator value for configurable variations

### DIFF
--- a/OneSila/products/schema/types/types.py
+++ b/OneSila/products/schema/types/types.py
@@ -169,6 +169,7 @@ class SimpleProductType(relay.Node, GetProductQuerysetMultiTenantMixin):
 class ConfigurableVariationType(relay.Node, GetQuerysetMultiTenantMixin):
     parent: Optional[ProductType]
     variation: Optional[ProductType]
+    configurator_value: Optional[str]
 
 
 @type(BundleVariation, filters=BundleVariationFilter, order=BundleVariationOrder, pagination=True, fields="__all__")


### PR DESCRIPTION
## Summary
- add configurator_value property on ConfigurableVariation model
- expose configurator_value via ConfigurableVariationType in GraphQL

## Testing
- `python manage.py test products` *(fails: connection to server at "localhost" port 5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c166b99748832e95abc0866d85c611