### PR TITLE
Normalize Amazon attribute values during patch building

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -462,6 +462,10 @@ class GetAmazonAPIMixin:
                     return True
                 if lower == "false":
                     return False
+                try:
+                    return int(data) if data.isdigit() else float(data)
+                except ValueError:
+                    return data
             return data
 
         patches = []
@@ -481,6 +485,8 @@ class GetAmazonAPIMixin:
                 new_value, current_value = self._merge_purchasable_offer(
                     new_value, current_value, clean
                 )
+            else:
+                current_value = clean(current_value)
 
             if new_value is None:
                 if key in current_attributes:

--- a/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
@@ -158,6 +158,16 @@ class AmazonProductPropertyBaseMixin(GetAmazonAPIMixin, AmazonRemoteValueMixin):
                     if cleaned_item is not None:
                         cleaned_list.append(cleaned_item)
                 return cleaned_list or None
+            if isinstance(node, str):
+                lower = node.lower()
+                if lower == "true":
+                    return True
+                if lower == "false":
+                    return False
+                try:
+                    return int(node) if node.isdigit() else float(node)
+                except ValueError:
+                    return node
             return node
 
         return _clean(_walk(data)) or {}


### PR DESCRIPTION
## Summary
- Convert string booleans and numbers to native types when replacing tokens for Amazon attributes
- Clean both current and new values (including numeric strings) when building patches, merging purchasable offers properly

## Testing
- `python OneSila/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c3dada4c98832eb89d49e8ba39bb91