### PR TITLE
Include marketplace_id in Amazon basic attribute builder

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/products.py
@@ -244,16 +244,21 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
         external_id = self.external_product_id
         if external_id:
             if external_id.type == external_id.TYPE_ASIN:
-                attrs["merchant_suggested_asin"] = [{"value": external_id.value}]
+                attrs["merchant_suggested_asin"] = [
+                    {"value": external_id.value, "marketplace_id": self.view.remote_id}
+                ]
             else:
                 attrs["externally_assigned_product_identifier"] = [
                     {
                         "type": external_id.type.lower(),
                         "value": external_id.value,
+                        "marketplace_id": self.view.remote_id,
                     }
                 ]
             if external_id.created_asin and external_id.type != external_id.TYPE_ASIN:
-                attrs["merchant_suggested_asin"] = [{"value": external_id.created_asin}]
+                attrs["merchant_suggested_asin"] = [
+                    {"value": external_id.created_asin, "marketplace_id": self.view.remote_id}
+                ]
         else:
             ean = self.ean_for_payload
             if ean:
@@ -261,6 +266,7 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
                     {
                         "type": "ean",
                         "value": ean,
+                        "marketplace_id": self.view.remote_id,
                     }
                 ]
 

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
@@ -739,7 +739,9 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
         }
 
         expected_attributes = {
-            "externally_assigned_product_identifier": [{"type": "ean", "value": "1234567890123"}],
+            "externally_assigned_product_identifier": [
+                {"type": "ean", "value": "1234567890123", "marketplace_id": "GB"}
+            ],
             "item_name": [
                 {
                     "value": "Chair name",
@@ -1048,7 +1050,9 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
             if key in ("main_offer_image_locator", "main_product_image_locator")
         }
         expected_attributes = {
-            "merchant_suggested_asin": [{"value": "ASIN123"}],
+            "merchant_suggested_asin": [
+                {"value": "ASIN123", "marketplace_id": "FR"}
+            ],
             "item_name": [
                 {
                     "value": "Chair name fr",
@@ -1513,7 +1517,10 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
         body = mock_instance.put_listings_item.call_args.kwargs.get("body")
         attrs = body.get("attributes", {})
 
-        self.assertEqual(attrs.get("merchant_suggested_asin"), [{"value": "ASIN123"}])
+        self.assertEqual(
+            attrs.get("merchant_suggested_asin"),
+            [{"value": "ASIN123", "marketplace_id": self.view.remote_id}],
+        )
         self.assertNotIn("externally_assigned_product_identifier", attrs)
 
     @patch("sales_channels.integrations.amazon.factories.mixins.GetAmazonAPIMixin._get_client", return_value=None)
@@ -1548,7 +1555,13 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
 
         self.assertEqual(
             attrs.get("externally_assigned_product_identifier"),
-            [{"type": "ean", "value": "1234567890123"}],
+            [
+                {
+                    "type": "ean",
+                    "value": "1234567890123",
+                    "marketplace_id": self.view.remote_id,
+                }
+            ],
         )
         self.assertNotIn("merchant_suggested_asin", attrs)
 


### PR DESCRIPTION
## Summary
- ensure build_basic_attributes adds `marketplace_id` for merchant_suggested_asin and externally_assigned_product_identifier
- update Amazon product factory tests for new marketplace handling

## Testing
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductFactoriesTest.test_create_product_factory_builds_correct_payload -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ddbf52e4832eaaee3a37e34fe684

## Summary by Sourcery

Include marketplace_id in Amazon product basic attributes for both merchant_suggested_asin and externally_assigned_product_identifier, and update corresponding factory tests to validate the new fields.

Enhancements:
- Attach marketplace_id to merchant_suggested_asin and externally_assigned_product_identifier entries in build_basic_attributes
- Include marketplace_id on EAN payload entries within the basic attribute builder

Tests:
- Update AmazonProductFactoriesTest cases to expect marketplace_id in the generated payload attributes