### PR TITLE
Refactor remote translation LLM and flows

### DIFF
--- a/OneSila/llm/factories/amazon.py
+++ b/OneSila/llm/factories/amazon.py
@@ -1,14 +1,25 @@
 from .mixins import OpenAIMixin
 
 
-class AmazonSelectValueTranslationLLM(OpenAIMixin):
-    """Translate Amazon property select values using OpenAI."""
+class RemoteSelectValueTranslationLLM(OpenAIMixin):
+    """Translate remote property select values using OpenAI."""
+
     model = "gpt-4.1-nano"
     temperature = 0.3
     max_tokens = 300
 
-    def __init__(self, remote_name, from_language_code="auto", to_language_code="en", property_name=None, property_code=None):
+    def __init__(
+        self,
+        *,
+        integration_label: str,
+        remote_name: str,
+        from_language_code: str = "auto",
+        to_language_code: str = "en",
+        property_name: str | None = None,
+        property_code: str | None = None,
+    ) -> None:
         super().__init__()
+        self.integration_label = integration_label
         self.remote_name = remote_name
         self.from_language_code = from_language_code
         self.to_language_code = to_language_code
@@ -16,7 +27,7 @@ class AmazonSelectValueTranslationLLM(OpenAIMixin):
         self.property_code = property_code
 
     @property
-    def system_prompt(self):
+    def system_prompt(self) -> str:
         return (
             "You are translating e-commerce property values. "
             "Do not translate product codes, model numbers, color codes, or other alphanumeric identifiers. "
@@ -25,24 +36,39 @@ class AmazonSelectValueTranslationLLM(OpenAIMixin):
         )
 
     @property
-    def prompt(self):
+    def prompt(self) -> str:
         context_line = ""
         if self.property_name and self.property_code:
             context_line = (
-                f"This value belongs to the amazon product attribute: '{self.property_name}' (code: {self.property_code}).\n"
+                f"This value belongs to the {self.integration_label} product attribute: "
+                f"'{self.property_name}' (code: {self.property_code}).\n"
             )
+        elif self.property_name:
+            context_line = (
+                f"This value belongs to the {self.integration_label} product attribute named "
+                f"'{self.property_name}'.\n"
+            )
+        elif self.property_code:
+            context_line = (
+                f"This value belongs to the {self.integration_label} product attribute with code "
+                f"'{self.property_code}'.\n"
+            )
+
         return (
             f"{context_line}"
-            f"Translate the following Amazon property select value from {self.from_language_code} to {self.to_language_code}:\n"
+            f"Translate the following {self.integration_label} property select value from "
+            f"{self.from_language_code} to {self.to_language_code}:\n"
             f"{self.remote_name}\n\n"
             "Rules:\n"
-            "- Do not translate product codes, model numbers, color codes, or any alphanumeric values; output the input exactly as provided.\n"
-            "- Only translate if you are at least 90% confident the translation is correct; otherwise return the original value.\n"
+            "- Do not translate product codes, model numbers, color codes, or any alphanumeric values; "
+            "output the input exactly as provided.\n"
+            "- Only translate if you are at least 90% confident the translation is correct; otherwise return "
+            "the original value.\n"
             "Respond with only the final value, no extra text, no explanation, no punctuation. "
             "Just one word or phrase. If the value is numeric or contains numbers, keep the numbers as digits."
         )
 
