### PR TITLE
Ignore marketplace_id in Amazon patch comparison

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -468,6 +468,17 @@ class GetAmazonAPIMixin:
                     return data
             return data
 
+        def remove_marketplace_id(data):
+            if isinstance(data, dict):
+                return {
+                    k: remove_marketplace_id(v)
+                    for k, v in data.items()
+                    if k != "marketplace_id"
+                }
+            if isinstance(data, list):
+                return [remove_marketplace_id(v) for v in data]
+            return data
+
         patches = []
         current_attributes = current_attributes or {}
         new_attributes = new_attributes or {}
@@ -496,7 +507,11 @@ class GetAmazonAPIMixin:
                 if key not in current_attributes:
                     patches.append({"op": "replace", "path": path, "value": new_value})
                 else:
-                    diff = DeepDiff(current_value, new_value, ignore_order=True)
+                    diff = DeepDiff(
+                        remove_marketplace_id(current_value),
+                        remove_marketplace_id(new_value),
+                        ignore_order=True,
+                    )
                     if diff:
                         patches.append({"op": "replace", "path": path, "value": new_value})
 

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
@@ -679,6 +679,16 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
         patches = mixin._build_patches(current, new)
         self.assertEqual(patches, [])
 
+    def test_build_patches_ignores_marketplace_id(self):
+        mixin = GetAmazonAPIMixin()
+        current = {"attr": [{"marketplace_id": "GB", "value": "foo"}]}
+        new = {"attr": [{"value": "foo"}]}
+        self.assertEqual(mixin._build_patches(current, new), [])
+        self.assertEqual(
+            mixin._build_patches({"attr": [{"value": "foo"}]}, {"attr": [{"marketplace_id": "GB", "value": "foo"}]}),
+            [],
+        )
+
     def test_replace_tokens_drops_empty_units(self):
         mixin = AmazonProductPropertyBaseMixin()
         data = {


### PR DESCRIPTION
## Summary
- skip marketplace_id when comparing Amazon attribute patches
- ensure _build_patches test ignores marketplace_id differences

## Testing
- `pre-commit run --files OneSila/sales_channels/integrations/amazon/factories/mixins.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py`
- `DJANGO_SETTINGS_MODULE=OneSila.settings pytest OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py::AmazonProductFactoriesTest::test_build_patches_ignores_marketplace_id -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f54d9c30832eaa624ab954145eef

## Summary by Sourcery

Ignore marketplace_id differences when building Amazon attribute patches by filtering out marketplace_id keys before computing diffs and add a unit test to validate this behavior

Enhancements:
- Exclude marketplace_id keys from patch comparison in the Amazon API mixin by removing them before DeepDiff

Tests:
- Add test to verify that _build_patches ignores marketplace_id differences