### PR TITLE
Include marketplace ID with Amazon product images

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/products/images.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/images.py
@@ -62,10 +62,19 @@ class AmazonMediaProductThroughBase(GetAmazonAPIMixin):
     def build_attributes(self):
         urls = self._get_images()
         attrs = {}
+        marketplace_id = self.view.remote_id if self.view else None
         # for idx, key in enumerate(self.OFFER_KEYS):
-        #     attrs[key] = [{"media_location": urls[idx]}] if idx < len(urls) else None
+        #     attrs[key] = (
+        #         [{"marketplace_id": marketplace_id, "media_location": urls[idx]}]
+        #         if idx < len(urls)
+        #         else None
+        #     )
         for idx, key in enumerate(self.PRODUCT_KEYS):
-            attrs[key] = [{"media_location": urls[idx]}] if idx < len(urls) else None
+            attrs[key] = (
+                [{"marketplace_id": marketplace_id, "media_location": urls[idx]}]
+                if idx < len(urls)
+                else None
+            )
         return attrs
 
     def build_body(self):

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_image_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_image_factories.py
@@ -134,11 +134,20 @@ class AmazonProductImageFactoryTest(DisableWooCommerceSignalsMixin, TestCase):
         expected_attrs = {}
         # for idx, key in enumerate(AmazonMediaProductThroughBase.OFFER_KEYS):
         #     expected_attrs[key] = (
-        #         [{"media_location": urls[idx]}] if idx < len(urls) else None
+        #         [{"marketplace_id": self.view.remote_id, "media_location": urls[idx]}]
+        #         if idx < len(urls)
+        #         else None
         #     )
         for idx, key in enumerate(AmazonMediaProductThroughBase.PRODUCT_KEYS):
             expected_attrs[key] = (
-                [{"media_location": urls[idx]}] if idx < len(urls) else None
+                [
+                    {
+                        "marketplace_id": self.view.remote_id,
+                        "media_location": urls[idx],
+                    }
+                ]
+                if idx < len(urls)
+                else None
             )
 
         with patch.object(
@@ -182,11 +191,20 @@ class AmazonProductImageFactoryTest(DisableWooCommerceSignalsMixin, TestCase):
         expected_attrs = {}
         # for idx, key in enumerate(AmazonMediaProductThroughBase.OFFER_KEYS):
         #     expected_attrs[key] = (
-        #         [{"media_location": urls[idx]}] if idx < len(urls) else None
+        #         [{"marketplace_id": self.view.remote_id, "media_location": urls[idx]}]
+        #         if idx < len(urls)
+        #         else None
         #     )
         for idx, key in enumerate(AmazonMediaProductThroughBase.PRODUCT_KEYS):
             expected_attrs[key] = (
-                [{"media_location": urls[idx]}] if idx < len(urls) else None
+                [
+                    {
+                        "marketplace_id": self.view.remote_id,
+                        "media_location": urls[idx],
+                    }
+                ]
+                if idx < len(urls)
+                else None
             )
 
         with patch.object(

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
@@ -738,7 +738,7 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
         keys = list(AmazonMediaProductThroughBase.PRODUCT_KEYS)
 
         expected_images = {
-            key: [{"media_location": url}]
+            key: [{"marketplace_id": "GB", "media_location": url}]
             for key in keys
             if key in ("main_offer_image_locator", "main_product_image_locator")
         }
@@ -1055,7 +1055,7 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
         keys = list(AmazonMediaProductThroughBase.PRODUCT_KEYS)
 
         expected_images = {
-            key: [{"media_location": "https://example.com/img.jpg"}]
+            key: [{"marketplace_id": "FR", "media_location": "https://example.com/img.jpg"}]
             for key in keys
             if key in ("main_offer_image_locator", "main_product_image_locator")
         }
@@ -1199,7 +1199,10 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
         mock_instance.get_listings_item.return_value = SimpleNamespace(
             attributes={
                 "main_product_image_locator": [
-                    {"media_location": "https://example.com/img-old.jpg"}
+                    {
+                        "marketplace_id": "GB",
+                        "media_location": "https://example.com/img-old.jpg",
+                    }
                 ]
             }
         )
@@ -1218,7 +1221,12 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
             {
                 "op": "replace",
                 "path": "/attributes/main_product_image_locator",
-                "value": [{"media_location": "https://example.com/img-new.jpg"}],
+                "value": [
+                    {
+                        "marketplace_id": "GB",
+                        "media_location": "https://example.com/img-new.jpg",
+                    }
+                ],
             },
             body["patches"]
         )


### PR DESCRIPTION
## Summary
- Add `marketplace_id` to each image attribute when building Amazon product payloads
- Adjust image-related tests to expect `marketplace_id` alongside `media_location`

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/products/images.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_image_factories.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py`
- `python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_image_factories sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c324f0d0e8832eb5e7388a8b8dbdd3

## Summary by Sourcery

Include marketplace_id in Amazon product image payloads

Enhancements:
- Add marketplace_id property to each image entry in the Amazon product payload builder

Tests:
- Update image factory tests to assert presence of marketplace_id alongside media_location
- Modify product factory tests to expect marketplace_id in both create and update image payloads