### PR TITLE
Ensure main image prioritized and parse others in order

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/imports/products_imports.py
@@ -209,10 +209,21 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
         attrs = product.get("attributes") or {}
         images = []
         index = 0
-        for key, values in attrs.items():
-            if not key.startswith("main_product_image_locator") and not key.startswith("other_product_image_locator"):
+
+        for value in attrs.get("main_product_image_locator", []):
+            url = value.get("media_location")
+            if not url:
                 continue
-            for value in values:
+            images.append({
+                "image_url": url,
+                "sort_order": index,
+                "is_main_image": index == 0,
+            })
+            index += 1
+
+        for i in range(1, 9):
+            key = f"other_product_image_locator_{i}"
+            for value in attrs.get(key, []):
                 url = value.get("media_location")
                 if not url:
                     continue
@@ -222,6 +233,7 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
                     "is_main_image": index == 0,
                 })
                 index += 1
+
         if index == 0:
             summaries = product.get("summaries") or []
             if summaries:
@@ -233,6 +245,7 @@ class AmazonProductsImportProcessor(TemporaryDisableInspectorSignalsMixin, Impor
                         "sort_order": index,
                         "is_main_image": index == 0,
                     })
+
         return images
 
     @timeit_and_log(logger, "AmazonProductsImportProcessor._parse_attributes")

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_products_imports.py
@@ -176,6 +176,44 @@ class AmazonProductsImportProcessorImagesTest(TestCase):
             ],
         )
 
+    def test_image_order_with_gaps(self):
+        product_data = {
+            "attributes": {
+                "main_product_image_locator": [
+                    {"media_location": "https://example.com/main.jpg"}
+                ],
+                "other_product_image_locator_1": [
+                    {"media_location": "https://example.com/1.jpg"}
+                ],
+                "other_product_image_locator_3": [
+                    {"media_location": "https://example.com/3.jpg"}
+                ],
+            }
+        }
+        with patch.object(AmazonProductsImportProcessor, "get_api", return_value=None):
+            processor = AmazonProductsImportProcessor(self.import_process, self.sales_channel)
+            images = processor._parse_images(product_data)
+        self.assertEqual(
+            images,
+            [
+                {
+                    "image_url": "https://example.com/main.jpg",
+                    "sort_order": 0,
+                    "is_main_image": True,
+                },
+                {
+                    "image_url": "https://example.com/1.jpg",
+                    "sort_order": 1,
+                    "is_main_image": False,
+                },
+                {
+                    "image_url": "https://example.com/3.jpg",
+                    "sort_order": 2,
+                    "is_main_image": False,
+                },
+            ],
+        )
+
 
 class AmazonProductsImportProcessorRulePreserveTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- Always parse `main_product_image_locator` first
- Sequentially parse `other_product_image_locator_*` keys in order 1-8, skipping gaps
- Test image parsing order with missing indices

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_products_imports.AmazonProductsImportProcessorImagesTest -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c30554f554832ebc8fb3a9e63d7979

## Summary by Sourcery

Ensure that the main product image is always parsed first and that additional product images are parsed in ascending order of their numeric suffix (1–8), skipping any gaps in the sequence.

Enhancements:
- Prioritize the `main_product_image_locator` entries before any `other_product_image_locator_*` entries and compute sort orders sequentially

Tests:
- Add a unit test to verify image parsing order when some `other_product_image_locator` indices are missing