### PR TITLE
Add eBay view policy and location metadata

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/views.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/views.py
@@ -23,7 +23,14 @@ class EbaySalesChannelViewPullFactory(GetEbayAPIMixin, PullRemoteInstanceMixin):
 
     def fetch_remote_instances(self):
         self.remote_instances = []
-        marketplaces = self.get_marketplace_ids()
+        try:
+            subscription_marketplace_ids = self.get_subscription_marketplace_ids()
+        except Exception:
+            subscription_marketplace_ids = None
+        if isinstance(subscription_marketplace_ids, list):
+            marketplaces = list(dict.fromkeys(subscription_marketplace_ids))
+        else:
+            marketplaces = self.get_marketplace_ids()
         try:
             default_marketplace = self.get_default_marketplace_id()
         except:
@@ -33,6 +40,7 @@ class EbaySalesChannelViewPullFactory(GetEbayAPIMixin, PullRemoteInstanceMixin):
             default_marketplace = None
 
         reference = self.marketplace_reference()
+        merchant_location_choices = self._get_merchant_location_choices()
 
         for marketplace_id in marketplaces:
             info = reference.get(marketplace_id)
@@ -43,12 +51,150 @@ class EbaySalesChannelViewPullFactory(GetEbayAPIMixin, PullRemoteInstanceMixin):
             name = info[0]
             languages = info[1]
             url = next(iter(languages.values()))[0] if languages else ""
+            fulfillment_policy_choices = self._get_fulfillment_policy_choices(marketplace_id)
+            payment_policy_choices = self._get_payment_policy_choices(marketplace_id)
+            return_policy_choices = self._get_return_policy_choices(marketplace_id)
+            default_category_tree_id = self._get_default_category_tree_id(marketplace_id)
             self.remote_instances.append({
                 "marketplace_id": marketplace_id,
                 "name": name,
                 "url": url,
                 "is_default": marketplace_id == default_marketplace,
+                "fulfillment_policy_choices": fulfillment_policy_choices,
+                "payment_policy_choices": payment_policy_choices,
+                "return_policy_choices": return_policy_choices,
+                "merchant_location_choices": merchant_location_choices,
+                "default_category_tree_id": default_category_tree_id,
             })
 
     def serialize_response(self, response):
         return response
+
+    def _get_policy_choices(self, endpoint, result_key, marketplace_id, value_key):
+        try:
+            response = self._request_account_policy(endpoint, marketplace_id)
+        except Exception:
+            return []
+
+        if not isinstance(response, dict):
+            return []
+
+        policies = response.get(result_key, [])
+        if not isinstance(policies, list):
+            return []
+
+        choices = []
+        for policy in policies:
+            if not isinstance(policy, dict):
+                continue
+            if policy.get("marketplaceId") != marketplace_id:
+                continue
+
+            value = policy.get(value_key)
+            if not value:
+                continue
+
+            label = policy.get("name") or value
+            choices.append({"label": label, "value": value})
+
+        return choices
+
+    def _get_fulfillment_policy_choices(self, marketplace_id):
+        return self._get_policy_choices(
+            "fulfillment_policy", "fulfillmentPolicies", marketplace_id, "fulfillmentPolicyId"
+        )
+
+    def _get_payment_policy_choices(self, marketplace_id):
+        return self._get_policy_choices(
+            "payment_policy", "paymentPolicies", marketplace_id, "paymentPolicyId"
+        )
+
+    def _get_return_policy_choices(self, marketplace_id):
+        return self._get_policy_choices(
+            "return_policy", "returnPolicies", marketplace_id, "returnPolicyId"
+        )
+
+    def _get_merchant_location_choices(self):
+        try:
+            response = self.api.sell_inventory_get_inventory_locations()
+        except Exception:
+            return []
+
+        if response is None:
+            return []
+
+        if isinstance(response, dict):
+            response_items = [response]
+        else:
+            try:
+                response_items = list(response)
+            except TypeError:
+                response_items = []
+
+        choices = []
+        for entry in response_items:
+            if not isinstance(entry, dict):
+                continue
+            record = entry.get("record")
+            if not isinstance(record, dict):
+                continue
+
+            merchant_location_key = record.get("merchant_location_key")
+            if not merchant_location_key:
+                continue
+
+            location = record.get("location", {})
+            address = location.get("address", {}) if isinstance(location, dict) else {}
+            if not isinstance(address, dict):
+                address = {}
+
+            address_parts = []
+            for key in (
+                "address_line1",
+                "address_line2",
+                "city",
+                "country",
+                "county",
+                "postal_code",
+                "state_or_province",
+            ):
+                value = address.get(key)
+                if value:
+                    address_parts.append(value)
+
+            label = ", ".join(address_parts) if address_parts else merchant_location_key
+            choices.append({"label": label, "value": merchant_location_key})
+
+        return choices
+
+    def _get_default_category_tree_id(self, marketplace_id):
+        try:
+            response = self.api.commerce_taxonomy_get_default_category_tree_id(marketplace_id)
+        except Exception:
+            return None
+
+        if isinstance(response, dict):
+            return response.get("category_tree_id")
+
+        return None
+
+    def process_remote_instance(self, remote_data, remote_instance_mirror, created):
+        updated_fields = []
+        for field in [
+            "fulfillment_policy_choices",
+            "payment_policy_choices",
+            "return_policy_choices",
+            "merchant_location_choices",
+            "default_category_tree_id",
+        ]:
+            if field not in remote_data:
+                continue
+
+            value = remote_data.get(field)
+
+            if getattr(remote_instance_mirror, field) != value:
+                setattr(remote_instance_mirror, field, value)
+                updated_fields.append(field)
+
+        if updated_fields:
+            remote_instance_mirror.save(update_fields=updated_fields)

