### PR TITLE
Simplify remote SKU uniqueness constraint

### DIFF
--- a/OneSila/sales_channels/models/products.py
+++ b/OneSila/sales_channels/models/products.py
@@ -29,9 +29,9 @@ class RemoteProduct(PolymorphicModel, RemoteObjectMixin, models.Model):
         unique_together = (('sales_channel', 'local_instance', 'remote_parent_product'),)
         constraints = [
             UniqueConstraint(
-                fields=['sales_channel', 'remote_sku', 'is_variation'],
+                fields=['sales_channel', 'remote_sku', 'is_variation', 'remote_parent_product'],
                 condition=Q(remote_sku__isnull=False),
-                name='unique_remote_sku_per_channel_if_present'
+                name='unique_remote_sku_per_channel_with_parent_if_present'
             ),
         ]
         verbose_name = 'Remote Product'


### PR DESCRIPTION
## Summary
- collapse the remote SKU uniqueness logic to a single constraint that applies regardless of parent presence

## Testing
- python OneSila/manage.py test sales_channels.tests.tests_models.RemoteProductConstraintTestCase *(fails: PostgreSQL server not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cafffd1444832e9bc490d5a2522e49

## Summary by Sourcery

Simplify remote SKU uniqueness by updating the UniqueConstraint on RemoteProduct to include the remote_parent_product field and adding tests to cover SKU uniqueness scenarios for variations.

Enhancements:
- Expand the UniqueConstraint on RemoteProduct to include remote_parent_product, consolidating SKU uniqueness logic into a single constraint

Tests:
- Add RemoteProductConstraintTestCase to verify variation SKUs can repeat across different parents
- Add test to ensure variation SKUs cannot repeat for the same parent