### PR TITLE
Improve Amazon patch and price payload handling

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/prices/prices.py
@@ -118,7 +118,13 @@ class AmazonPriceUpdateFactory(GetAmazonAPIMixin, RemotePriceUpdateFactory):
             purchasable_offer_values.append(offer_entry)
 
             if self.remote_product.product_owner and full_price is not None:
-                list_price_values.append({"currency": iso, value_key: full_price})
+                list_price_values.append(
+                    {
+                        "currency": iso,
+                        "marketplace_id": self.view.remote_id,
+                        value_key: full_price,
+                    }
+                )
 
         if self.get_value_only:
             self.value = {

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_price_factories.py
@@ -261,6 +261,7 @@ class AmazonPriceUpdateRequirementsTest(DisableWooCommerceSignalsMixin, Transact
         list_price = self.get_patch_value(patches, "/attributes/list_price")
         self.assertIsNotNone(list_price, "list_price patch is missing")
         self.assertEqual(list_price[0]["value_with_tax"], 80.0)
+        self.assertEqual(list_price[0]["marketplace_id"], self.view.remote_id)
 
     def test_missing_asin_still_uses_listing_requirements(self):
         self.remote_product.product_owner = True
@@ -274,3 +275,4 @@ class AmazonPriceUpdateRequirementsTest(DisableWooCommerceSignalsMixin, Transact
 
         list_price = self.get_patch_value(patches, "/attributes/list_price")
         self.assertIsNotNone(list_price, "list_price patch is missing")
+        self.assertEqual(list_price[0]["marketplace_id"], self.view.remote_id)


### PR DESCRIPTION
## Summary
- extract purchasable offer merge helper and cast string booleans
- drop unit-only and marketplace-only values in cleaned payloads
- add regression test for empty unit removal

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/mixins.py OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py`
- `DJANGO_SETTINGS_MODULE=OneSila.settings.base python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_price_factories.AmazonPriceUpdateRequirementsTest.test_product_owner_uses_price_listing_requirements sales_channels.integrations.amazon.tests.tests_factories.tests_price_factories.AmazonPriceUpdateRequirementsTest.test_missing_asin_still_uses_listing_requirements sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductFactoriesTest.test_build_patches_keeps_non_all_audiences sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductFactoriesTest.test_replace_tokens_drops_empty_units -v 2` *(fails: connection to PostgreSQL refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c34714ddbc832ebb42db13a76eae75

## Summary by Sourcery

Improve Amazon integration payload handling by merging existing purchasable offers, casting string booleans, cleaning out empty entries, and including marketplace_id in price payloads, with accompanying regression tests.

Enhancements:
- Add a merge helper for purchasable offers to preserve unique audience/currency entries and merge start dates
- Extend cleaning logic to cast string booleans and drop empty unit‐only or marketplace‐only values
- Refactor property payload walker to recursively remove empty or irrelevant fields
- Include marketplace_id in list_price payloads for price updates

Tests:
- Add tests to ensure non-ALL audiences are retained in purchasable_offer patches
- Add a regression test for dropping empty unit values
- Assert marketplace_id presence in list_price in price factory tests