### PR TITLE
Refactor eBay property defaults into constants

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/constants.py
+++ b/OneSila/sales_channels/integrations/ebay/constants.py
@@ -1,0 +1,85 @@
+from django.utils.translation import gettext_lazy as _
+
+from properties.models import Property
+
+
+EBAY_INTERNAL_PROPERTY_DEFAULTS = [
+    {
+        'code': 'condition',
+        'label': _("Condition"),
+        'type': Property.TYPES.SELECT,
+        'is_root': True,
+    },
+    {
+        'code': 'packageWeightAndSize__dimensions__length',
+        'label': _("Package Length"),
+        'type': Property.TYPES.FLOAT,
+        'is_root': True,
+    },
+    {
+        'code': 'packageWeightAndSize__dimensions__width',
+        'label': _("Package Width"),
+        'type': Property.TYPES.FLOAT,
+        'is_root': True,
+    },
+    {
+        'code': 'packageWeightAndSize__dimensions__height',
+        'label': _("Package Height"),
+        'type': Property.TYPES.FLOAT,
+        'is_root': True,
+    },
+    {
+        'code': 'packageWeightAndSize__weight__value',
+        'label': _("Package Weight"),
+        'type': Property.TYPES.FLOAT,
+        'is_root': True,
+    },
+    {
+        'code': 'packageWeightAndSize__packageType',
+        'label': _("eBay Package Type"),
+        'type': Property.TYPES.SELECT,
+        'is_root': True,
+    },
+    {
+        'code': 'isbn',
+        'label': _("International Standard Book Number"),
+        'type': Property.TYPES.TEXT,
+        'is_root': False,
+    },
+    {
+        'code': 'brand',
+        'label': _("Brand"),
+        'type': Property.TYPES.SELECT,
+        'is_root': False,
+    },
+    {
+        'code': 'mpn',
+        'label': _("Manufacturer Part Number"),
+        'type': Property.TYPES.TEXT,
+        'is_root': False,
+    },
+    {
+        'code': 'upc',
+        'label': _("Universal Product Code"),
+        'type': Property.TYPES.TEXT,
+        'is_root': False,
+    },
+]
+
+
+def default_length_unit_choices():
+    return [
+        {"value": "INCH", "label": _("Inch")},
+        {"value": "FEET", "label": _("Feet")},
+        {"value": "CENTIMETER", "label": _("Centimeter")},
+        {"value": "METER", "label": _("Meter")},
+    ]
+
+
+def default_weight_unit_choices():
+    return [
+        {"value": "POUND", "label": _("Pound")},
+        {"value": "KILOGRAM", "label": _("Kilogram")},
+        {"value": "OUNCE", "label": _("Ounce")},
+        {"value": "GRAM", "label": _("Gram")},
+    ]

--- a/OneSila/sales_channels/integrations/ebay/flows/internal_properties.py
+++ b/OneSila/sales_channels/integrations/ebay/flows/internal_properties.py
@@ -1,0 +1,16 @@
+from sales_channels.integrations.ebay.constants import EBAY_INTERNAL_PROPERTY_DEFAULTS
+from sales_channels.integrations.ebay.models import EbayInternalProperty
+
+
+def ensure_internal_properties_flow(sales_channel):
+    """Ensure default internal properties exist for the given sales channel."""
+    for definition in EBAY_INTERNAL_PROPERTY_DEFAULTS:
+        EbayInternalProperty.objects.get_or_create(
+            sales_channel=sales_channel,
+            code=definition['code'],
+            defaults={
+                'label': definition['label'],
+                'type': definition['type'],
+                'is_root': definition['is_root'],
+            },
+        )

