### PR TITLE
Fix missing Magento product content class attribute

### DIFF
--- a/OneSila/sales_channels/integrations/magento2/factories/imports/imports.py
+++ b/OneSila/sales_channels/integrations/magento2/factories/imports/imports.py
@@ -43,6 +43,7 @@ class MagentoImportProcessor(TemporaryDisableInspectorSignalsMixin, SalesChannel
     remote_ean_code_class = MagentoEanCode
     remote_imageproductassociation_class = MagentoImageProductAssociation
     remote_price_class = MagentoPrice
+    remote_product_content_class = MagentoProductContent
 
     def __init__(self, import_process, sales_channel, language=None):
         super().__init__(import_process, sales_channel, language)


### PR DESCRIPTION
## Summary
- register `remote_product_content_class` on the Magento import processor so translation handling can resolve the remote model class

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb26638d24832e8173d195782b9dcb

## Summary by Sourcery

Bug Fixes:
- Register remote_product_content_class on MagentoImportProcessor to resolve the remote model class for product content