### PR TITLE
Translate WooCommerce boolean attributes to strings

### DIFF
--- a/OneSila/sales_channels/integrations/woocommerce/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/woocommerce/factories/mixins.py
@@ -9,6 +9,7 @@ from sales_channels.integrations.woocommerce.constants import API_ATTRIBUTE_PREF
 from properties.models import Property, ProductProperty
 from django.db.models import Q
 from sales_channels.factories.prices.prices import ToUpdateCurrenciesMixin
+from django.utils.translation import gettext as _
 
 import logging
 logger = logging.getLogger(__name__)
@@ -120,9 +121,9 @@ class WoocommerceRemoteValueConversionMixin:
         """Handles float value types."""
         return value
 
-    def get_boolean_value(self, value: bool) -> int:
-        """Converts boolean values to 1 (True) or 0 (False) as required by Magento."""
-        return value
+    def get_boolean_value(self, value: bool) -> str:
+        """Converts boolean values to translated strings for WooCommerce."""
+        return _("Yes") if value else _("No")
 
     def get_select_value(self, value):
         """Handles select and multiselect values."""

--- a/OneSila/sales_channels/integrations/woocommerce/tests/tests_factories/tests_boolean_conversion.py
+++ b/OneSila/sales_channels/integrations/woocommerce/tests/tests_factories/tests_boolean_conversion.py
@@ -1,0 +1,14 @@
+from django.test import SimpleTestCase
+from django.utils.translation import gettext as _, override
+
+from sales_channels.integrations.woocommerce.factories.mixins import (
+    WoocommerceRemoteValueConversionMixin,
+)
+
+
+class BooleanConversionTest(SimpleTestCase):
+    def test_boolean_values_are_translated_strings(self):
+        mixin = WoocommerceRemoteValueConversionMixin()
+        with override('en'):
+            self.assertEqual(mixin.get_boolean_value(True), _("Yes"))
+            self.assertEqual(mixin.get_boolean_value(False), _("No"))


### PR DESCRIPTION
## Summary
- convert boolean attribute values to translated "Yes"/"No" strings for WooCommerce
- test boolean value conversion

## Testing
- `python manage.py test sales_channels.integrations.woocommerce.tests.tests_factories.tests_boolean_conversion -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68c2acdce1e0832e9caa619b5046850b

## Summary by Sourcery

Translate WooCommerce boolean attributes to localized "Yes"/"No" strings using Django gettext and add tests for the conversion.

Enhancements:
- Refactor get_boolean_value to return translated "Yes" or "No" strings instead of raw boolean or integer values

Tests:
- Add BooleanConversionTest to verify that true and false values are correctly converted to localized strings under different language overrides