### PR TITLE
Log parameters when duplicate Magento select values found

### DIFF
--- a/OneSila/sales_channels/integrations/magento2/factories/imports/imports.py
+++ b/OneSila/sales_channels/integrations/magento2/factories/imports/imports.py
@@ -510,6 +510,20 @@ class MagentoImportProcessor(TemporaryDisableInspectorSignalsMixin, SalesChannel
                             raise
 
                         continue
+                    except MagentoPropertySelectValue.MultipleObjectsReturned as exc:
+                        params = {
+                            "sales_channel_id": getattr(self.sales_channel, "id", None),
+                            "multi_tenant_company_id": getattr(self.import_process.multi_tenant_company, "id", None),
+                            "remote_property_id": getattr(magento_property, "id", None),
+                            "remote_property_remote_id": getattr(magento_property, "remote_id", None),
+                            "remote_id": magento_value,
+                        }
+                        message = (
+                            "Multiple MagentoPropertySelectValue objects returned for "
+                            f"parameters: {params}"
+                        )
+                        logger.error(message)
+                        raise MagentoPropertySelectValue.MultipleObjectsReturned(message) from exc
 
                 else:  # MULTISELECT
                     select_values_ids = magento_value.split(',')


### PR DESCRIPTION
## Summary
- add defensive handling for MagentoPropertySelectValue queries returning multiple records
- include the parameters used in the query in the raised exception and log entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb31a5ab98832e873f26e54cb37333

## Summary by Sourcery

Enhancements:
- Catch MultipleObjectsReturned for MagentoPropertySelectValue, log the involved parameters, and re-raise the exception with the parameter details for improved diagnostics.