### PR TITLE
Use company language for select value labels

### DIFF
--- a/OneSila/sales_channels/integrations/magento2/factories/imports/imports.py
+++ b/OneSila/sales_channels/integrations/magento2/factories/imports/imports.py
@@ -242,8 +242,26 @@ class MagentoImportProcessor(TemporaryDisableInspectorSignalsMixin, SalesChannel
 
     def get_structured_select_value_data(self, value_data: AttributeOption):
 
+        structured_value = value_data.label
+        translations_dict = getattr(value_data, 'translations', None)
+
+        if translations_dict:
+            preferred_language = getattr(self.multi_tenant_company, 'language', None)
+            if preferred_language:
+                preferred_translation = translations_dict.get(preferred_language)
+                if preferred_translation:
+                    structured_value = preferred_translation
+                else:
+                    first_translation = next(iter(translations_dict.values()), None)
+                    if first_translation:
+                        structured_value = first_translation
+            else:
+                first_translation = next(iter(translations_dict.values()), None)
+                if first_translation:
+                    structured_value = first_translation
+
         structured_data = {
-            'value': value_data.label,
+            'value': structured_value,
         }
 
         if hasattr(value_data, 'translations'):


### PR DESCRIPTION
## Summary
- remove the cached language priority list from the Magento import processor
- choose select value labels using the company language when available, otherwise fall back to the first translation or the admin label

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbeb6a3f30832e82003a4e1e46e7d3

## Summary by Sourcery

Update Magento import processor to use company-preferred language for select value labels and remove the outdated cached language priority list, adding fallbacks to ensure labels are always set.

Enhancements:
- Remove cached language priority list from Magento import processor
- Select attribute option labels using the company’s preferred language with fallback to the first available translation or the default admin label