### PR TITLE
Fix WooCommerce boolean attribute handling

### DIFF
--- a/OneSila/sales_channels/integrations/woocommerce/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/woocommerce/factories/mixins.py
@@ -260,6 +260,12 @@ class WooCommerceProductAttributeMixin(WoocommerceSalesChannelLanguageMixin, Woo
 
         return ga
 
+    def get_serialised_woocommerce_value(self, prod_prop):
+        value = prod_prop.get_serialised_value(language=self.sales_channel_assign_language)
+        if prod_prop.property.type == Property.TYPES.BOOLEAN:
+            value = self.get_boolean_value(value)
+        return value
+
     def get_common_properties(self):
         product = self.get_local_product()
         variations = product.get_configurable_variations(active_only=True)
@@ -294,7 +300,7 @@ class WooCommerceProductAttributeMixin(WoocommerceSalesChannelLanguageMixin, Woo
         # set() on a nested list. Instead convert into tuples.
         from itertools import chain
 
-        raw_values = [i.get_serialised_value(language=self.sales_channel_assign_language) for i in properties]
+        raw_values = [self.get_serialised_woocommerce_value(i) for i in properties]
 
         # Flatten all nested lists one level
         flattened = list(chain.from_iterable(
@@ -389,7 +395,7 @@ class WooCommerceProductAttributeMixin(WoocommerceSalesChannelLanguageMixin, Woo
                     attribute_payload.append({
                         'id': ga.remote_id,
                         'visible': True,
-                        'option': prod_prop.get_serialised_value(language=self.sales_channel_assign_language),
+                        'option': self.get_serialised_woocommerce_value(prod_prop),
                     })
                 else:
                     # NOTE: This does not support multi-values.
@@ -400,7 +406,7 @@ class WooCommerceProductAttributeMixin(WoocommerceSalesChannelLanguageMixin, Woo
                     variant_payload.append({
                         'name': prod_prop.property.name,
                         'visible': True,
-                        'option': prod_prop.get_serialised_value(language=self.sales_channel_assign_language),
+                        'option': self.get_serialised_woocommerce_value(prod_prop),
                     })
             logger.debug(f"Variant payload: {variant_payload}")
             attribute_payload.extend(variant_payload)
@@ -422,7 +428,7 @@ class WooCommerceProductAttributeMixin(WoocommerceSalesChannelLanguageMixin, Woo
                 # The simple product takes its own property values.
                 # The configurable takes them from the varisations.
                 if self.is_woocommerce_simple_product:
-                    values = prod_prop.get_serialised_value(language=self.sales_channel_assign_language)
+                    values = self.get_serialised_woocommerce_value(prod_prop)
                 elif self.is_woocommerce_configurable_product:
                     values = self.get_variation_product_property_values(prod_prop)
 


### PR DESCRIPTION
## Summary
- Convert boolean property values to 'Yes'/'No' strings before building WooCommerce attribute payloads
- Ensure variation and product attribute payloads always send string options

## Testing
- `PYTHONPATH=. DJANGO_SETTINGS_MODULE=OneSila.settings pytest sales_channels/integrations/woocommerce/tests/tests_api.py -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c3370cfc44832e81249d95a26dae14

## Summary by Sourcery

Centralize value serialization and fix boolean attribute handling in WooCommerce payloads

Bug Fixes:
- Convert boolean property values to 'Yes'/'No' in WooCommerce attribute payloads
- Ensure variation and product attribute payloads always send string options

Enhancements:
- Introduce get_serialised_woocommerce_value method to unify value serialization