-    def translate(self):
+    def translate(self) -> str:
         response = self.openai.responses.create(
             model=self.model,
             instructions=self.system_prompt,
@@ -52,8 +78,78 @@ class AmazonSelectValueTranslationLLM(OpenAIMixin):
                 {
                     "role": "user",
                     "content": [
-                        {"type": "input_text", "text": self.prompt}
-                    ]
+                        {"type": "input_text", "text": self.prompt},
+                    ],
+                }
+            ],
+        )
+        return response.output[0].content[0].text.strip()
+
+
+class RemotePropertyTranslationLLM(OpenAIMixin):
+    """Translate remote property names using OpenAI."""
+
+    model = "gpt-4.1-nano"
+    temperature = 0.3
+    max_tokens = 300
+
+    def __init__(
+        self,
+        *,
+        integration_label: str,
+        remote_name: str,
+        from_language_code: str = "auto",
+        to_language_code: str = "en",
+        remote_identifier: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.integration_label = integration_label
+        self.remote_name = remote_name
+        self.from_language_code = from_language_code
+        self.to_language_code = to_language_code
+        self.remote_identifier = remote_identifier
+
+    @property
+    def system_prompt(self) -> str:
+        return (
+            "You are translating e-commerce property names. "
+            "Do not translate product codes, model numbers, or other alphanumeric identifiers. "
+            "If the input appears to be such a code, return it exactly as provided. "
+            "If you are less than 90% confident in the translation, return the original value. Output only the final value."
+        )
+
+    @property
+    def prompt(self) -> str:
+        identifier_line = ""
+        if self.remote_identifier:
+            identifier_line = (
+                f"This property has the identifier '{self.remote_identifier}' in {self.integration_label}.\n"
+            )
+
+        return (
+            f"{identifier_line}"
+            f"Translate the following {self.integration_label} property name from {self.from_language_code} "
+            f"to {self.to_language_code}:\n"
+            f"{self.remote_name}\n\n"
+            "Rules:\n"
+            "- Preserve any product codes, model numbers, or alphanumeric identifiers exactly as provided.\n"
+            "- Only translate if you are at least 90% confident the translation is correct; otherwise return "
+            "the original value.\n"
+            "Respond with only the final name, without explanations or additional text."
+        )
+
+    def translate(self) -> str:
+        response = self.openai.responses.create(
+            model=self.model,
+            instructions=self.system_prompt,
+            temperature=self.temperature,
+            max_output_tokens=self.max_tokens,
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": self.prompt},
+                    ],
                 }
             ],
         )

