### PR TITLE
Implement eBay product type rule factory

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/full_schema.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/full_schema.py
@@ -2,14 +2,26 @@
 
 from __future__ import annotations
 
-from typing import Optional
+import logging
+from typing import Any, Optional
 
+from properties.models import Property, ProductPropertiesRuleItem
 from sales_channels.integrations.ebay.factories.mixins import GetEbayAPIMixin
-from sales_channels.integrations.ebay.models import EbaySalesChannel, EbaySalesChannelView
+from sales_channels.integrations.ebay.models import (
+    EbayProductType,
+    EbayProductTypeItem,
+    EbayProperty,
+    EbayPropertySelectValue,
+    EbaySalesChannel,
+    EbaySalesChannelView,
+)
+
+
+logger = logging.getLogger(__name__)
 
 
 class EbayProductTypeRuleFactory(GetEbayAPIMixin):
-    """Placeholder factory that will build local rules for eBay product types."""
+    """Build local mirrors of eBay product type metadata for a given category."""
 
     def __init__(
         self,
@@ -25,6 +37,7 @@ class EbayProductTypeRuleFactory(GetEbayAPIMixin):
         self.category_id = str(category_id) if category_id is not None else None
         self.category_tree_id = category_tree_id or getattr(self.view, "default_category_tree_id", None)
         self.language = language
+        self.multi_tenant_company = sales_channel.multi_tenant_company
 
         # Each factory instance needs its own API configured for the specific view headers.
         self.api = self.get_api()
@@ -32,8 +45,31 @@ class EbayProductTypeRuleFactory(GetEbayAPIMixin):
     def run(self) -> None:
         """Build local product type rules for the configured category."""
 
-        # Implementation will be provided in a follow-up iteration.
-        return None
+        if not self.category_id:
+            logger.warning("Skipping eBay product type sync because category_id is missing.")
+            return
+
+        if not self.category_tree_id:
+            logger.warning(
+                "Skipping eBay product type sync for category %s due to missing category tree id.",
+                self.category_id,
+            )
+            return
+
+        category_data = self._fetch_category_details()
+        product_type = self._get_or_create_product_type(category_data)
+        if product_type is None:
+            return
+
+        aspects = self._fetch_aspects()
+        if not aspects:
+            return
+
+        for aspect in aspects:
+            remote_property = self._sync_property(product_type, aspect)
+            if remote_property is None:
+                continue
+            self._sync_product_type_item(product_type, remote_property, aspect)
 
     @staticmethod
     def _ensure_real_view(view: EbaySalesChannelView) -> EbaySalesChannelView:
@@ -45,3 +81,283 @@ class EbayProductTypeRuleFactory(GetEbayAPIMixin):
             if isinstance(real_view, EbaySalesChannelView):
                 return real_view
         return view
+
+    def _fetch_category_details(self) -> dict[str, Any] | None:
+        """Return basic information about the configured category."""
+
+        try:
+            response = self.api.commerce_taxonomy_get_category_subtree(
+                category_id=self.category_id,
+                category_tree_id=self.category_tree_id,
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception(
+                "Failed to fetch eBay category subtree for category %s in tree %s",
+                self.category_id,
+                self.category_tree_id,
+            )
+            return None
+
+        if not isinstance(response, dict):
+            return None
+
+        node = response.get("categorySubtreeNode")
+        if isinstance(node, dict):
+            category = node.get("category")
+            if isinstance(category, dict):
+                return category
+            return node
+        return None
+
+    def _fetch_aspects(self) -> list[dict[str, Any]]:
+        """Fetch aspect metadata for the configured category."""
+
+        try:
+            response = self.api.commerce_taxonomy_get_item_aspects_for_category(
+                category_id=self.category_id,
+                category_tree_id=self.category_tree_id,
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception(
+                "Failed to fetch eBay aspects for category %s in tree %s",
+                self.category_id,
+                self.category_tree_id,
+            )
+            return []
+
+        if isinstance(response, dict):
+            aspects = response.get("aspects")
+            if isinstance(aspects, list):
+                return [aspect for aspect in aspects if isinstance(aspect, dict)]
+        return []
+
+    def _get_or_create_product_type(self, category: dict[str, Any] | None) -> EbayProductType | None:
+        """Create or update the EbayProductType record for the current category."""
+
+        remote_id = self.category_id
+        name = None
+        if category:
+            category_id = category.get("categoryId")
+            if category_id is not None:
+                remote_id = str(category_id)
+            name = category.get("categoryName")
+
+        if remote_id is None:
+            logger.warning("Unable to determine remote_id for eBay category. Skipping sync.")
+            return None
+
+        product_type, _ = EbayProductType.objects.get_or_create(
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id=str(remote_id),
+        )
+
+        update_fields: list[str] = []
+        if name and product_type.name != name:
+            product_type.name = name
+            update_fields.append("name")
+        if update_fields:
+            product_type.save(update_fields=update_fields)
+
+        return product_type
+
+    def _sync_property(
+        self,
+        product_type: EbayProductType,
+        aspect: dict[str, Any],
+    ) -> EbayProperty | None:
+        localized_name = aspect.get("localizedAspectName")
+        if not localized_name:
+            return None
+
+        constraint = aspect.get("aspectConstraint") or {}
+        applicable_to = constraint.get("aspectApplicableTo")
+        if isinstance(applicable_to, list) and "PRODUCT" not in applicable_to:
+            return None
+
+        aspect_values = aspect.get("aspectValues") or []
+        aspect_format = constraint.get("aspectFormat")
+        property_type, allows_unmapped = self._determine_property_metadata(aspect, aspect_values)
+
+        remote_property, _ = EbayProperty.objects.get_or_create(
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+            marketplace=self.view,
+            localized_name=localized_name,
+        )
+
+        update_fields: list[str] = []
+        aspect_id = aspect.get("aspectId")
+        if aspect_id is not None:
+            aspect_id = str(aspect_id)
+            if remote_property.remote_id != aspect_id:
+                remote_property.remote_id = aspect_id
+                update_fields.append("remote_id")
+
+        if remote_property.type != property_type:
+            remote_property.type = property_type
+            update_fields.append("type")
+
+        if remote_property.allows_unmapped_values != allows_unmapped:
+            remote_property.allows_unmapped_values = allows_unmapped
+            update_fields.append("allows_unmapped_values")
+
+        normalized_format = aspect_format or None
+        if remote_property.value_format != normalized_format:
+            remote_property.value_format = normalized_format
+            update_fields.append("value_format")
+
+        if remote_property.raw_data != aspect:
+            remote_property.raw_data = aspect
+            update_fields.append("raw_data")
+
+        if update_fields:
+            remote_property.save(update_fields=update_fields)
+
+        self._sync_property_values(remote_property, aspect_values)
+
+        return remote_property
+
+    def _sync_property_values(
+        self,
+        remote_property: EbayProperty,
+        aspect_values: list[Any],
+    ) -> None:
+        if remote_property.type not in {Property.TYPES.SELECT, Property.TYPES.MULTISELECT}:
+            return
+
+        for value_data in aspect_values or []:
+            if not isinstance(value_data, dict):
+                continue
+            localized_value = value_data.get("localizedValue")
+            if not localized_value:
+                continue
+
+            value_obj, _ = EbayPropertySelectValue.objects.get_or_create(
+                sales_channel=self.sales_channel,
+                multi_tenant_company=self.multi_tenant_company,
+                ebay_property=remote_property,
+                marketplace=self.view,
+                localized_value=localized_value,
+            )
+
+            remote_value_id = value_data.get("valueId") or value_data.get("value")
+            if remote_value_id is not None:
+                remote_value_id = str(remote_value_id)
+                if value_obj.remote_id != remote_value_id:
+                    value_obj.remote_id = remote_value_id
+                    value_obj.save(update_fields=["remote_id"])
+
+    def _sync_product_type_item(
+        self,
+        product_type: EbayProductType,
+        remote_property: EbayProperty,
+        aspect: dict[str, Any],
+    ) -> None:
+        constraint = aspect.get("aspectConstraint") or {}
+        remote_type = self._determine_remote_type(constraint)
+
+        rule_item, _ = EbayProductTypeItem.objects.get_or_create(
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+            product_type=product_type,
+            remote_property=remote_property,
+        )
+
+        if rule_item.remote_type != remote_type:
+            rule_item.remote_type = remote_type
+            rule_item.save(update_fields=["remote_type"])
+
+    def _determine_property_metadata(
+        self,
+        aspect: dict[str, Any],
+        aspect_values: list[Any],
+    ) -> tuple[str, bool]:
+        constraint = aspect.get("aspectConstraint") or {}
+        data_type = (constraint.get("aspectDataType") or "").upper()
+        mode = (constraint.get("aspectMode") or "").upper()
+        cardinality = (constraint.get("itemToAspectCardinality") or "").upper()
+        advanced_data_type = (constraint.get("aspectAdvancedDataType") or "").upper()
+        max_length = self._to_int(constraint.get("aspectMaxLength"))
+        aspect_format = constraint.get("aspectFormat")
+
+        # Default values
+        property_type = Property.TYPES.TEXT
+        allows_unmapped = False
+
+        if mode == "FREE_TEXT" and advanced_data_type == "NUMERIC_RANGE":
+            return Property.TYPES.TEXT, False
+
+        if data_type == "NUMBER":
+            format_lower = (aspect_format or "").lower()
+            if format_lower == "double":
+                return Property.TYPES.FLOAT, False
+            return Property.TYPES.INT, False
+
+        if data_type == "DATE":
+            if self._is_datetime_format(aspect_format):
+                return Property.TYPES.DATETIME, False
+            return Property.TYPES.DATE, False
+
+        if aspect_values:
+            allows_unmapped = mode == "FREE_TEXT"
+            if cardinality == "MULTI":
+                property_type = Property.TYPES.MULTISELECT
+            else:
+                property_type = Property.TYPES.SELECT
+            return property_type, allows_unmapped
+
+        if mode == "FREE_TEXT":
+            if max_length is not None and max_length > 800:
+                return Property.TYPES.DESCRIPTION, False
+            return Property.TYPES.TEXT, False
+
+        return property_type, allows_unmapped
+
+    @staticmethod
+    def _is_datetime_format(aspect_format: Any) -> bool:
+        if not aspect_format or not isinstance(aspect_format, str):
+            return False
+        fmt_lower = aspect_format.lower()
+        return any(token in fmt_lower for token in ("hh", "ss")) or ":" in aspect_format or "t" in fmt_lower or " " in aspect_format
+
+    @staticmethod
+    def _to_int(value: Any) -> Optional[int]:
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            try:
+                return int(value)
+            except ValueError:
+                return None
+        return None
+
+    @staticmethod
+    def _normalize_bool(value: Any) -> Optional[bool]:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lowered = value.lower()
+            if lowered in {"true", "false"}:
+                return lowered == "true"
+        return None
+
+    def _determine_remote_type(self, constraint: dict[str, Any]) -> Optional[str]:
+        variations = self._normalize_bool(constraint.get("aspectEnabledForVariations"))
+        required = self._normalize_bool(constraint.get("aspectRequired"))
+        usage = (constraint.get("aspectUsage") or "").upper()
+
+        if variations:
+            if required:
+                return ProductPropertiesRuleItem.REQUIRED_IN_CONFIGURATOR
+            return ProductPropertiesRuleItem.OPTIONAL_IN_CONFIGURATOR
+
+        if required:
+            if usage in {"", "RECOMMENDED"}:
+                return ProductPropertiesRuleItem.REQUIRED
+            return ProductPropertiesRuleItem.REQUIRED
+
+        if required is False:
+            return ProductPropertiesRuleItem.OPTIONAL
+
+        return ProductPropertiesRuleItem.OPTIONAL

--- a/OneSila/sales_channels/integrations/ebay/tests/tests_factories/test_full_schema.py
+++ b/OneSila/sales_channels/integrations/ebay/tests/tests_factories/test_full_schema.py
@@ -1,0 +1,417 @@
+"""Tests for the EbayProductTypeRuleFactory."""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import patch
+
+from properties.models import Property, ProductPropertiesRuleItem
+from sales_channels.integrations.ebay.models import (
+    EbayProductType,
+    EbayProductTypeItem,
+    EbayProperty,
+    EbaySalesChannelView,
+)
+from sales_channels.integrations.ebay.models.properties import EbayPropertySelectValue
+
+from .mixins import TestCaseEbayMixin
+
+
+def _ensure_stubbed_ebay_rest() -> None:
+    if "ebay_rest" in sys.modules:
+        return
+
+    ebay_rest = types.ModuleType("ebay_rest")
+
+    class _StubAPI:  # pragma: no cover - simple stub to satisfy imports
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    ebay_rest.API = _StubAPI
+    ebay_rest.token = types.ModuleType("ebay_rest.token")
+    sys.modules["ebay_rest"] = ebay_rest
+
+    reference_module = types.ModuleType("ebay_rest.reference")
+
+    class _StubReference:
+        @staticmethod
+        def get_marketplace_id_values() -> dict[str, str]:
+            return {}
+
+    reference_module.Reference = _StubReference
+    sys.modules["ebay_rest.reference"] = reference_module
+
+    api_module = types.ModuleType("ebay_rest.api")
+    sys.modules["ebay_rest.api"] = api_module
+
+    commerce_identity_module = types.ModuleType("ebay_rest.api.commerce_identity")
+    api_module.commerce_identity = commerce_identity_module
+    sys.modules["ebay_rest.api.commerce_identity"] = commerce_identity_module
+
+    commerce_identity_api_module = types.ModuleType("ebay_rest.api.commerce_identity.api")
+    commerce_identity_module.api = commerce_identity_api_module
+    sys.modules["ebay_rest.api.commerce_identity.api"] = commerce_identity_api_module
+
+    user_api_module = types.ModuleType("ebay_rest.api.commerce_identity.api.user_api")
+
+    class _StubUserApi:  # pragma: no cover - simple stub to satisfy imports
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    user_api_module.UserApi = _StubUserApi
+    commerce_identity_api_module.user_api = user_api_module
+    sys.modules["ebay_rest.api.commerce_identity.api.user_api"] = user_api_module
+
+    sell_marketing_module = types.ModuleType("ebay_rest.api.sell_marketing")
+    api_module.sell_marketing = sell_marketing_module
+    sys.modules["ebay_rest.api.sell_marketing"] = sell_marketing_module
+
+    api_client_module = types.ModuleType("ebay_rest.api.sell_marketing.api_client")
+
+    class _StubApiClient:  # pragma: no cover - simple stub to satisfy imports
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    api_client_module.ApiClient = _StubApiClient
+    sell_marketing_module.api_client = api_client_module
+    sys.modules["ebay_rest.api.sell_marketing.api_client"] = api_client_module
+
+    configuration_module = types.ModuleType("ebay_rest.api.sell_marketing.configuration")
+
+    class _StubConfiguration:  # pragma: no cover - simple stub to satisfy imports
+        def __init__(self) -> None:
+            self.access_token: str | None = None
+            self.host: str | None = None
+
+    configuration_module.Configuration = _StubConfiguration
+    sell_marketing_module.configuration = configuration_module
+    sys.modules["ebay_rest.api.sell_marketing.configuration"] = configuration_module
+
+
+@dataclass
+class _DummyEbayAPI:
+    category_response: dict[str, Any]
+    aspects_response: dict[str, Any]
+
+    def commerce_taxonomy_get_category_subtree(self, *, category_id: str, category_tree_id: str) -> dict[str, Any]:
+        return self.category_response
+
+    def commerce_taxonomy_get_item_aspects_for_category(self, *, category_id: str, category_tree_id: str) -> dict[str, Any]:
+        return self.aspects_response
+
+
+class TestEbayProductTypeRuleFactory(TestCaseEbayMixin):
+    """Validate mapping logic for EbayProductTypeRuleFactory."""
+
+    maxDiff = None
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.view = EbaySalesChannelView.objects.create(
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="EBAY_GB",
+            default_category_tree_id="123",
+            is_default=True,
+        )
+
+    def _build_category_response(self) -> dict[str, Any]:
+        return {
+            "categorySubtreeNode": {
+                "category": {
+                    "categoryId": "3197",
+                    "categoryName": "Furniture",
+                }
+            }
+        }
+
+    def _build_aspects_response(self) -> dict[str, Any]:
+        return {
+            "aspects": [
+                {
+                    "localizedAspectName": "Brand",
+                    "aspectConstraint": {
+                        "aspectDataType": "STRING",
+                        "itemToAspectCardinality": "SINGLE",
+                        "aspectMode": "FREE_TEXT",
+                        "aspectRequired": True,
+                        "aspectUsage": "RECOMMENDED",
+                        "aspectEnabledForVariations": False,
+                        "aspectApplicableTo": ["PRODUCT"],
+                    },
+                    "aspectValues": [
+                        {"localizedValue": "Unbranded"},
+                        {"localizedValue": "Apple"},
+                    ],
+                },
+                {
+                    "localizedAspectName": "Color",
+                    "aspectConstraint": {
+                        "aspectDataType": "STRING",
+                        "itemToAspectCardinality": "SINGLE",
+                        "aspectMode": "FREE_TEXT",
+                        "aspectRequired": True,
+                        "aspectUsage": "RECOMMENDED",
+                        "aspectEnabledForVariations": True,
+                        "aspectApplicableTo": ["PRODUCT"],
+                    },
+                    "aspectValues": [
+                        {"localizedValue": "Black"},
+                        {"localizedValue": "Blue"},
+                    ],
+                },
+                {
+                    "localizedAspectName": "Pattern",
+                    "aspectConstraint": {
+                        "aspectDataType": "STRING",
+                        "itemToAspectCardinality": "SINGLE",
+                        "aspectMode": "FREE_TEXT",
+                        "aspectRequired": False,
+                        "aspectUsage": "OPTIONAL",
+                        "aspectEnabledForVariations": True,
+                        "aspectApplicableTo": ["PRODUCT"],
+                    },
+                    "aspectValues": [
+                        {"localizedValue": "Striped"},
+                        {"localizedValue": "Solid"},
+                    ],
+                },
+                {
+                    "localizedAspectName": "Connectivity",
+                    "aspectConstraint": {
+                        "aspectDataType": "STRING",
+                        "itemToAspectCardinality": "MULTI",
+                        "aspectMode": "FREE_TEXT",
+                        "aspectRequired": False,
+                        "aspectUsage": "RECOMMENDED",
+                        "aspectEnabledForVariations": False,
+                        "aspectApplicableTo": ["PRODUCT"],
+                    },
+                    "aspectValues": [
+                        {"localizedValue": "2G"},
+                        {"localizedValue": "3G"},
+                        {"localizedValue": "4G"},
+                    ],
+                },
+                {
+                    "localizedAspectName": "EC Range",
+                    "aspectConstraint": {
+                        "aspectDataType": "STRING",
+                        "itemToAspectCardinality": "SINGLE",
+                        "aspectMode": "SELECTION_ONLY",
+                        "aspectRequired": False,
+                        "aspectUsage": "RECOMMENDED",
+                        "aspectEnabledForVariations": False,
+                        "aspectApplicableTo": ["PRODUCT"],
+                    },
+                    "aspectValues": [{"localizedValue": "A - G"}],
+                },
+                {
+                    "localizedAspectName": "Energy Star",
+                    "aspectConstraint": {
+                        "aspectDataType": "STRING",
+                        "itemToAspectCardinality": "SINGLE",
+                        "aspectMode": "SELECTION_ONLY",
+                        "aspectRequired": False,
+                        "aspectUsage": "RECOMMENDED",
+                        "aspectEnabledForVariations": False,
+                        "aspectApplicableTo": ["PRODUCT"],
+                    },
+                    "aspectValues": [
+                        {"localizedValue": "A"},
+                        {"localizedValue": "B"},
+                        {"localizedValue": "C"},
+                    ],
+                },
+                {
+                    "localizedAspectName": "Detailed Description",
+                    "aspectConstraint": {
+                        "aspectDataType": "STRING",
+                        "aspectMode": "FREE_TEXT",
+                        "aspectRequired": False,
+                        "aspectUsage": "OPTIONAL",
+                        "aspectEnabledForVariations": False,
+                        "aspectApplicableTo": ["PRODUCT"],
+                        "aspectMaxLength": 1000,
+                    },
+                    "aspectValues": [],
+                },
+                {
+                    "localizedAspectName": "Material",
+                    "aspectConstraint": {
+                        "aspectDataType": "STRING",
+                        "aspectMode": "FREE_TEXT",
+                        "aspectRequired": False,
+                        "aspectUsage": "OPTIONAL",
+                        "aspectEnabledForVariations": False,
+                        "aspectApplicableTo": ["PRODUCT"],
+                        "aspectMaxLength": 200,
+                    },
+                },
+                {
+                    "localizedAspectName": "Voltage",
+                    "aspectConstraint": {
+                        "aspectDataType": "STRING",
+                        "aspectMode": "FREE_TEXT",
+                        "aspectRequired": False,
+                        "aspectUsage": "OPTIONAL",
+                        "aspectEnabledForVariations": False,
+                        "aspectApplicableTo": ["PRODUCT"],
+                        "aspectAdvancedDataType": "NUMERIC_RANGE",
+                    },
+                },
+                {
+                    "localizedAspectName": "Screen Size",
+                    "aspectConstraint": {
+                        "aspectDataType": "NUMBER",
+                        "aspectFormat": "double",
+                        "aspectMode": "FREE_TEXT",
+                        "aspectRequired": False,
+                        "aspectUsage": "OPTIONAL",
+                        "aspectEnabledForVariations": False,
+                        "aspectApplicableTo": ["PRODUCT"],
+                    },
+                },
+                {
+                    "localizedAspectName": "Memory",
+                    "aspectConstraint": {
+                        "aspectDataType": "NUMBER",
+                        "aspectFormat": "int32",
+                        "aspectMode": "FREE_TEXT",
+                        "aspectRequired": False,
+                        "aspectUsage": "OPTIONAL",
+                        "aspectEnabledForVariations": False,
+                        "aspectApplicableTo": ["PRODUCT"],
+                    },
+                },
+                {
+                    "localizedAspectName": "Release Date",
+                    "aspectConstraint": {
+                        "aspectDataType": "DATE",
+                        "aspectFormat": "YYYYMMDD",
+                        "aspectMode": "FREE_TEXT",
+                        "aspectRequired": False,
+                        "aspectUsage": "OPTIONAL",
+                        "aspectEnabledForVariations": False,
+                        "aspectApplicableTo": ["PRODUCT"],
+                    },
+                },
+                {
+                    "localizedAspectName": "Warranty Expiration",
+                    "aspectConstraint": {
+                        "aspectDataType": "DATE",
+                        "aspectFormat": "YYYYMMDDHHMMSS",
+                        "aspectMode": "FREE_TEXT",
+                        "aspectRequired": False,
+                        "aspectUsage": "OPTIONAL",
+                        "aspectEnabledForVariations": False,
+                        "aspectApplicableTo": ["PRODUCT"],
+                    },
+                },
+                {
+                    "localizedAspectName": "Item Only",
+                    "aspectConstraint": {
+                        "aspectDataType": "STRING",
+                        "aspectMode": "FREE_TEXT",
+                        "aspectApplicableTo": ["ITEM"],
+                    },
+                },
+            ]
+        }
+
+    def test_run_creates_remote_models_with_expected_mapping(self) -> None:
+        _ensure_stubbed_ebay_rest()
+
+        from sales_channels.integrations.ebay.factories.sales_channels.full_schema import (
+            EbayProductTypeRuleFactory,
+        )
+
+        dummy_api = _DummyEbayAPI(
+            category_response=self._build_category_response(),
+            aspects_response=self._build_aspects_response(),
+        )
+
+        with patch.object(EbayProductTypeRuleFactory, "get_api", return_value=dummy_api):
+            factory = EbayProductTypeRuleFactory(
+                sales_channel=self.sales_channel,
+                view=self.view,
+                category_id="3197",
+                category_tree_id="123",
+            )
+            factory.run()
+
+        product_type = EbayProductType.objects.get(
+            sales_channel=self.sales_channel,
+            remote_id="3197",
+        )
+        self.assertEqual(product_type.name, "Furniture")
+
+        properties = {
+            prop.localized_name: prop
+            for prop in EbayProperty.objects.filter(
+                sales_channel=self.sales_channel,
+                marketplace=self.view,
+            )
+        }
+
+        self.assertNotIn("Item Only", properties)
+        expected_property_names = {
+            "Brand",
+            "Color",
+            "Pattern",
+            "Connectivity",
+            "EC Range",
+            "Energy Star",
+            "Detailed Description",
+            "Material",
+            "Voltage",
+            "Screen Size",
+            "Memory",
+            "Release Date",
+            "Warranty Expiration",
+        }
+        self.assertEqual(set(properties), expected_property_names)
+
+        self.assertEqual(properties["Brand"].type, Property.TYPES.SELECT)
+        self.assertTrue(properties["Brand"].allows_unmapped_values)
+        self.assertEqual(properties["Color"].type, Property.TYPES.SELECT)
+        self.assertEqual(properties["Connectivity"].type, Property.TYPES.MULTISELECT)
+        self.assertEqual(properties["EC Range"].type, Property.TYPES.SELECT)
+        self.assertFalse(properties["EC Range"].allows_unmapped_values)
+        self.assertEqual(properties["Detailed Description"].type, Property.TYPES.DESCRIPTION)
+        self.assertEqual(properties["Material"].type, Property.TYPES.TEXT)
+        self.assertEqual(properties["Voltage"].type, Property.TYPES.TEXT)
+        self.assertEqual(properties["Screen Size"].type, Property.TYPES.FLOAT)
+        self.assertEqual(properties["Memory"].type, Property.TYPES.INT)
+        self.assertEqual(properties["Release Date"].type, Property.TYPES.DATE)
+        self.assertEqual(properties["Warranty Expiration"].type, Property.TYPES.DATETIME)
+        self.assertEqual(properties["Release Date"].value_format, "YYYYMMDD")
+        self.assertEqual(properties["Warranty Expiration"].value_format, "YYYYMMDDHHMMSS")
+
+        brand_values = {
+            value.localized_value
+            for value in EbayPropertySelectValue.objects.filter(remote_property=properties["Brand"])
+        }
+        self.assertEqual(brand_values, {"Unbranded", "Apple"})
+
+        connectivity_values = {
+            value.localized_value
+            for value in EbayPropertySelectValue.objects.filter(remote_property=properties["Connectivity"])
+        }
+        self.assertEqual(connectivity_values, {"2G", "3G", "4G"})
+
+        items = {
+            item.remote_property.localized_name: item.remote_type
+            for item in EbayProductTypeItem.objects.filter(product_type=product_type)
+        }
+
+        self.assertEqual(items["Brand"], ProductPropertiesRuleItem.REQUIRED)
+        self.assertEqual(items["Color"], ProductPropertiesRuleItem.REQUIRED_IN_CONFIGURATOR)
+        self.assertEqual(items["Pattern"], ProductPropertiesRuleItem.OPTIONAL_IN_CONFIGURATOR)
+        self.assertEqual(items["Connectivity"], ProductPropertiesRuleItem.OPTIONAL)
+        self.assertEqual(items["EC Range"], ProductPropertiesRuleItem.OPTIONAL)
+        self.assertEqual(items["Detailed Description"], ProductPropertiesRuleItem.OPTIONAL)
+


### PR DESCRIPTION
## Summary
- build `EbayProductTypeRuleFactory` to fetch category metadata, synchronise eBay product types, aspects, values, and requirement flags
- add a factory test covering property type/value mapping and remote requirement resolution using stubbed API responses

## Testing
- `python OneSila/manage.py test sales_channels.integrations.ebay.tests.tests_factories.test_full_schema` *(fails: PostgreSQL connection refused in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b485c488832eb30e8760d188a4c2