### PR TITLE
Normalize boolean strings when building Amazon patches

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -440,6 +440,12 @@ class GetAmazonAPIMixin:
                 return {k: clean(v) for k, v in data.items() if v is not None}
             if isinstance(data, list):
                 return [clean(v) for v in data if v is not None]
+            if isinstance(data, str):
+                lower = data.lower()
+                if lower == "true":
+                    return True
+                if lower == "false":
+                    return False
             return data
 
         patches = []
@@ -452,12 +458,11 @@ class GetAmazonAPIMixin:
             if key in skip_keys:
                 continue
             new_value = clean(new_value)
-            current_value = current_attributes.get(key)
+            current_value = clean(current_attributes.get(key))
             path = f"/attributes/{key}"
 
             if new_value is None:
                 if key in current_attributes:
-                    current_value = clean(current_value)
                     patches.append({"op": "delete", "path": path, "value": current_value})
             else:
                 if key not in current_attributes:


### PR DESCRIPTION
## Summary
- Normalize string boolean values to real booleans before diffing Amazon attributes
- Clean current attribute values to avoid unnecessary patch operations

## Testing
- `python manage.py test sales_channels -v 2` *(fails: connection to PostgreSQL at localhost:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c2dd337688832ebd9c63e04823c7d7

## Summary by Sourcery

Normalize boolean strings in attribute cleaning and prevent redundant patch operations

Enhancements:
- Convert string values "true"/"false" to actual booleans in the clean function
- Clean and normalize existing attribute values before diffing to avoid unnecessary patches