--- a/OneSila/llm/flows/remote_translations.py
+++ b/OneSila/llm/flows/remote_translations.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Sequence
+
+from llm.factories.amazon import (
+    RemotePropertyTranslationLLM,
+    RemoteSelectValueTranslationLLM,
+)
+
+
+class BaseRemoteTranslationFlow:
+    """Shared logic to translate remote entities using LLMs."""
+
+    translator_class = None
+
+    def __init__(
+        self,
+        *,
+        instance: Any,
+        integration_label: str,
+        remote_name_fields: Iterable[Any] | Any,
+        translation_field: str,
+        remote_language_getter: Callable[[Any], str | None] | None = None,
+        target_language_getter: Callable[[Any], str | None] | None = None,
+    ) -> None:
+        self.instance = instance
+        self.integration_label = integration_label
+        self.remote_name_fields = remote_name_fields
+        self.translation_field = translation_field
+        self.remote_language_getter = remote_language_getter or self._default_remote_language_getter
+        self.target_language_getter = target_language_getter or self._default_target_language_getter
+
+    def flow(self) -> str | None:
+        remote_text = self._get_remote_text()
+        if not remote_text:
+            return None
+
+        remote_lang = self._get_remote_language()
+        target_lang = self._get_target_language()
+
+        translated = self._translate(remote_text, remote_lang, target_lang)
+        self._persist_translation(translated)
+        return translated
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _get_remote_text(self) -> str | None:
+        fields = self.remote_name_fields
+        if isinstance(fields, (str, tuple)):
+            fields_to_check: Sequence[Any] = (fields,) if isinstance(fields, str) else fields
+        elif isinstance(fields, Iterable):
+            fields_to_check = tuple(fields)
+        else:
+            fields_to_check = (fields,)
+
+        for field in fields_to_check:
+            value = self._resolve_attribute(field)
+            if value:
+                return value
+        return None
+
+    def _get_remote_language(self) -> str | None:
+        getter = self.remote_language_getter
+        return getter(self.instance) if callable(getter) else getter
+
+    def _get_target_language(self) -> str | None:
+        getter = self.target_language_getter
+        return getter(self.instance) if callable(getter) else getter
+
+    def _translate(self, remote_text: str, remote_lang: str | None, target_lang: str | None) -> str:
+        if not remote_lang or not target_lang or remote_lang == target_lang:
+            return remote_text
+
+        translator = self._build_translator(remote_text, remote_lang, target_lang)
+        try:
+            return translator.translate()
+        except Exception:
+            return remote_text
+
+    def _build_translator(self, remote_text: str, remote_lang: str, target_lang: str):
+        if self.translator_class is None:
+            raise ValueError("translator_class must be defined for the flow")
+
+        kwargs = self._translator_kwargs(remote_text, remote_lang, target_lang)
+        return self.translator_class(**kwargs)
+
+    def _translator_kwargs(self, remote_text: str, remote_lang: str, target_lang: str) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _persist_translation(self, translated: str) -> None:
+        current_value = getattr(self.instance, self.translation_field, None)
+        if current_value != translated:
+            setattr(self.instance, self.translation_field, translated)
+            self.instance.save(update_fields=[self.translation_field])
+
+    def _resolve_attribute(self, attr_path: Any) -> Any:
+        if attr_path is None:
+            return None
+
+        if callable(attr_path):
+            return attr_path(self.instance)
+
+        value = self.instance
+
+        if isinstance(attr_path, str):
+            parts = attr_path.split(".")
+        elif isinstance(attr_path, (list, tuple)):
+            parts = list(attr_path)
+        else:
+            return getattr(value, attr_path, None)
+
+        for part in parts:
+            if value is None:
+                return None
+            value = getattr(value, part, None)
+        return value
+
+    @staticmethod
+    def _default_remote_language_getter(instance: Any) -> str | None:
+        marketplace = getattr(instance, "marketplace", None)
+        if marketplace is None:
+            return None
+
+        remote_languages = getattr(marketplace, "remote_languages", None)
+        if remote_languages is None:
+            return None
+
+        remote_language_obj = remote_languages.first()
+        if not remote_language_obj:
+            return None
+
+        return getattr(remote_language_obj, "local_instance", None)
+
+    @staticmethod
+    def _default_target_language_getter(instance: Any) -> str | None:
+        sales_channel = getattr(instance, "sales_channel", None)
+        if sales_channel is None:
+            return None
+
+        company = getattr(sales_channel, "multi_tenant_company", None)
+        if company is None:
+            return None
+
+        return getattr(company, "language", None)
+
+
+class TranslateRemoteSelectValueFlow(BaseRemoteTranslationFlow):
+    """Translate remote property select values and persist the result."""
+
+    translator_class = RemoteSelectValueTranslationLLM
+
+    def __init__(
+        self,
+        *,
+        instance: Any,
+        integration_label: str,
+        remote_name_fields: Iterable[Any] | Any,
+        translation_field: str,
+        property_name_attr: Any | None = None,
+        property_code_attr: Any | None = None,
+        remote_language_getter: Callable[[Any], str | None] | None = None,
+        target_language_getter: Callable[[Any], str | None] | None = None,
+    ) -> None:
+        super().__init__(
+            instance=instance,
+            integration_label=integration_label,
+            remote_name_fields=remote_name_fields,
+            translation_field=translation_field,
+            remote_language_getter=remote_language_getter,
+            target_language_getter=target_language_getter,
+        )
+        self.property_name_attr = property_name_attr
+        self.property_code_attr = property_code_attr
+
+    def _translator_kwargs(self, remote_text: str, remote_lang: str, target_lang: str) -> dict[str, Any]:
+        return {
+            "integration_label": self.integration_label,
+            "remote_name": remote_text,
+            "from_language_code": remote_lang,
+            "to_language_code": target_lang,
+            "property_name": self._resolve_attribute(self.property_name_attr),
+            "property_code": self._resolve_attribute(self.property_code_attr),
+        }
+
+
+class TranslateRemotePropertyFlow(BaseRemoteTranslationFlow):
+    """Translate remote property names and persist the result."""
+
+    translator_class = RemotePropertyTranslationLLM
+
+    def __init__(
+        self,
+        *,
+        instance: Any,
+        integration_label: str,
+        remote_name_fields: Iterable[Any] | Any,
+        translation_field: str,
+        remote_identifier_attr: Any | None = None,
+        remote_language_getter: Callable[[Any], str | None] | None = None,
+        target_language_getter: Callable[[Any], str | None] | None = None,
+    ) -> None:
+        super().__init__(
+            instance=instance,
+            integration_label=integration_label,
+            remote_name_fields=remote_name_fields,
+            translation_field=translation_field,
+            remote_language_getter=remote_language_getter,
+            target_language_getter=target_language_getter,
+        )
+        self.remote_identifier_attr = remote_identifier_attr
+
+    def _translator_kwargs(self, remote_text: str, remote_lang: str, target_lang: str) -> dict[str, Any]:
+        return {
+            "integration_label": self.integration_label,
+            "remote_name": remote_text,
+            "from_language_code": remote_lang,
+            "to_language_code": target_lang,
+            "remote_identifier": self._resolve_attribute(self.remote_identifier_attr),
+        }