--- a/OneSila/sales_channels/integrations/ebay/models/__init__.py
+++ b/OneSila/sales_channels/integrations/ebay/models/__init__.py
@@ -4,7 +4,7 @@ from .products import (
     EbayMediaThroughProduct, EbayEanCode
 )
 from .properties import (
-    EbayProperty, EbayProductProperty, EbayPropertySelectValue,
+    EbayProperty, EbayInternalProperty, EbayProductProperty, EbayPropertySelectValue,
     EbayProductType, EbayProductTypeItem,
 )
 from .sales_channels import (

--- a/OneSila/sales_channels/integrations/ebay/models/sales_channels.py
+++ b/OneSila/sales_channels/integrations/ebay/models/sales_channels.py
@@ -1,5 +1,9 @@
 from django.utils.translation import gettext_lazy as _
 from core import models
+from sales_channels.integrations.ebay.constants import (
+    default_length_unit_choices,
+    default_weight_unit_choices,
+)
 from sales_channels.models.sales_channels import SalesChannel, SalesChannelView, RemoteLanguage
 import uuid
 
@@ -134,6 +138,31 @@ class EbaySalesChannelView(SalesChannelView):
         default=list,
         blank=True,
         help_text="List of available inventory locations.",
+    )
+
+    # --- Package Measurements ---
+    length_unit = models.CharField(
+        max_length=16,
+        null=True,
+        blank=True,
+        help_text="Selected unit of measure for package dimensions.",
+    )
+    length_unit_choices = models.JSONField(
+        default=default_length_unit_choices,
+        blank=True,
+        help_text="Available units of measure for package dimensions.",
+    )
+
+    weight_unit = models.CharField(
+        max_length=16,
+        null=True,
+        blank=True,
+        help_text="Selected unit of measure for package weight.",
+    )
+    weight_unit_choices = models.JSONField(
+        default=default_weight_unit_choices,
+        blank=True,
+        help_text="Available units of measure for package weight.",
     )
 
     # --- Category Tree ---

--- a/OneSila/sales_channels/integrations/ebay/receivers.py
+++ b/OneSila/sales_channels/integrations/ebay/receivers.py
@@ -6,6 +6,9 @@ from sales_channels.integrations.ebay.models import (
     EbayProperty,
     EbayPropertySelectValue,
 )
+from sales_channels.integrations.ebay.flows.internal_properties import (
+    ensure_internal_properties_flow,
+)
 from sales_channels.integrations.ebay.factories.sync import (
     EbayPropertyRuleItemSyncFactory,
 )
@@ -40,6 +43,8 @@ def sales_channels__ebay__handle_pull(sender, instance, **kwargs):
     currencies_factory = EbayRemoteCurrencyPullFactory(sales_channel=instance)
     currencies_factory.run()
 
+    ensure_internal_properties_flow(instance)
+
 
 @receiver(post_create, sender='ebay.EbayProperty')
 @receiver(post_update, sender='ebay.EbayProperty')
@@ -71,8 +76,6 @@ def _get_remote_language_code(view):
 
     remote_language = view.remote_languages.first()
     return remote_language.local_instance if remote_language else None
-
-
 @receiver(post_create, sender='ebay.EbayProperty')
 @receiver(post_update, sender='ebay.EbayProperty')
 def sales_channels__ebay_property__translate(sender, instance: EbayProperty, **kwargs):

