### PR TITLE
Move sales channel assignment validation to mutation

### DIFF
--- a/OneSila/sales_channels/models/sales_channels.py
+++ b/OneSila/sales_channels/models/sales_channels.py
@@ -157,50 +157,7 @@ class SalesChannelViewAssign(PolymorphicModel, RemoteObjectMixin, models.Model):
         verbose_name = 'Sales Channel View Assign'
         verbose_name_plural = 'Sales Channel View Assigns'
         ordering = ('product_id', 'sales_channel_view__name')
-        search_terms = ['product__translations__name', 'product__sku' ,'sales_channel_view__name']
-
-    # @TODO: Move this into the mutation
-    def clean(self):
-        super().clean()
-
-        sales_channel = self.sales_channel_view.sales_channel.get_real_instance()
-
-        from sales_channels.integrations.amazon.models import (
-            AmazonSalesChannel,
-            AmazonProductBrowseNode,
-            AmazonVariationTheme,
-        )
-
-        if isinstance(sales_channel, AmazonSalesChannel):
-            exists = SalesChannelViewAssign.objects.filter(
-                product=self.product,
-                sales_channel_view__sales_channel=sales_channel,
-            ).exclude(pk=self.pk).exists()
-
-            if not exists:
-                if not AmazonProductBrowseNode.objects.filter(
-                    product=self.product,
-                    sales_channel=sales_channel,
-                    view=self.sales_channel_view,
-                ).exists():
-                    raise ValidationError(
-                        {'__all__': _('Amazon products require a browse node for the first assignment.')}
-                    )
-
-                if self.product.is_configurable() and not AmazonVariationTheme.objects.filter(
-                    product=self.product, view=self.sales_channel_view
-                ).exists():
-                    raise ValidationError(
-                        {
-                            '__all__': _(
-                                'Amazon configurable products require a variation theme for the first assignment.'
-                            )
-                        }
-                    )
-
-    def save(self, *args, **kwargs):
-        self.clean()
-        return super().save(*args, **kwargs)
+        search_terms = ['product__translations__name', 'product__sku', 'sales_channel_view__name']
 
     def __str__(self):
         return f"{self.product} @ {self.sales_channel_view}"

--- a/OneSila/sales_channels/schema/mutations/mutation_type.py
+++ b/OneSila/sales_channels/schema/mutations/mutation_type.py
@@ -7,6 +7,7 @@ from ..types.input import SalesChannelImportInput, SalesChannelImportPartialInpu
     SalesChannelIntegrationPricelistInput, SalesChannelIntegrationPricelistPartialInput, SalesChannelViewInput, \
     SalesChannelViewPartialInput, SalesChannelViewAssignInput, SalesChannelViewAssignPartialInput, \
     RemoteLanguagePartialInput, RemoteCurrencyPartialInput, ImportPropertyInput
+from .validators import validate_sku_conflicts, validate_amazon_first_assignment
 
 
 @type(name='Mutation')
@@ -42,9 +43,15 @@ class SalesChannelsMutation:
 
     create_import_properties: List[ImportPropertyType] = create(List[ImportPropertyInput])
 
-    create_sales_channel_view_assign: SalesChannelViewAssignType = create(SalesChannelViewAssignInput)
+    create_sales_channel_view_assign: SalesChannelViewAssignType = create(
+        SalesChannelViewAssignInput,
+        validators=[validate_sku_conflicts, validate_amazon_first_assignment],
+    )
     resync_sales_channel_view_assign: SalesChannelViewAssignType = resync_sales_channel_assign()
-    create_sales_channel_view_assigns: List[SalesChannelViewAssignType] = create(SalesChannelViewAssignInput)
+    create_sales_channel_view_assigns: List[SalesChannelViewAssignType] = create(
+        SalesChannelViewAssignInput,
+        validators=[validate_sku_conflicts, validate_amazon_first_assignment],
+    )
     update_sales_channel_view_assign: SalesChannelViewAssignType = update(SalesChannelViewAssignPartialInput)
     delete_sales_channel_view_assign: SalesChannelViewAssignType = delete()
     delete_sales_channel_view_assigns: List[SalesChannelViewAssignType] = delete()

