### PR TITLE
Avoid passing zero offset to eBay pagination

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/mixins.py
@@ -288,7 +288,12 @@ class GetEbayAPIMixin:
         offset = kwargs.pop("offset", 0) or 0
 
         while True:
-            response = fetcher(limit=limit, offset=offset, **kwargs)
+            request_kwargs = dict(kwargs)
+            request_kwargs["limit"] = limit
+            if offset:
+                request_kwargs["offset"] = offset
+
+            response = fetcher(**request_kwargs)
 
             is_iterator_response = isinstance(response, Iterator)
             response_items = response if is_iterator_response else (response,)


### PR DESCRIPTION
## Summary
- avoid sending an explicit offset of zero when fetching paginated eBay resources so the ebay_rest client can manage pagination

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9438b5520832e86c154a94e14c97e

## Summary by Sourcery

Omit explicit offset parameter when it is zero in eBay pagination requests to allow the client to manage pagination

Bug Fixes:
- Do not include offset in request parameters if its value is zero

Enhancements:
- Build request parameters dynamically to always include limit and conditionally include offset