### PR TITLE
Restore eBay property select value schema

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/mutations.py
@@ -5,12 +5,14 @@ from sales_channels.integrations.ebay.schema.types.input import (
     EbaySalesChannelPartialInput,
     EbayValidateAuthInput,
     EbayPropertyPartialInput,
+    EbayPropertySelectValuePartialInput,
     EbaySalesChannelViewPartialInput,
 )
 from sales_channels.integrations.ebay.schema.types.types import (
     EbaySalesChannelType,
     EbayRedirectUrlType,
     EbayPropertyType,
+    EbayPropertySelectValueType,
     EbaySalesChannelViewType,
 )
 from core.schema.core.mutations import create, type, List, update
@@ -29,7 +31,7 @@ class EbaySalesChannelMutation:
     update_ebay_sales_channel: EbaySalesChannelType = update(EbaySalesChannelPartialInput)
 
     update_ebay_property: EbayPropertyType = update(EbayPropertyPartialInput)
-    # update_ebay_property_select_value: EbayPropertySelectValueType = update(EbayPropertySelectValuePartialInput)
+    update_ebay_property_select_value: EbayPropertySelectValueType = update(EbayPropertySelectValuePartialInput)
     update_ebay_sales_channel_view: EbaySalesChannelViewType = update(EbaySalesChannelViewPartialInput)
 
     @strawberry_django.mutation(handle_django_errors=True, extensions=default_extensions)

--- a/OneSila/sales_channels/integrations/ebay/schema/queries.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/queries.py
@@ -2,6 +2,7 @@ from core.schema.core.queries import node, connection, DjangoListConnection, typ
 from sales_channels.integrations.ebay.schema.types.types import (
     EbaySalesChannelType,
     EbayPropertyType,
+    EbayPropertySelectValueType,
     EbaySalesChannelViewType,
 )
 
@@ -14,8 +15,8 @@ class EbaySalesChannelsQuery:
     ebay_property: EbayPropertyType = node()
     ebay_properties: DjangoListConnection[EbayPropertyType] = connection()
 
-    # ebay_property_select_value: EbayPropertySelectValueType = node()
-    # ebay_property_select_values: DjangoListConnection[EbayPropertySelectValueType] = connection()
+    ebay_property_select_value: EbayPropertySelectValueType = node()
+    ebay_property_select_values: DjangoListConnection[EbayPropertySelectValueType] = connection()
 
     ebay_channel_view: EbaySalesChannelViewType = node()
     ebay_channel_views: DjangoListConnection[EbaySalesChannelViewType] = connection()

--- a/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
@@ -5,6 +5,7 @@ from core.schema.core.types.types import auto
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
     EbayProperty,
+    EbayPropertySelectValue,
     EbaySalesChannelView,
 )
 from properties.schema.types.filters import PropertyFilter, PropertySelectValueFilter
@@ -26,13 +27,13 @@ class EbayPropertyFilter(SearchFilterMixin):
     # type: auto
 
 
-# @filter(EbayPropertySelectValue)
-# class EbayPropertySelectValueFilter(SearchFilterMixin):
-#     id: auto
-#     sales_channel: Optional[SalesChannelFilter]
-#     ebay_property: Optional[EbayPropertyFilter]
-#     local_instance: Optional[PropertySelectValueFilter]
-#     marketplace: Optional[SalesChannelViewFilter]
+@filter(EbayPropertySelectValue)
+class EbayPropertySelectValueFilter(SearchFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]
+    ebay_property: Optional[EbayPropertyFilter]
+    local_instance: Optional[PropertySelectValueFilter]
+    marketplace: Optional[SalesChannelViewFilter]
 
 
 @filter(EbaySalesChannelView)

--- a/OneSila/sales_channels/integrations/ebay/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/input.py
@@ -2,6 +2,7 @@ from core.schema.core.types.input import NodeInput, input, partial, strawberry_i
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
     EbayProperty,
+    EbayPropertySelectValue,
     EbaySalesChannelView,
 )
 
@@ -32,14 +33,14 @@ class EbayPropertyPartialInput(NodeInput):
     pass
 
 
