### PR TITLE
Record broken import entries incrementally

### DIFF
--- a/OneSila/imports_exports/admin.py
+++ b/OneSila/imports_exports/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from imports_exports.models import MappedImport, ImportReport
+from imports_exports.models import MappedImport, ImportReport, ImportBrokenRecord
 from django.utils.safestring import mark_safe
 import json
 from pygments import highlight
@@ -9,7 +9,6 @@ from pygments.formatters import HtmlFormatter
 @admin.register(MappedImport)
 class MappedImportAdmin(admin.ModelAdmin):
     readonly_fields = ['formatted_broken_records']
-    exclude = ('broken_records',)
 
     def formatted_broken_records(self, instance):
         if not instance.broken_records:
@@ -30,3 +29,57 @@ class MappedImportAdmin(admin.ModelAdmin):
 class ImportReportAdmin(admin.ModelAdmin):
     pass
 
+
+
+@admin.register(ImportBrokenRecord)
+class ImportBrokenRecordAdmin(admin.ModelAdmin):
+    list_display = (
+        'import_process',
+        'import_status',
+        'record_summary',
+        'created_at',
+    )
+    list_filter = (
+        'import_process__status',
+        'import_process__skip_broken_records',
+        'import_process__update_only',
+    )
+    search_fields = (
+        'import_process__name',
+        'record__error',
+        'record__message',
+        'record__code',
+        'record__step',
+    )
+    autocomplete_fields = ['import_process']
+    readonly_fields = ['formatted_record', 'created_at', 'updated_at']
+    ordering = ('-created_at',)
+
+    def import_status(self, obj):
+        return obj.import_process.get_status_display()
+
+    import_status.short_description = 'Import Status'
+
+    def record_summary(self, obj):
+        if not obj.record:
+            return '—'
+        for key in ('error', 'message', 'code', 'step'):
+            value = obj.record.get(key)
+            if value:
+                return value
+        return '—'
+
+    record_summary.short_description = 'Summary'
+
+    def formatted_record(self, instance):
+        if not instance.record:
+            return "—"
+
+        response = json.dumps(instance.record, sort_keys=True, indent=2, ensure_ascii=False)
+        formatter = HtmlFormatter(style='colorful')
+        highlighted = highlight(response, JsonLexer(), formatter)
+
+        style = f"<style>{formatter.get_style_defs()}</style><br>"
+        return mark_safe(style + highlighted.replace('\\n', '<br/>'))
+
+    formatted_record.short_description = 'Broken Record'

--- a/OneSila/imports_exports/decorators.py
+++ b/OneSila/imports_exports/decorators.py
@@ -1,6 +1,6 @@
+import inspect
 import traceback
 from functools import wraps
-import inspect
 
 def handle_import_exception(func):
 
@@ -33,7 +33,7 @@ def handle_import_exception(func):
                     'error': str(e),
                     'traceback': traceback.format_exc(),
                 }
-                self._broken_records.append(record)
+                self._add_broken_record(record=record)
             else:
                 raise
 

--- a/OneSila/imports_exports/helpers.py
+++ b/OneSila/imports_exports/helpers.py
@@ -3,8 +3,7 @@ from django.db import transaction
 from django.db.models import F, Case, When, IntegerField
 from django.db.models.functions import Cast
 
-from sales_channels.integrations.amazon.models import AmazonImportBrokenRecord
-from .models import Import
+from .models import Import, ImportBrokenRecord
 
 
 def increment_processed_records(process_id: int, delta: int = 1) -> None:
@@ -28,7 +27,7 @@ def increment_processed_records(process_id: int, delta: int = 1) -> None:
 def append_broken_record(process_id: int, record: dict) -> None:
     """Safely append a broken record to the import process."""
     imp = Import.objects.get(pk=process_id)