--- a/OneSila/sales_channels/schema/mutations/validators.py
+++ b/OneSila/sales_channels/schema/mutations/validators.py
@@ -1,0 +1,93 @@
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+from sales_channels.exceptions import VariationAlreadyExistsOnWebsite
+from sales_channels.models.sales_channels import SalesChannelViewAssign
+from sales_channels.integrations.shopify.models import ShopifySalesChannel
+
+
+def validate_sku_conflicts(data, info):
+    product = data['product']
+    view = data['sales_channel_view']
+    sales_channel = view.sales_channel.get_real_instance()
+
+    if isinstance(sales_channel, ShopifySalesChannel):
+        return
+
+    if product.is_configurable():
+        variations = product.get_configurable_variations(active_only=True)
+        variation_ids = [v.id for v in variations]
+        conflicted_ids = SalesChannelViewAssign.objects.filter(
+            product_id__in=variation_ids,
+            sales_channel=sales_channel,
+            remote_product__isnull=False,
+        ).values_list("product_id", flat=True)
+
+        if conflicted_ids:
+            sku_map = {v.id: v.sku for v in variations}
+            conflicted_skus = [sku_map[pid] for pid in conflicted_ids]
+            skus = ", ".join(conflicted_skus)
+            raise VariationAlreadyExistsOnWebsite(
+                f"Variations with SKU(s) {skus} already exist on this sales channel. "
+                "Remove them before syncing as a configurable product."
+            )
+    else:
+        if SalesChannelViewAssign.objects.filter(
+            product=product,
+            sales_channel=sales_channel,
+        ).exists():
+            parents = list(product.configurables.all())
+            parent_ids = [p.id for p in parents]
+            conflicted_parent_ids = SalesChannelViewAssign.objects.filter(
+                product_id__in=parent_ids,
+                sales_channel=sales_channel,
+                remote_product__isnull=False,
+            ).values_list("product_id", flat=True)
+
+            if conflicted_parent_ids:
+                sku_map = {p.id: p.sku for p in parents}
+                conflicted_skus = [sku_map[pid] for pid in conflicted_parent_ids]
+                skus = ", ".join(conflicted_skus)
+                raise VariationAlreadyExistsOnWebsite(
+                    f"Parent product(s) with SKU(s) {skus} already exist on this sales channel. "
+                    "Remove them before syncing this variation independently."
+                )
+
+
+def validate_amazon_first_assignment(data, info):
+    product = data['product']
+    view = data['sales_channel_view']
+    sales_channel = view.sales_channel.get_real_instance()
+
+    from sales_channels.integrations.amazon.models import (
+        AmazonSalesChannel,
+        AmazonProductBrowseNode,
+        AmazonVariationTheme,
+    )
+
+    if isinstance(sales_channel, AmazonSalesChannel):
+        exists = SalesChannelViewAssign.objects.filter(
+            product=product,
+            sales_channel_view__sales_channel=sales_channel,
+        ).exists()
+
+        if not exists:
+            if not AmazonProductBrowseNode.objects.filter(
+                product=product,
+                sales_channel=sales_channel,
+                view=view,
+            ).exists():
+                raise ValidationError(
+                    {'__all__': _('Amazon products require a browse node for the first assignment.')}
+                )
+
+            if product.is_configurable() and not AmazonVariationTheme.objects.filter(
+                product=product, view=view
+            ).exists():
+                raise ValidationError(
+                    {
+                        '__all__': _(
+                            'Amazon configurable products require a variation theme for the first assignment.'
+                        )
+                    }
+                )


### PR DESCRIPTION
## Summary
- allow `CreateMutation` to accept pre-create validators
- run SKU and Amazon assignment checks via new validators
- remove redundant validations from model and sync factory

## Testing
- `pre-commit run --files OneSila/core/schema/core/mutations.py OneSila/sales_channels/factories/products/products.py OneSila/sales_channels/models/sales_channels.py OneSila/sales_channels/schema/mutations/mutation_type.py OneSila/sales_channels/schema/mutations/validators.py`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c2aca878b8832e8bae9aaa34ad1952

## Summary by Sourcery

Add pre-create validation support to GraphQL mutations and move existing sales channel assignment checks into reusable validators.

New Features:
- Add optional pre-create validators to CreateMutation and execute them before instance creation.
- Attach SKU conflict and Amazon first-assignment checks to create_sales_channel_view_assign mutations.

Enhancements:
- Extract sales channel SKU duplication and Amazon assignment validations into separate validator functions.
- Remove redundant validation logic from the SalesChannelViewAssign model and sync factory.