-# @input(EbayPropertySelectValue, fields="__all__")
-# class EbayPropertySelectValueInput:
-#     pass
-#
-#
-# @partial(EbayPropertySelectValue, fields="__all__")
-# class EbayPropertySelectValuePartialInput(NodeInput):
-#     pass
+@input(EbayPropertySelectValue, fields="__all__")
+class EbayPropertySelectValueInput:
+    pass
+
+
+@partial(EbayPropertySelectValue, fields="__all__")
+class EbayPropertySelectValuePartialInput(NodeInput):
+    pass
 
 
 @input(EbaySalesChannelView, fields="__all__")

--- a/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
@@ -3,6 +3,7 @@ from core.schema.core.types.types import auto
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
     EbayProperty,
+    EbayPropertySelectValue,
     EbaySalesChannelView,
 )
 
@@ -17,9 +18,9 @@ class EbayPropertyOrder:
     id: auto
 
 
-# @order(EbayPropertySelectValue)
-# class EbayPropertySelectValueOrder:
-#     id: auto
+@order(EbayPropertySelectValue)
+class EbayPropertySelectValueOrder:
+    id: auto
 
 
 @order(EbaySalesChannelView)

--- a/OneSila/sales_channels/integrations/ebay/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/types.py
@@ -11,16 +11,19 @@ from core.schema.core.types.types import (
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
     EbayProperty,
+    EbayPropertySelectValue,
     EbaySalesChannelView,
 )
 from sales_channels.integrations.ebay.schema.types.filters import (
     EbaySalesChannelFilter,
     EbayPropertyFilter,
+    EbayPropertySelectValueFilter,
     EbaySalesChannelViewFilter,
 )
 from sales_channels.integrations.ebay.schema.types.ordering import (
     EbaySalesChannelOrder,
     EbayPropertyOrder,
+    EbayPropertySelectValueOrder,
     EbaySalesChannelViewOrder,
 )
 
@@ -58,33 +61,33 @@ class EbayPropertyType(relay.Node, GetQuerysetMultiTenantMixin):
         'PropertyType',
         lazy("properties.schema.types.types")
     ]]
-    # select_values: List[Annotated[
-    #     'EbayPropertySelectValueType',
-    #     lazy("sales_channels.integrations.ebay.schema.types.types")
-    # ]]
+    select_values: List[Annotated[
+        'EbayPropertySelectValueType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]]
 
 
-# @type(
-#     EbayPropertySelectValue,
-#     filters=EbayPropertySelectValueFilter,
-#     order=EbayPropertySelectValueOrder,
-#     pagination=True,
-#     fields="__all__",
-# )
-# class EbayPropertySelectValueType(relay.Node, GetQuerysetMultiTenantMixin):
-#     sales_channel: Annotated[
-#         'EbaySalesChannelType',
-#         lazy("sales_channels.integrations.ebay.schema.types.types")
-#     ]
-#     ebay_property: EbayPropertyType
-#     marketplace: Annotated[
-#         'SalesChannelViewType',
-#         lazy("sales_channels.schema.types.types")
-#     ]
-#     local_instance: Optional[Annotated[
-#         'PropertySelectValueType',
-#         lazy("properties.schema.types.types")
-#     ]]
+@type(
+    EbayPropertySelectValue,
+    filters=EbayPropertySelectValueFilter,
+    order=EbayPropertySelectValueOrder,
+    pagination=True,
+    fields="__all__",
+)
+class EbayPropertySelectValueType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'EbaySalesChannelType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]
+    ebay_property: EbayPropertyType
+    marketplace: Annotated[
+        'SalesChannelViewType',
+        lazy("sales_channels.schema.types.types")
+    ]
+    local_instance: Optional[Annotated[
+        'PropertySelectValueType',
+        lazy("properties.schema.types.types")
+    ]]
 
 
 @type(


### PR DESCRIPTION
## Summary
- restore the EbayPropertySelectValue GraphQL filter, order, input, and type definitions
- re-expose EbayPropertySelectValue queries and mutation operations
- ensure EbayProperty types include select value relations in the schema

## Testing
- python -m compileall OneSila/sales_channels/integrations/ebay/schema

------
https://chatgpt.com/codex/tasks/task_e_68c9b4cb4c70832e9b81c8a33c437c06