### PR TITLE
Add eBay import tasks and property sync logic

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/__init__.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/__init__.py
@@ -7,6 +7,7 @@ from .sales_channels import (
     EbayProductTypeRuleFactory,
 )
 from .imports import EbaySchemaImportProcessor
+from .sync import EbayPropertyRuleItemSyncFactory
 
 __all__ = [
     'GetEbayRedirectUrlFactory',
@@ -16,4 +17,5 @@ __all__ = [
     'EbaySalesChannelViewPullFactory',
     'EbayProductTypeRuleFactory',
     'EbaySchemaImportProcessor',
+    'EbayPropertyRuleItemSyncFactory',
 ]

--- a/OneSila/sales_channels/integrations/ebay/factories/sync/__init__.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sync/__init__.py
@@ -1,0 +1,7 @@
+"""Synchronization factories for the eBay integration."""
+
+from .rule_sync import EbayPropertyRuleItemSyncFactory
+
+__all__ = [
+    "EbayPropertyRuleItemSyncFactory",
+]

--- a/OneSila/sales_channels/integrations/ebay/factories/sync/rule_sync.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sync/rule_sync.py
@@ -1,0 +1,55 @@
+"""Factories for synchronizing local rule items based on eBay mappings."""
+
+from django.db.models import Max
+
+from properties.models import ProductPropertiesRuleItem
+from sales_channels.integrations.ebay.models import EbayProductTypeItem, EbayProperty
+
+
+class EbayPropertyRuleItemSyncFactory:
+    """Ensure ProductPropertiesRuleItems exist for mapped eBay properties."""
+
+    def __init__(self, ebay_property: EbayProperty):
+        self.ebay_property = ebay_property
+
+    def run(self) -> None:
+        if not self.ebay_property.local_instance:
+            return
+
+        items = EbayProductTypeItem.objects.filter(
+            ebay_property=self.ebay_property,
+            product_type__local_instance__isnull=False,
+        )
+
+        for item in items:
+            rule = item.product_type.local_instance
+            max_sort = (
+                rule.items.aggregate(max_sort=Max("sort_order")).get("max_sort")
+                or 0
+            )
+
+            rule_item, created = ProductPropertiesRuleItem.objects.get_or_create(
+                multi_tenant_company=rule.multi_tenant_company,
+                rule=rule,
+                property=self.ebay_property.local_instance,
+                defaults={
+                    "type": item.remote_type or ProductPropertiesRuleItem.OPTIONAL,
+                    "sort_order": max_sort + 1,
+                },
+            )
+
+            if created:
+                continue
+
+            new_type = item.remote_type or ProductPropertiesRuleItem.OPTIONAL
+            if rule_item.type == new_type:
+                continue
+
+            if (
+                new_type == ProductPropertiesRuleItem.OPTIONAL
+                and rule_item.type != ProductPropertiesRuleItem.OPTIONAL
+            ):
+                continue
+
+            rule_item.type = new_type
+            rule_item.save(update_fields=["type"])

--- a/OneSila/sales_channels/integrations/ebay/models/__init__.py
+++ b/OneSila/sales_channels/integrations/ebay/models/__init__.py
@@ -11,3 +11,4 @@ from .sales_channels import (
     EbaySalesChannel, EbaySalesChannelView, EbayRemoteLanguage
 )
 from .taxes import EbayCurrency
+from .imports import EbaySalesChannelImport

--- a/OneSila/sales_channels/integrations/ebay/models/imports.py
+++ b/OneSila/sales_channels/integrations/ebay/models/imports.py
@@ -1,0 +1,23 @@
+"""eBay-specific import models."""
+
+from django.db import models
+
+from sales_channels.models.imports import SalesChannelImport
+
+
+class EbaySalesChannelImport(SalesChannelImport):
+    """Import process tailored for the eBay integration."""
+
+    TYPE_SCHEMA = "schema"
+    TYPE_PRODUCTS = "products"
+
+    TYPE_CHOICES = [
+        (TYPE_SCHEMA, "Schema"),
+        (TYPE_PRODUCTS, "Products"),
+    ]
+
+    type = models.CharField(max_length=32, choices=TYPE_CHOICES)
+
+    class Meta:
+        verbose_name = "eBay Sales Channel Import"
+        verbose_name_plural = "eBay Sales Channel Imports"

--- a/OneSila/sales_channels/integrations/ebay/receivers.py
+++ b/OneSila/sales_channels/integrations/ebay/receivers.py
@@ -1,6 +1,18 @@
 from core.receivers import receiver
+from core.signals import post_create, post_update
 from sales_channels.signals import refresh_website_pull_models, sales_channel_created
-from sales_channels.integrations.ebay.models import EbaySalesChannel
+from sales_channels.integrations.ebay.models import (
+    EbaySalesChannel,
+    EbayProperty,
+    EbayPropertySelectValue,
+)
+from sales_channels.integrations.ebay.factories.sync import (
+    EbayPropertyRuleItemSyncFactory,
+)
+from sales_channels.integrations.ebay.tasks import (
+    ebay_translate_property_task,
+    ebay_translate_select_value_task,
+)
 
 # @receiver(post_update, sender='app_name.Model')
 # def app_name__model__action__example(sender, instance, **kwargs):
@@ -27,3 +39,76 @@ def sales_channels__ebay__handle_pull(sender, instance, **kwargs):
 
     currencies_factory = EbayRemoteCurrencyPullFactory(sales_channel=instance)
     currencies_factory.run()
+
+
+@receiver(post_create, sender='ebay.EbayProperty')
+@receiver(post_update, sender='ebay.EbayProperty')
+def sales_channels__ebay_property__sync_rule_item(sender, instance: EbayProperty, **kwargs):
+    signal = kwargs.get('signal')
+    if signal == post_update and not instance.is_dirty_field('local_instance', check_relationship=True):
+        return
+    if signal == post_create and not instance.local_instance:
+        return
+
+    factory = EbayPropertyRuleItemSyncFactory(instance)
+    factory.run()
+
+
+@receiver(post_update, sender='ebay.EbayProperty')
+def sales_channels__ebay_property__unmap_select_values(sender, instance: EbayProperty, **kwargs):
+    if not instance.is_dirty_field('local_instance', check_relationship=True):
+        return
+
+    EbayPropertySelectValue.objects.filter(
+        ebay_property=instance,
+        local_instance__isnull=False,
+    ).update(local_instance=None)
+
+
+def _get_remote_language_code(view):
+    if view is None:
+        return None
+
+    remote_language = view.remote_languages.first()
+    return remote_language.local_instance if remote_language else None
+
+
+@receiver(post_create, sender='ebay.EbayProperty')
+@receiver(post_update, sender='ebay.EbayProperty')
+def sales_channels__ebay_property__translate(sender, instance: EbayProperty, **kwargs):
+    signal = kwargs.get('signal')
+    if signal == post_update and not instance.is_dirty_field('localized_name'):
+        return
+
+    remote_lang = _get_remote_language_code(instance.marketplace)
+    company_lang = instance.sales_channel.multi_tenant_company.language
+    remote_name = instance.localized_name or instance.remote_id
+
+    if not remote_name:
+        return
+
+    if not remote_lang or remote_lang == company_lang:
+        if instance.translated_name != remote_name:
+            instance.translated_name = remote_name
+            instance.save(update_fields=['translated_name'])
+        return
+
+    ebay_translate_property_task(instance.id)
+
+
+@receiver(post_create, sender='ebay.EbayPropertySelectValue')
+def sales_channels__ebay_property_select_value__translate(sender, instance: EbayPropertySelectValue, **kwargs):
+    remote_lang = _get_remote_language_code(instance.marketplace)
+    company_lang = instance.sales_channel.multi_tenant_company.language
+    remote_name = instance.localized_value or instance.remote_id
+
+    if not remote_name:
+        return
+
+    if not remote_lang or remote_lang == company_lang:
+        if instance.translated_value != remote_name:
+            instance.translated_value = remote_name
+            instance.save(update_fields=['translated_value'])
+        return
+
+    ebay_translate_select_value_task(instance.id)

--- a/OneSila/sales_channels/integrations/ebay/tasks.py
+++ b/OneSila/sales_channels/integrations/ebay/tasks.py
@@ -1,0 +1,90 @@
+"""Huey tasks for the eBay integration."""
+
+from huey.contrib.djhuey import db_task
+
+from llm.factories.translations import StringTranslationLLM
+
+
+@db_task()
+def ebay_import_db_task(import_process, sales_channel):
+    from sales_channels.integrations.ebay.factories.imports.schema_imports import (
+        EbaySchemaImportProcessor,
+    )
+    from sales_channels.integrations.ebay.models import EbaySalesChannelImport
+
+    import_type = getattr(import_process, "type", EbaySalesChannelImport.TYPE_SCHEMA)
+
+    if import_type == EbaySalesChannelImport.TYPE_SCHEMA:
+        factory = EbaySchemaImportProcessor(
+            import_process=import_process,
+            sales_channel=sales_channel,
+        )
+        factory.run()
+
+
+@db_task()
+def ebay_translate_property_task(property_id: int):
+    from sales_channels.integrations.ebay.models import EbayProperty
+
+    instance = EbayProperty.objects.get(id=property_id)
+
+    remote_name = instance.localized_name or instance.remote_id
+    if not remote_name:
+        return
+
+    remote_language_obj = instance.marketplace.remote_languages.first()
+    remote_lang = remote_language_obj.local_instance if remote_language_obj else None
+    company_lang = instance.sales_channel.multi_tenant_company.language
+
+    if not remote_lang or remote_lang == company_lang:
+        translated = remote_name
+    else:
+        translator = StringTranslationLLM(
+            to_translate=remote_name,
+            from_language_code=remote_lang,
+            to_language_code=company_lang,
+            multi_tenant_company=instance.sales_channel.multi_tenant_company,
+            sales_channel=instance.sales_channel,
+        )
+        try:
+            translated = translator.translate()
+        except Exception:
+            translated = remote_name
+
+    if instance.translated_name != translated:
+        instance.translated_name = translated
+        instance.save(update_fields=["translated_name"])
+
+
+@db_task()
+def ebay_translate_select_value_task(select_value_id: int):
+    from sales_channels.integrations.ebay.models import EbayPropertySelectValue
+
+    instance = EbayPropertySelectValue.objects.get(id=select_value_id)
+
+    remote_name = instance.localized_value or instance.remote_id
+    if not remote_name:
+        return
+
+    remote_language_obj = instance.marketplace.remote_languages.first()
+    remote_lang = remote_language_obj.local_instance if remote_language_obj else None
+    company_lang = instance.sales_channel.multi_tenant_company.language
+
+    if not remote_lang or remote_lang == company_lang:
+        translated = remote_name
+    else:
+        translator = StringTranslationLLM(
+            to_translate=remote_name,
+            from_language_code=remote_lang,
+            to_language_code=company_lang,
+            multi_tenant_company=instance.sales_channel.multi_tenant_company,
+            sales_channel=instance.sales_channel,
+        )
+        try:
+            translated = translator.translate()
+        except Exception:
+            translated = remote_name
+
+    if instance.translated_value != translated:
+        instance.translated_value = translated
+        instance.save(update_fields=["translated_value"])

--- a/OneSila/sales_channels/integrations/ebay/tests/tests_factories/test_sync_factories.py
+++ b/OneSila/sales_channels/integrations/ebay/tests/tests_factories/test_sync_factories.py
@@ -1,0 +1,194 @@
+"""Tests for eBay sync factories and tasks."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from core.tests import TestCase
+from model_bakery import baker
+from properties.models import (
+    ProductPropertiesRule,
+    ProductPropertiesRuleItem,
+    Property,
+    PropertySelectValue,
+    PropertySelectValueTranslation,
+    PropertyTranslation,
+)
+from sales_channels.integrations.ebay.factories.sync import (
+    EbayPropertyRuleItemSyncFactory,
+)
+from sales_channels.integrations.ebay.models import (
+    EbayProductType,
+    EbayProductTypeItem,
+    EbayProperty,
+    EbayPropertySelectValue,
+    EbaySalesChannel,
+    EbaySalesChannelView,
+    EbayRemoteLanguage,
+)
+from sales_channels.integrations.ebay.tasks import (
+    ebay_translate_property_task,
+    ebay_translate_select_value_task,
+)
+
+
+class EbaySyncFactoriesTest(TestCase):
+    """Validate eBay specific sync helpers."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.multi_tenant_company.language = "en"
+        self.multi_tenant_company.save(update_fields=["language"])
+
+        self.sales_channel = EbaySalesChannel.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            hostname="test.ebay",
+            environment=EbaySalesChannel.PRODUCTION,
+        )
+        self.view = EbaySalesChannelView.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="EBAY_GB",
+            name="UK",
+            is_default=True,
+        )
+
+        EbayRemoteLanguage.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            sales_channel_view=self.view,
+            remote_code="de",
+            local_instance="de",
+        )
+
+        self.product_type_property = (
+            Property.objects.filter(
+                is_product_type=True,
+                multi_tenant_company=self.multi_tenant_company,
+            ).first()
+        )
+        if not self.product_type_property:
+            self.product_type_property = Property.objects.create(
+                multi_tenant_company=self.multi_tenant_company,
+                type=Property.TYPES.SELECT,
+                is_product_type=True,
+                internal_name="product_type",
+            )
+            PropertyTranslation.objects.create(
+                multi_tenant_company=self.multi_tenant_company,
+                property=self.product_type_property,
+                language=self.multi_tenant_company.language,
+                name="Product Type",
+            )
+
+        self.product_type_value = (
+            PropertySelectValue.objects.filter(
+                property=self.product_type_property,
+                multi_tenant_company=self.multi_tenant_company,
+            ).first()
+        )
+        if not self.product_type_value:
+            self.product_type_value = PropertySelectValue.objects.create(
+                multi_tenant_company=self.multi_tenant_company,
+                property=self.product_type_property,
+            )
+            PropertySelectValueTranslation.objects.create(
+                multi_tenant_company=self.multi_tenant_company,
+                propertyselectvalue=self.product_type_value,
+                language=self.multi_tenant_company.language,
+                value="Default",
+            )
+
+        self.rule, _ = ProductPropertiesRule.objects.get_or_create(
+            multi_tenant_company=self.multi_tenant_company,
+            product_type=self.product_type_value,
+        )
+
+        self.local_property = baker.make(
+            Property,
+            multi_tenant_company=self.multi_tenant_company,
+            type=Property.TYPES.SELECT,
+            is_product_type=False,
+        )
+        PropertyTranslation.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            property=self.local_property,
+            language=self.multi_tenant_company.language,
+            name="Color",
+        )
+
+    def _create_remote_property(self, *, localized_name: str = "Farbe") -> EbayProperty:
+        return EbayProperty.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            marketplace=self.view,
+            localized_name=localized_name,
+            local_instance=self.local_property,
+        )
+
+    def test_property_rule_item_sync_creates_rule_item(self) -> None:
+        remote_property = self._create_remote_property()
+        product_type = EbayProductType.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            remote_id="123",
+            local_instance=self.rule,
+        )
+        EbayProductTypeItem.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            product_type=product_type,
+            ebay_property=remote_property,
+            remote_type=ProductPropertiesRuleItem.REQUIRED,
+        )
+
+        EbayPropertyRuleItemSyncFactory(remote_property).run()
+
+        rule_item = ProductPropertiesRuleItem.objects.get(
+            rule=self.rule,
+            property=self.local_property,
+        )
+        self.assertEqual(rule_item.type, ProductPropertiesRuleItem.REQUIRED)
+
+    @patch("sales_channels.integrations.ebay.tasks.StringTranslationLLM")
+    def test_translate_property_task_translates_when_languages_differ(self, mock_translator) -> None:
+        mock_translator.return_value.translate.return_value = "Color"
+        remote_property = self._create_remote_property()
+
+        ebay_translate_property_task.call_local(remote_property.id)
+
+        mock_translator.assert_called_once()
+        remote_property.refresh_from_db()
+        self.assertEqual(remote_property.translated_name, "Color")
+
+    @patch("sales_channels.integrations.ebay.tasks.StringTranslationLLM")
+    def test_translate_property_task_copies_when_language_matches(self, mock_translator) -> None:
+        remote_language = self.view.remote_languages.first()
+        remote_language.local_instance = "en"
+        remote_language.save(update_fields=["local_instance"])
+
+        remote_property = self._create_remote_property(localized_name="Color")
+
+        ebay_translate_property_task.call_local(remote_property.id)
+
+        mock_translator.assert_not_called()
+        remote_property.refresh_from_db()
+        self.assertEqual(remote_property.translated_name, "Color")
+
+    @patch("sales_channels.integrations.ebay.tasks.StringTranslationLLM")
+    def test_translate_select_value_task_translates(self, mock_translator) -> None:
+        mock_translator.return_value.translate.return_value = "Black"
+        remote_property = self._create_remote_property()
+        select_value = EbayPropertySelectValue.objects.create(
+            multi_tenant_company=self.multi_tenant_company,
+            sales_channel=self.sales_channel,
+            ebay_property=remote_property,
+            marketplace=self.view,
+            localized_value="Schwarz",
+        )
+
+        ebay_translate_select_value_task.call_local(select_value.id)
+
+        mock_translator.assert_called_once()
+        select_value.refresh_from_db()
+        self.assertEqual(select_value.translated_value, "Black")


### PR DESCRIPTION
## Summary
- add an eBay-specific sales channel import model and Huey tasks for schema imports and translations
- create factories and receivers to sync mapped eBay properties, unmap select values, and trigger translations
- extend shared sales channel receivers and add tests covering the new eBay functionality

## Testing
- `python manage.py test sales_channels.integrations.ebay.tests.tests_factories.test_sync_factories` *(fails: database connection refused in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c457ff88832e968afd9e0afc52ca