### PR TITLE
Validate sales channel pricing

### DIFF
--- a/OneSila/products/tests/tests_models.py
+++ b/OneSila/products/tests/tests_models.py
@@ -13,7 +13,9 @@ from products.models import (
 )
 from media.models import Media, MediaProductThrough
 from properties.models import Property, PropertyTranslation, ProductProperty, ProductPropertyTextTranslation
-from sales_prices.models import SalesPrice
+from sales_prices.models import SalesPrice, SalesPriceList, SalesPriceListItem
+from sales_channels.integrations.amazon.models import AmazonSalesChannel
+from sales_channels.models import SalesChannelIntegrationPricelist
 
 
 class AlasProductTestCase(TestCase):
@@ -162,3 +164,63 @@ class ProductTranslationModelTest(TestCase):
                 name="Duplicate",
                 multi_tenant_company=self.multi_tenant_company,
             )
+
+
+class ProductPriceValidationTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.channel = AmazonSalesChannel.objects.create(
+            hostname="https://example.com",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.product = SimpleProduct.objects.create(
+            multi_tenant_company=self.multi_tenant_company
+        )
+        self.price_list = SalesPriceList.objects.create(
+            name="pl",
+            currency=self.currency,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        SalesChannelIntegrationPricelist.objects.create(
+            sales_channel=self.channel,
+            price_list=self.price_list,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def _create_item(self, price, discount):
+        return SalesPriceListItem.objects.create(
+            salespricelist=self.price_list,
+            product=self.product,
+            price_override=price,
+            discount_override=discount,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def test_discount_greater_or_equal_returns_full_price_only(self):
+        self._create_item(100, 120)
+        full_price, discount = self.product.get_price_for_sales_channel(
+            self.channel, self.currency
+        )
+        self.assertEqual(full_price, 100)
+        self.assertIsNone(discount)
+
+    def test_zero_price_raises_error(self):
+        SalesPriceListItem.objects.create(
+            salespricelist=self.price_list,
+            product=self.product,
+            price_auto=0,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        with self.assertRaises(ValueError):
+            self.product.get_price_for_sales_channel(self.channel, self.currency)
+
+    def test_zero_discount_raises_error(self):
+        SalesPriceListItem.objects.create(
+            salespricelist=self.price_list,
+            product=self.product,
+            price_override=100,
+            discount_auto=0,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        with self.assertRaises(ValueError):
+            self.product.get_price_for_sales_channel(self.channel, self.currency)


### PR DESCRIPTION
## Summary
- silently drop discounts that are equal to or above the full price
- raise an error when price or discount is zero
- test price validation logic on sales channel pricing

## Testing
- `pre-commit run --files OneSila/products/models.py OneSila/products/tests/tests_models.py`
- `python OneSila/manage.py test products.tests.tests_models.ProductPriceValidationTestCase`


------
https://chatgpt.com/codex/tasks/task_e_68c2dfa738f4832e8c35645098ac8272

## Summary by Sourcery

Enforce validation rules on sales channel pricing to silently drop discounts that meet or exceed the full price, raise errors when price or discount is zero, and add tests to verify these behaviors

Enhancements:
- Validate pricing logic in get_price_for_sales_channel by dropping discounts equal to or exceeding the full price and raising errors for zero price or discount values

Tests:
- Add ProductPriceValidationTestCase to cover scenarios for excessive discounts and zero price or discount errors in sales channel pricing