--- a/OneSila/sales_channels/integrations/ebay/tests/tests_factories/tests_pull.py
+++ b/OneSila/sales_channels/integrations/ebay/tests/tests_factories/tests_pull.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from .mixins import TestCaseEbayMixin
 from sales_channels.integrations.ebay.factories.sales_channels import (
     EbayRemoteCurrencyPullFactory,
@@ -16,9 +18,29 @@ class TestEbayPullFactories(TestCaseEbayMixin):
         self.assertEqual(len(codes), currencies.count())
 
     def test_pull_view(self):
-        factory = EbaySalesChannelViewPullFactory(sales_channel=self.sales_channel)
-        factory.run()
-        self.assertTrue(factory.remote_model_class.objects.filter(sales_channel=self.sales_channel).exists())
+        fulfillment = [{'label': 'Fulfillment', 'value': 'f1'}]
+        payment = [{'label': 'Payment', 'value': 'p1'}]
+        return_policies = [{'label': 'Return', 'value': 'r1'}]
+        locations = [{'label': '123 High Street, London', 'value': 'loc1'}]
+
+        with patch.object(EbaySalesChannelViewPullFactory, 'get_subscription_marketplace_ids', return_value=['EBAY_GB']), \
+                patch.object(EbaySalesChannelViewPullFactory, '_get_fulfillment_policy_choices', return_value=fulfillment), \
+                patch.object(EbaySalesChannelViewPullFactory, '_get_payment_policy_choices', return_value=payment), \
+                patch.object(EbaySalesChannelViewPullFactory, '_get_return_policy_choices', return_value=return_policies), \
+                patch.object(EbaySalesChannelViewPullFactory, '_get_merchant_location_choices', return_value=locations), \
+                patch.object(EbaySalesChannelViewPullFactory, '_get_default_category_tree_id', return_value='3'), \
+                patch.object(EbaySalesChannelViewPullFactory, 'get_default_marketplace_id', return_value='EBAY_GB'):
+            factory = EbaySalesChannelViewPullFactory(sales_channel=self.sales_channel)
+            factory.run()
+
+        queryset = factory.remote_model_class.objects.filter(sales_channel=self.sales_channel)
+        self.assertTrue(queryset.exists())
+        view = queryset.get()
+        self.assertEqual(view.fulfillment_policy_choices, fulfillment)
+        self.assertEqual(view.payment_policy_choices, payment)
+        self.assertEqual(view.return_policy_choices, return_policies)
+        self.assertEqual(view.merchant_location_choices, locations)
+        self.assertEqual(view.default_category_tree_id, '3')
 
     def test_pull_language(self):
         factory = EbayRemoteLanguagePullFactory(sales_channel=self.sales_channel)


### PR DESCRIPTION
## Summary
- pull policy, location, and taxonomy metadata for each eBay marketplace view when syncing
- persist the fetched choices on every pull so view configuration stays current using label/value pairs expected by the UI
- cover the new metadata handling in the eBay sales channel view pull test suite

## Testing
- `python OneSila/manage.py test sales_channels.integrations.ebay.tests.tests_factories.tests_pull` *(fails: ModuleNotFoundError: No module named 'ebay_rest')*

------
https://chatgpt.com/codex/tasks/task_e_68c88c34eda8832ebac93c9685676dd6

## Summary by Sourcery

Add eBay marketplace metadata synchronization by pulling policy, location, and taxonomy details during view sync, and persist the retrieved label/value pairs to the view records.

New Features:
- Fetch and store fulfillment, payment, and return policy choices for each eBay marketplace view
- Fetch and store merchant location choices for each eBay marketplace view
- Fetch and store the default category tree ID for each eBay marketplace view

Enhancements:
- Prefer subscription marketplace IDs when fetching views with fallback to standard marketplace IDs
- Optimize view synchronization to only save updated metadata fields

Tests:
- Extend view pull tests to stub and verify new policy, location, and category tree metadata persistence