### PR TITLE
Refine eBay category suggestion mutation

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/__init__.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/__init__.py
@@ -5,6 +5,7 @@ from .sales_channels import (
     EbayRemoteLanguagePullFactory,
     EbaySalesChannelViewPullFactory,
     EbayProductTypeRuleFactory,
+    EbayCategorySuggestionFactory,
 )
 from .imports import EbaySchemaImportProcessor
 from .sync import EbayPropertyRuleItemSyncFactory
@@ -16,6 +17,7 @@ __all__ = [
     'EbayRemoteLanguagePullFactory',
     'EbaySalesChannelViewPullFactory',
     'EbayProductTypeRuleFactory',
+    'EbayCategorySuggestionFactory',
     'EbaySchemaImportProcessor',
     'EbayPropertyRuleItemSyncFactory',
 ]

--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/__init__.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/__init__.py
@@ -2,6 +2,7 @@ from .oauth import GetEbayRedirectUrlFactory, ValidateEbayAuthFactory
 from .currencies import EbayRemoteCurrencyPullFactory
 from .languages import EbayRemoteLanguagePullFactory
 from .views import EbaySalesChannelViewPullFactory
+from .categories import EbayCategorySuggestionFactory
 from .full_schema import EbayProductTypeRuleFactory
 
 __all__ = [
@@ -11,4 +12,5 @@ __all__ = [
     'EbayRemoteLanguagePullFactory',
     'EbaySalesChannelViewPullFactory',
     'EbayProductTypeRuleFactory',
+    'EbayCategorySuggestionFactory',
 ]

--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/categories.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/categories.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sales_channels.integrations.ebay.factories.mixins import GetEbayAPIMixin
+from sales_channels.integrations.ebay.models.sales_channels import (
+    EbaySalesChannel,
+    EbaySalesChannelView,
+)
+
+
+class EbayCategorySuggestionFactory(GetEbayAPIMixin):
+    """Fetch and normalize eBay category suggestions or trees."""
+
+    def __init__(self, *, view: Any, query: str | None = None) -> None:
+        self.original_view = view
+        self.view = self._resolve_view(view)
+        self.sales_channel = self._resolve_sales_channel(self.view, view)
+        self.query = (query or "").strip()
+        self.api = None
+        self.category_tree_id: str = ""
+        self.categories: list[dict[str, Any]] = []
+        self._resolved_category_tree_id: str | None = None
+        self._raw_payload: Any = {}
+        self._normalized_payload: dict[str, Any] = {}
+
+    def run(self) -> None:
+        self._reset_state()
+        if not self._resolve_context():
+            return
+        if not self._resolve_category_tree_id():
+            return
+        if not self._configure_api():
+            return
+        self._fetch_payload()
+        self._normalize_payload()
+        self._parse_categories()
+        self._finalize_category_tree_id()
+
+    def _reset_state(self) -> None:
+        self.categories = []
+        self.category_tree_id = ""
+        self._resolved_category_tree_id = None
+        self._raw_payload = {}
+        self._normalized_payload = {}
+        self.api = None
+
+    def _resolve_context(self) -> bool:
+        return self.view is not None and self.sales_channel is not None
+
+    def _resolve_category_tree_id(self) -> bool:
+        category_tree_id = getattr(self.view, "default_category_tree_id", None)
+        if not category_tree_id:
+            return False
+
+        self._resolved_category_tree_id = str(category_tree_id)
+        return True
+
+    def _configure_api(self) -> bool:
+        try:
+            self.api = self.get_api()
+        except Exception:
+            self.api = None
+            return False
+
+        return self.api is not None
+
+    def _fetch_payload(self) -> None:
+        if self.api is None or self._resolved_category_tree_id is None:
+            return
+
+        try:
+            if self.query:
+                self._raw_payload = self.api.commerce_taxonomy_get_category_suggestions(
+                    category_tree_id=self._resolved_category_tree_id,
+                    q=self.query,
+                )
+            else:
+                self._raw_payload = self.api.commerce_taxonomy_get_category_tree(
+                    category_tree_id=self._resolved_category_tree_id,
+                )
+        except Exception:
+            self._raw_payload = {}
+
+    def _normalize_payload(self) -> None:
+        self._normalized_payload = self._to_dict(self._raw_payload)
+
+    def _parse_categories(self) -> None:
+        data = self._normalized_payload
+        if self.query:
+            self.categories = self._parse_suggestions(data)
+            return
+
+        categories: list[dict[str, Any]] = []
+        root_node = None
+        if isinstance(data, dict):
+            root_node = data.get("rootCategoryNode") or data.get("root_category_node")
+        if isinstance(root_node, dict):
+            self._traverse_tree(root_node, [], categories)
+        self.categories = categories
+
+    def _finalize_category_tree_id(self) -> None:
+        tree_id = None
+        data = self._normalized_payload
+        if isinstance(data, dict):
+            tree_id = data.get("categoryTreeId") or data.get("category_tree_id")
+        if tree_id is None:
+            tree_id = self._resolved_category_tree_id
+
+        self.category_tree_id = str(tree_id) if tree_id is not None else ""
+
+    def _resolve_view(self, view: Any) -> EbaySalesChannelView | None:
+        if isinstance(view, EbaySalesChannelView):
+            return view
+
+        getter = getattr(view, "get_real_instance", None)
+        if callable(getter):
+            real_view = getter()
+            if isinstance(real_view, EbaySalesChannelView):
+                return real_view
+
+        pk = getattr(view, "pk", None)
+        if pk is not None:
+            return EbaySalesChannelView.objects.filter(pk=pk).first()
+        return None
+
+    def _resolve_sales_channel(
+        self,
+        resolved_view: EbaySalesChannelView | None,
+        original_view: Any,
+    ) -> EbaySalesChannel | None:
+        candidate = None
+        if resolved_view is not None:
+            candidate = getattr(resolved_view, "sales_channel", None)
+        if candidate is None and original_view is not None:
+            candidate = getattr(original_view, "sales_channel", None)
+
+        if isinstance(candidate, EbaySalesChannel):
+            return candidate
+
+        getter = getattr(candidate, "get_real_instance", None)
+        if callable(getter):
+            real_channel = getter()
+            if isinstance(real_channel, EbaySalesChannel):
+                return real_channel
+
+        pk = getattr(candidate, "pk", None)
+        if pk is not None:
+            return EbaySalesChannel.objects.filter(pk=pk).first()
+        return None
+
+    def _to_dict(self, payload: Any) -> dict[str, Any]:
+        if isinstance(payload, dict):
+            return payload
+        to_dict = getattr(payload, "to_dict", None)
+        if callable(to_dict):
+            try:
+                data = to_dict()
+                if isinstance(data, dict):
+                    return data
+            except Exception:
+                return {}
+        return {}
+
+    def _build_entry(
+        self,
+        category: dict[str, Any],
+        path_segments: list[str],
+        leaf: bool,
+    ) -> dict[str, Any] | None:
+        category_id = category.get("categoryId")
+        category_name = category.get("categoryName")
+        if category_id is None or not category_name:
+            return None
+        category_path = " > ".join([segment for segment in path_segments if segment])
+        return {
+            "category_id": str(category_id),
+            "category_name": category_name,
+            "category_path": category_path,
+            "leaf": bool(leaf),
+        }
+
+    def _parse_suggestions(self, data: dict[str, Any]) -> list[dict[str, Any]]:
+        suggestions: list[dict[str, Any]] = []
+        raw_entries = data.get("categorySuggestions") or data.get("category_suggestions") or []
+        for entry in raw_entries:
+            if not isinstance(entry, dict):
+                continue
+            category = entry.get("category") or {}
+            ancestors = entry.get("categoryTreeNodeAncestors") or entry.get("category_tree_node_ancestors") or []
+            path_segments: list[str] = []
+            for ancestor in ancestors:
+                if not isinstance(ancestor, dict):
+                    continue
+                ancestor_category = ancestor.get("category") or {}
+                name = ancestor_category.get("categoryName")
+                if name:
+                    path_segments.append(name)
+            path_segments.append(category.get("categoryName"))
+            suggestion = self._build_entry(category, path_segments, True)
+            if suggestion is not None:
+                suggestions.append(suggestion)
+        return suggestions
+
+    def _traverse_tree(
+        self,
+        node: dict[str, Any],
+        path_segments: list[str],
+        accumulator: list[dict[str, Any]],
+    ) -> None:
+        category = node.get("category") or {}
+        category_id = category.get("categoryId")
+        category_name = category.get("categoryName")
+        current_path = path_segments
+        if category_name:
+            current_path = path_segments + [category_name]
+        leaf = bool(node.get("leafCategoryTreeNode"))
+        if category_id not in (None, "0", 0) and category_name:
+            entry = self._build_entry(category, current_path, leaf)
+            if entry is not None:
+                accumulator.append(entry)
+        children = node.get("childCategoryTreeNodes", []) or []
+        for child in children:
+            if isinstance(child, dict):
+                self._traverse_tree(child, current_path, accumulator)

--- a/OneSila/sales_channels/integrations/ebay/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/types.py
@@ -106,3 +106,17 @@ class EbaySalesChannelViewType(relay.Node, GetQuerysetMultiTenantMixin):
     @field()
     def active(self, info) -> bool:
         return self.sales_channel.active
+
+
+@strawberry_type
+class SuggestedEbayCategoryEntry:
+    category_id: str
+    category_name: str
+    category_path: str
+    leaf: bool
+
+
+@strawberry_type
+class SuggestedEbayCategory:
+    category_tree_id: str
+    categories: List[SuggestedEbayCategoryEntry]


### PR DESCRIPTION
## Summary
- introduce an EbayCategorySuggestionFactory that encapsulates retrieving and parsing category suggestions or the full tree
- update the suggest_ebay_category mutation to rely on the new factory for cleaner logic
- simplify the EbayCategorySuggestionFactory run sequence to directly invoke helper steps without additional control flags

## Testing
- python -m compileall OneSila/sales_channels/integrations/ebay/schema/mutations.py OneSila/sales_channels/integrations/ebay/factories/sales_channels/categories.py

------
https://chatgpt.com/codex/tasks/task_e_68c9cca38334832ebc26e934246422de