--- a/OneSila/sales_channels/integrations/ebay/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/mutations.py
@@ -4,6 +4,7 @@ from sales_channels.integrations.ebay.schema.types.input import (
     EbaySalesChannelInput,
     EbaySalesChannelPartialInput,
     EbayValidateAuthInput,
+    EbayInternalPropertyPartialInput,
     EbayPropertyPartialInput,
     EbayPropertySelectValuePartialInput,
     EbaySalesChannelViewPartialInput,
@@ -11,6 +12,7 @@ from sales_channels.integrations.ebay.schema.types.input import (
 from sales_channels.integrations.ebay.schema.types.types import (
     EbaySalesChannelType,
     EbayRedirectUrlType,
+    EbayInternalPropertyType,
     EbayPropertyType,
     EbayPropertySelectValueType,
     EbaySalesChannelViewType,
@@ -31,6 +33,7 @@ class EbaySalesChannelMutation:
     update_ebay_sales_channel: EbaySalesChannelType = update(EbaySalesChannelPartialInput)
 
     update_ebay_property: EbayPropertyType = update(EbayPropertyPartialInput)
+    update_ebay_internal_property: EbayInternalPropertyType = update(EbayInternalPropertyPartialInput)
     update_ebay_property_select_value: EbayPropertySelectValueType = update(EbayPropertySelectValuePartialInput)
     update_ebay_sales_channel_view: EbaySalesChannelViewType = update(EbaySalesChannelViewPartialInput)
 

--- a/OneSila/sales_channels/integrations/ebay/schema/queries.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/queries.py
@@ -1,6 +1,7 @@
 from core.schema.core.queries import node, connection, DjangoListConnection, type
 from sales_channels.integrations.ebay.schema.types.types import (
     EbaySalesChannelType,
+    EbayInternalPropertyType,
     EbayPropertyType,
     EbayPropertySelectValueType,
     EbaySalesChannelViewType,
@@ -14,6 +15,9 @@ class EbaySalesChannelsQuery:
 
     ebay_property: EbayPropertyType = node()
     ebay_properties: DjangoListConnection[EbayPropertyType] = connection()
+
+    ebay_internal_property: EbayInternalPropertyType = node()
+    ebay_internal_properties: DjangoListConnection[EbayInternalPropertyType] = connection()
 
     ebay_property_select_value: EbayPropertySelectValueType = node()
     ebay_property_select_values: DjangoListConnection[EbayPropertySelectValueType] = connection()

--- a/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
@@ -4,6 +4,7 @@ from core.schema.core.types.filters import filter, SearchFilterMixin
 from core.schema.core.types.types import auto
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
+    EbayInternalProperty,
     EbayProperty,
     EbayPropertySelectValue,
     EbaySalesChannelView,
@@ -25,6 +26,15 @@ class EbayPropertyFilter(SearchFilterMixin):
     local_instance: Optional[PropertyFilter]
     allow_multiple: auto
     # type: auto
+
+
+@filter(EbayInternalProperty)
+class EbayInternalPropertyFilter(SearchFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]
+    local_instance: Optional[PropertyFilter]
+    code: auto
+    is_root: auto
 
 
 @filter(EbayPropertySelectValue)

--- a/OneSila/sales_channels/integrations/ebay/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/input.py
@@ -1,6 +1,7 @@
 from core.schema.core.types.input import NodeInput, input, partial, strawberry_input
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
+    EbayInternalProperty,
     EbayProperty,
     EbayPropertySelectValue,
     EbaySalesChannelView,
@@ -30,6 +31,16 @@ class EbayPropertyInput:
 
 @partial(EbayProperty, fields="__all__")
 class EbayPropertyPartialInput(NodeInput):
+    pass
+
+
+@input(EbayInternalProperty, fields="__all__")
+class EbayInternalPropertyInput:
+    pass
+
+
+@partial(EbayInternalProperty, fields="__all__")
+class EbayInternalPropertyPartialInput(NodeInput):
     pass
 
 

--- a/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
@@ -2,6 +2,7 @@ from core.schema.core.types.ordering import order
 from core.schema.core.types.types import auto
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
+    EbayInternalProperty,
     EbayProperty,
     EbayPropertySelectValue,
     EbaySalesChannelView,
@@ -15,6 +16,11 @@ class EbaySalesChannelOrder:
 
 @order(EbayProperty)
 class EbayPropertyOrder:
+    id: auto
+
+
+@order(EbayInternalProperty)
+class EbayInternalPropertyOrder:
     id: auto
 
 

--- a/OneSila/sales_channels/integrations/ebay/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/types.py
@@ -10,18 +10,21 @@ from core.schema.core.types.types import (
 )
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
+    EbayInternalProperty,
     EbayProperty,
     EbayPropertySelectValue,
     EbaySalesChannelView,
 )
 from sales_channels.integrations.ebay.schema.types.filters import (
     EbaySalesChannelFilter,
+    EbayInternalPropertyFilter,
     EbayPropertyFilter,
     EbayPropertySelectValueFilter,
     EbaySalesChannelViewFilter,
 )
 from sales_channels.integrations.ebay.schema.types.ordering import (
     EbaySalesChannelOrder,
+    EbayInternalPropertyOrder,
     EbayPropertyOrder,
     EbayPropertySelectValueOrder,
     EbaySalesChannelViewOrder,
@@ -64,6 +67,24 @@ class EbayPropertyType(relay.Node, GetQuerysetMultiTenantMixin):
     select_values: List[Annotated[
         'EbayPropertySelectValueType',
         lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]]
+
+
+@type(
+    EbayInternalProperty,
+    filters=EbayInternalPropertyFilter,
+    order=EbayInternalPropertyOrder,
+    pagination=True,
+    fields="__all__",
+)
+class EbayInternalPropertyType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'EbaySalesChannelType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]
+    local_instance: Optional[Annotated[
+        'PropertyType',
+        lazy("properties.schema.types.types")
     ]]
 
 


### PR DESCRIPTION
## Summary
- add an ebay constants module containing internal property defaults and measurement unit choice helpers
- update eBay models to rely on the shared constants
- move the internal property seeding logic into a dedicated flow and call it from receivers

## Testing
- python -m compileall OneSila/sales_channels/integrations/ebay

------
https://chatgpt.com/codex/tasks/task_e_68c9dad76d2c832e9bec94c38db418eb