### PR TITLE
Skip Amazon update when no patches

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -541,6 +541,13 @@ class GetAmazonAPIMixin:
             "productType": product_type.product_type_code,
             "patches": patches,
         }
+        if not patches:
+            logger.info(
+                "update_product skipping remote call for sku=%s marketplace_id=%s: no patches generated",
+                sku,
+                marketplace_id,
+            )
+            return None
         logger.info(
             "update_product current attributes:\n%s",
             pprint.pformat(current_attributes),


### PR DESCRIPTION
## Summary
- avoid issuing Amazon patch requests when the generated patch list is empty
- add a regression test covering the skip scenario

## Testing
- python OneSila/manage.py test sales_channels.integrations.amazon.tests.tests_factories.tests_product_factories.AmazonProductFactoriesTest.test_update_product_skips_when_no_patches *(fails: database connection not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caf73eff90832e81c55784976d350c

## Summary by Sourcery

Skip unnecessary Amazon listing update calls when there are no attribute changes and add a regression test to ensure the behavior.

Enhancements:
- Guard update_product to return early and log when no patches are generated

Tests:
- Add test to verify that update_product does not call the Amazon API when there are no patches