### PR TITLE
Cleanup amazon payload before patch

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -462,6 +462,10 @@ class GetAmazonAPIMixin:
                     return True
                 if lower == "false":
                     return False
+                try:
+                    return int(data) if data.isdigit() else float(data)
+                except ValueError:
+                    return data
             return data
 
         patches = []
@@ -481,6 +485,8 @@ class GetAmazonAPIMixin:
                 new_value, current_value = self._merge_purchasable_offer(
                     new_value, current_value, clean
                 )
+            else:
+                current_value = clean(current_value)
 
             if new_value is None:
                 if key in current_attributes:

--- a/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/properties/mixins.py
@@ -158,6 +158,16 @@ class AmazonProductPropertyBaseMixin(GetAmazonAPIMixin, AmazonRemoteValueMixin):
                     if cleaned_item is not None:
                         cleaned_list.append(cleaned_item)
                 return cleaned_list or None
+            if isinstance(node, str):
+                lower = node.lower()
+                if lower == "true":
+                    return True
+                if lower == "false":
+                    return False
+                try:
+                    return int(node) if node.isdigit() else float(node)
+                except ValueError:
+                    return node
             return node
 
         return _clean(_walk(data)) or {}

--- a/OneSila/sales_channels/integrations/magento2/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/magento2/factories/mixins.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from properties.models import Property, ProductPropertyTextTranslation
 from sales_channels.integrations.magento2.models.properties import MagentoAttributeSet, MagentoAttributeSetAttribute, MagentoProperty
 from magento.models import AttributeSet
-
+from django.conf import settings
 from sales_channels.integrations.magento2.models.sales_channels import MagentoRemoteLanguage
 from sales_channels.models.sales_channels import RemoteLanguage, SalesChannelViewAssign
 
@@ -19,7 +19,7 @@ class GetMagentoAPIMixin:
             password=self.sales_channel.host_api_key,
             api_key=self.sales_channel.host_api_key,
             local=not self.sales_channel.verify_ssl,
-            user_agent=None,
+            user_agent=settings.ONESILA_DEFAULT_USER_AGENT,
             authentication_method=self.sales_channel.authentication_method,
             strict_mode=True
         )


### PR DESCRIPTION
## Summary by Sourcery

Enhance payload cleaning and API client configuration by adding type coercion for Amazon integration and setting a default user agent for Magento2.

Enhancements:
- Coerce string values in Amazon payloads to booleans, integers, or floats during cleaning
- Apply cleaning logic to existing attributes when merging Amazon patch data
- Configure a default user agent for the Magento2 API client instead of None