--- a/OneSila/sales_channels/integrations/amazon/receivers.py
+++ b/OneSila/sales_channels/integrations/amazon/receivers.py
@@ -32,7 +32,7 @@ from sales_channels.integrations.amazon.tasks import (
 from sales_channels.integrations.amazon.constants import (
     AMAZON_SELECT_VALUE_TRANSLATION_IGNORE_CODES,
 )
-from llm.factories.amazon import AmazonSelectValueTranslationLLM  # noqa: F401
+from llm.factories.amazon import RemoteSelectValueTranslationLLM  # noqa: F401
 from imports_exports.signals import import_success
 from sales_channels.integrations.amazon.factories.imports.products_imports import AmazonConfigurableVariationsFactory
 from sales_channels.integrations.amazon.flows.tasks_runner import run_single_amazon_product_task_flow

--- a/OneSila/sales_channels/integrations/amazon/tasks.py
+++ b/OneSila/sales_channels/integrations/amazon/tasks.py
@@ -77,7 +77,7 @@ def amazon_translate_select_value_task(select_value_id: int):
     from sales_channels.integrations.amazon.constants import (
         AMAZON_SELECT_VALUE_TRANSLATION_IGNORE_CODES,
     )
-    from llm.factories.amazon import AmazonSelectValueTranslationLLM
+    from llm.factories.amazon import RemoteSelectValueTranslationLLM
 
     instance = AmazonPropertySelectValue.objects.get(id=select_value_id)
 
@@ -92,7 +92,8 @@ def amazon_translate_select_value_task(select_value_id: int):
     elif not remote_lang or remote_lang == company_lang:
         translated = remote_name
     else:
-        translator = AmazonSelectValueTranslationLLM(
+        translator = RemoteSelectValueTranslationLLM(
+            integration_label="Amazon",
             remote_name=remote_name,
             from_language_code=remote_lang,
             to_language_code=company_lang,

--- a/OneSila/sales_channels/integrations/ebay/tasks.py
+++ b/OneSila/sales_channels/integrations/ebay/tasks.py
@@ -2,7 +2,10 @@
 
 from huey.contrib.djhuey import db_task
 
-from llm.factories.translations import StringTranslationLLM
+from llm.flows.remote_translations import (
+    TranslateRemotePropertyFlow,
+    TranslateRemoteSelectValueFlow,
+)
 
 
 @db_task()
@@ -27,33 +30,14 @@ def ebay_translate_property_task(property_id: int):
     from sales_channels.integrations.ebay.models import EbayProperty
 
     instance = EbayProperty.objects.get(id=property_id)
-
-    remote_name = instance.localized_name or instance.remote_id
-    if not remote_name:
-        return
-
-    remote_language_obj = instance.marketplace.remote_languages.first()
-    remote_lang = remote_language_obj.local_instance if remote_language_obj else None
-    company_lang = instance.sales_channel.multi_tenant_company.language
-
-    if not remote_lang or remote_lang == company_lang:
-        translated = remote_name
-    else:
-        translator = StringTranslationLLM(
-            to_translate=remote_name,
-            from_language_code=remote_lang,
-            to_language_code=company_lang,
-            multi_tenant_company=instance.sales_channel.multi_tenant_company,
-            sales_channel=instance.sales_channel,
-        )
-        try:
-            translated = translator.translate()
-        except Exception:
-            translated = remote_name
-
-    if instance.translated_name != translated:
-        instance.translated_name = translated
-        instance.save(update_fields=["translated_name"])
+    flow = TranslateRemotePropertyFlow(
+        instance=instance,
+        integration_label="eBay",
+        remote_name_fields=("localized_name", "remote_id"),
+        translation_field="translated_name",
+        remote_identifier_attr="remote_id",
+    )
+    flow.flow()
 
 
 @db_task()
@@ -61,30 +45,12 @@ def ebay_translate_select_value_task(select_value_id: int):
     from sales_channels.integrations.ebay.models import EbayPropertySelectValue
 
     instance = EbayPropertySelectValue.objects.get(id=select_value_id)
-
-    remote_name = instance.localized_value or instance.remote_id
-    if not remote_name:
-        return
-
-    remote_language_obj = instance.marketplace.remote_languages.first()
-    remote_lang = remote_language_obj.local_instance if remote_language_obj else None
-    company_lang = instance.sales_channel.multi_tenant_company.language
-
-    if not remote_lang or remote_lang == company_lang:
-        translated = remote_name
-    else:
-        translator = StringTranslationLLM(
-            to_translate=remote_name,
-            from_language_code=remote_lang,
-            to_language_code=company_lang,
-            multi_tenant_company=instance.sales_channel.multi_tenant_company,
-            sales_channel=instance.sales_channel,
-        )
-        try:
-            translated = translator.translate()
-        except Exception:
-            translated = remote_name
-
-    if instance.translated_value != translated:
-        instance.translated_value = translated
-        instance.save(update_fields=["translated_value"])
+    flow = TranslateRemoteSelectValueFlow(
+        instance=instance,
+        integration_label="eBay",
+        remote_name_fields=("localized_value", "remote_id"),
+        translation_field="translated_value",
+        property_name_attr="ebay_property.localized_name",
+        property_code_attr="ebay_property.remote_id",
+    )
+    flow.flow()

--- a/OneSila/sales_channels/integrations/ebay/tests/tests_factories/test_sync_factories.py
+++ b/OneSila/sales_channels/integrations/ebay/tests/tests_factories/test_sync_factories.py
@@ -150,7 +150,7 @@ class EbaySyncFactoriesTest(TestCase):
         )
         self.assertEqual(rule_item.type, ProductPropertiesRuleItem.REQUIRED)
 
-    @patch("sales_channels.integrations.ebay.tasks.StringTranslationLLM")
+    @patch("llm.flows.remote_translations.RemotePropertyTranslationLLM")
     def test_translate_property_task_translates_when_languages_differ(self, mock_translator) -> None:
         mock_translator.return_value.translate.return_value = "Color"
         remote_property = self._create_remote_property()
@@ -161,7 +161,7 @@ class EbaySyncFactoriesTest(TestCase):
         remote_property.refresh_from_db()
         self.assertEqual(remote_property.translated_name, "Color")
 
-    @patch("sales_channels.integrations.ebay.tasks.StringTranslationLLM")
+    @patch("llm.flows.remote_translations.RemotePropertyTranslationLLM")
     def test_translate_property_task_copies_when_language_matches(self, mock_translator) -> None:
         remote_language = self.view.remote_languages.first()
         remote_language.local_instance = "en"
@@ -175,7 +175,7 @@ class EbaySyncFactoriesTest(TestCase):
         remote_property.refresh_from_db()
         self.assertEqual(remote_property.translated_name, "Color")
 
-    @patch("sales_channels.integrations.ebay.tasks.StringTranslationLLM")
+    @patch("llm.flows.remote_translations.RemoteSelectValueTranslationLLM")
     def test_translate_select_value_task_translates(self, mock_translator) -> None:
         mock_translator.return_value.translate.return_value = "Black"
         remote_property = self._create_remote_property()


### PR DESCRIPTION
## Summary
- generalize the Amazon translation factory into reusable remote select-value and property translators
- introduce remote translation flows to centralize marketplace translation logic
- update Amazon/eBay translation tasks and unit tests to rely on the new translators and flows

## Testing
- python OneSila/manage.py test sales_channels.integrations.ebay.tests.tests_factories.test_sync_factories *(fails: ModuleNotFoundError: No module named 'ebay_rest')*

------
https://chatgpt.com/codex/tasks/task_e_68c9ca6de090832e846073b27c47ab4f