-    AmazonImportBrokenRecord.objects.create(
+    ImportBrokenRecord.objects.create(
         multi_tenant_company=imp.multi_tenant_company,
         import_process=imp,
         record=record,

--- a/OneSila/imports_exports/models.py
+++ b/OneSila/imports_exports/models.py
@@ -70,7 +70,6 @@ class Import(PolymorphicModel, models.Model):
         blank=True,
         help_text="JSON array storing details of records that failed during import."
     )
-
     total_records = models.PositiveIntegerField(
         default=0,
         help_text="Total number of items that this import will process.",
@@ -162,6 +161,25 @@ class Import(PolymorphicModel, models.Model):
 
     class Meta:
         ordering = ['-created_at']
+
+
+class ImportBrokenRecord(models.Model):
+    """Store broken records generated during an import process."""
+
+    import_process = models.ForeignKey(
+        'imports_exports.Import',
+        on_delete=models.CASCADE,
+        related_name='broken_record_entries'
+    )
+    record = models.JSONField(
+        blank=True,
+        help_text="Store broken record that failed during import."
+    )
+
+    class Meta:
+        verbose_name = "Import Broken Record"
+        verbose_name_plural = "Import Broken Records"
+
 
 
 class ImportableModel(PolymorphicModel, models.Model):

--- a/OneSila/imports_exports/tests/tests_factories/tests_mapped_imports.py
+++ b/OneSila/imports_exports/tests/tests_factories/tests_mapped_imports.py
@@ -55,6 +55,7 @@ class MappedImportSkipBrokenRecordsTest(TestCase):
 
         self.assertEqual(mapped_import.status, 'success')
         self.assertEqual(len(mapped_import.broken_records), 1)
+        self.assertEqual(mapped_import.broken_record_entries.count(), 1)
         self.assertIn('step', mapped_import.broken_records[0])
         self.assertIn('error', mapped_import.broken_records[0])
         self.assertIn('traceback', mapped_import.broken_records[0])
@@ -89,4 +90,5 @@ class MappedImportUpdateOnlyBrokenRecordsTest(TestCase):
 
         self.assertEqual(mapped_import.status, 'success')
         self.assertEqual(len(mapped_import.broken_records), 1)
+        self.assertEqual(mapped_import.broken_record_entries.count(), 1)
         self.assertIn('error', mapped_import.broken_records[0])

--- a/OneSila/sales_channels/integrations/magento2/factories/imports/imports.py
+++ b/OneSila/sales_channels/integrations/magento2/factories/imports/imports.py
@@ -559,7 +559,7 @@ class MagentoImportProcessor(TemporaryDisableInspectorSignalsMixin, SalesChannel
             "error": "MagentoPropertySelectValue matching query does not exist.",
         }
 
-        self._broken_records.append(record)
+        self._add_broken_record(record=record)
 
     def register_product_processing_error(self, product: MagentoApiProduct, exc: Exception):
         record = {
@@ -570,7 +570,7 @@ class MagentoImportProcessor(TemporaryDisableInspectorSignalsMixin, SalesChannel
             "traceback": traceback.format_exc(),
         }
 
-        self._broken_records.append(record)
+        self._add_broken_record(record=record)
 
     def get_product_prices(self, product: MagentoApiProduct,
                            currency_product_map=None):


### PR DESCRIPTION
## Summary
- restore the JSON `Import.broken_records` field while keeping the `ImportBrokenRecord` relation for future backfills
- add `_add_broken_record` on the core import mixin to sanitize payloads, persist them through `append_broken_record`, and refresh the JSON snapshot at completion
- route the import exception decorator and Magento factory helpers through the shared `_add_broken_record` path

## Testing
- `python manage.py test imports_exports.tests.tests_factories.tests_mapped_imports -v 2` *(fails: PostgreSQL service is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7d5415f8832e8dc1d29f6520edef

## Summary by Sourcery

Implement incremental tracking of broken import entries by introducing a dedicated ImportBrokenRecord model and helper, while retaining a JSON snapshot of broken_records on the Import model and providing admin support for both formats.

New Features:
- Introduce ImportBrokenRecord model to store broken import records incrementally
- Add Django admin interface for ImportBrokenRecord with formatted JSON views

Enhancements:
- Restore and refresh Import.broken_records JSON field as a snapshot after import completion
- Implement _add_broken_record helper in import mixin to sanitize payloads and persist records immediately
- Route import exception decorator and Magento import factories through the unified _add_broken_record path

Tests:
- Extend tests to assert broken_record_entries relation is populated alongside JSON snapshots