### PR TITLE
Document focused test command in root guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent Guidelines for OneSilaHeadless
+
+## General Principles
+- Respect the owner's workflow: never create Django migration files unless explicitly requested. The team prefers to run `makemigrations` themselves.
+- Modify only the files that are required for the task. Avoid opportunistic refactors, whitespace changes, or reformatting in unrelated modules.
+- Keep performance in mind. Avoid N+1 queries and ensure GraphQL data access uses `select_related`/`prefetch_related` where needed.
+- Protect secrets: never commit API keys or credentials. Require environment variables for sensitive configuration.
+- Follow the "always kwargs" pattern for Python callables. Define functions with a leading `*` so they only accept keyword arguments.
+- Keep individual source files under ~500 lines. If a file grows beyond this, split it into the conventional folder structure (e.g., `schema/`, `factories/`, `flows/`).
+- Prefer incremental, well-tested changes. Add tests for any meaningful behaviour change; very small tweaks are the only exception. Use decorator-based patching for integrations (e.g., `@patch("sales_channels.integrations.amazon.receivers.create_amazon_product_type_rule_task")`). When adding or updating tests locally, try running them with `./manage.py test -k new_test_name` so only the new or changed cases execute. If a failure is clearly caused by the SQLite-in-container setup (the project runs on PostgreSQL), document the limitation and proceed; otherwise, fix the code or the test before shipping.
+- When defining Strawberry GraphQL types that reference foreign keys, manually add lazy imports such as `product: Optional[Annotated['ProductType', lazy("products.schema.types.types")]]`.
+- Mind concurrency and scale; design solutions that remain efficient as data volume grows.
+
+## Collaboration Notes
+- Our broader documentation lives at https://github.com/OneSila/OneSilaDocs/tree/master. It may be slightly outdated but is useful context.
+- Security and compliance are paramount. Sanitize third-party input and validate payloads from integrations.
+- Pull requests must include:
+  - Summary of change
+  - Related issue (if available)
+  - How it was tested (explicit command list or rationale when tests are not applicable)
+- Agents may generate PR descriptions automatically. Ensure the final message follows the template above.
+
+## Code Organization Conventions
+- Tasks expose flows for asynchronous work. Name them as `app_name__tasks__action` or `app_name__tasks__action__cronjob` and keep decision logic inside flows/factories.
+- Flows should coordinate behaviour without embedding heavy logic in tasks or receivers. Name them clearly (e.g., `StockSyncFlow`).
+- Factories handle deterministic work steps. Helper methods start with `_`, while `work()` orchestrates execution.
+- Signals belong in `signals.py` and receivers in `receivers.py`. Use naming like `app_name__model__signal_name`, import receivers via `AppConfig.ready`, and trigger custom signals (e.g., `sync_failed`) rather than embedding logic in Django's default signals.
+
+## Tooling Expectations
+- Recommended local tooling: `.pre-commit-config.yaml` with `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`, and `autopep8`. Use `setup.cfg` to configure `pycodestyle` (`max-line-length = 160`, ignore `E128`, exclude migrations/venv).
+- Test suites typically run through `coverage run --source='.' manage.py test`; follow up with `coverage report -m` or `coverage html` when validating coverage locally.
+
+Adhering to these guidelines keeps the repo healthy and predictable for everyone contributing to OneSilaHeadless.

--- a/OneSila/imports_exports/factories/AGENTS.md
+++ b/OneSila/imports_exports/factories/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Guidelines for `imports_exports/factories`
+
+## Scope
+Applies to import/export factories under `OneSila/imports_exports/factories/`.
+
+## Property Import Flow
+- `ImportPropertyInstance` must accept either `name` or `internal_name`. Keep heuristics that auto-detect the `type` when omitted.
+- Only update boolean flags (`is_public_information`, `add_to_filters`, `has_image`) when values change; avoid redundant writes.
+- Ensure `translations` payloads create/update the related translation models consistently.
+
+## Property Select Values
+- `ImportPropertySelectValueInstance` can operate on existing properties or `property_data` dictionaries. Reuse `ImportPropertyInstance` to create properties on the fly.
+- Validate dependencies: confirm the associated property exists and is public before creating remote values.
+
+## Product Property Rules
+- `ImportProductPropertiesRuleInstance` manages rule creation and optional nested items; `require_ean_code` defaults to `False`.
+- Nested items are delegated to `ImportProductPropertiesRuleItemInstance`. Support inline property/rule creation via `_data` payloads.
+- Permit updates to `type` and `sort_order` only when values actually change.
+
+## Examples & Testing
+- When in doubt, reference the README payload examples. Mirror those structures in fixtures/tests to ensure factories remain backward compatible.

--- a/OneSila/llm/AGENTS.md
+++ b/OneSila/llm/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent Guidelines for `llm`
+
+## Scope
+Applies to language model utilities under `OneSila/llm/`.
+
+## Development Practices
+- Every change must be covered by tests; this package is experimental but requires safeguards.
+- Keep factory interfaces simple for shell usage (see README examples for `DescriptionGenLLM`, `ShortDescriptionLLM`, `StringTranslationLLM`, and `ProductResearchLLM`).
+- Assume settings like `settings.LANGUAGE_CODE` are available; avoid hardcoded language values.
+- When integrating external services (e.g., replicate.com for background removal), abstract credentials behind environment variables.

--- a/OneSila/products/AGENTS.md
+++ b/OneSila/products/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Guidelines for `products`
+
+## Scope
+Applies to product domain logic.
+
+## Product Model Philosophy
+- Products encompass physical, virtual, bundled, manufacturable, and service offerings. Avoid assumptions that limit logic to shippable goods.
+- Ensure features work for both sellable and non-sellable product variants.
+- When adding behaviour, confirm compatibility across configurables, bundles, manufactured goods, and simple SKUs.

--- a/OneSila/products_inspector/AGENTS.md
+++ b/OneSila/products_inspector/AGENTS.md
@@ -1,0 +1,19 @@
+# Agent Guidelines for `products_inspector`
+
+## Scope
+Applies to all files in `OneSila/products_inspector/`.
+
+## Adding Inspector Block Checkers
+- Define new error codes and block configuration in `constants.py`. Keep error metadata updated in `ERROR_TYPES`.
+- Expose block settings via dictionaries stored alongside existing `blocks` entries.
+- Provide custom `QuerySet` and `Manager` classes for new proxy models, delegating to the core inspector queryset/manager.
+- Implement proxy models that import their block configuration, expose `proxy_filter_fields`, and set meaningful `verbose_name` values.
+
+## Signals and Factories
+- Declare paired success/failure signals for new inspectors, caching when appropriate.
+- Register factories with `InspectorBlockFactoryRegistry` and raise `InspectorBlockFailed` when validation fails.
+- Receivers should refresh inspectors via `inspector_block_refresh.send(...)` following the documented pattern.
+
+## Testing & Frontend Impact
+- Add targeted tests validating the new block's behaviour.
+- Coordinate with frontend teams: add translations for new error codes and update the `errorMap` logic when backend behaviour changes.

--- a/OneSila/sales_channels/factories/orders/AGENTS.md
+++ b/OneSila/sales_channels/factories/orders/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Guidelines for `sales_channels/factories/orders`
+
+## Scope
+Covers factories that pull remote orders/customers/items.
+
+## Periodic Pull Model
+- Use scheduled tasks (not signals) to import orders, customers, and order items from remote platforms.
+- Link remote records to local `Order`, customer, and item models, populating minimal fields such as quantity, price, and `remote_sku`.
+- Keep remote product creation out of scope; focus on syncing transactional data.
+
+## Factory Expectations
+- `RemoteOrderPullFactory` should validate incoming payloads, map addresses/customers, and ensure idempotent creation of order hierarchies.
+- Tests must cover periodic execution and confirm that repeated pulls do not duplicate records.

--- a/OneSila/sales_channels/factories/prices/AGENTS.md
+++ b/OneSila/sales_channels/factories/prices/AGENTS.md
@@ -1,0 +1,12 @@
+# Agent Guidelines for `sales_channels/factories/prices`
+
+## Scope
+Covers remote price factories and signals.
+
+## Signal Triggers
+- Fire `update_remote_price` when price lists are assigned/removed, price list dates change, list items mutate, or direct price/RRP fields update.
+- Use `price_changed` as the aggregation point for promotions. When this signal fires, evaluate whether the product is online before calling the price update factory.
+
+## Implementation Notes
+- Centralize the "is product assigned to channel" check inside the factory handling `update_remote_price`.
+- Ensure periodic promotions trigger exactly once per boundary day (today for start, yesterday for end) to avoid thrashing remote APIs.

--- a/OneSila/sales_channels/factories/products/AGENTS.md
+++ b/OneSila/sales_channels/factories/products/AGENTS.md
@@ -1,0 +1,20 @@
+# Agent Guidelines for `sales_channels/factories/products`
+
+## Scope
+Applies to remote product factories, including content, variations, sync, deletion, and configurator updates.
+
+## Content Synchronisation
+- When `ProductTranslation` objects change, use the `update_remote_product_content` signal to push updates. Ensure the related `RemoteProduct` exists before invoking factories.
+
+## Variation Handling
+- On `ConfigurableVariation` creation, trigger `add_remote_product_variation` and ensure parent products have `SalesChannelViewAssign` links. Handle deletion with `remove_remote_product_variation` using the standard delete flow.
+
+## Product Sync Lifecycle
+- `RemoteProductSyncFactory` mediates create/update logic. Gate execution behind inspector preflight checks and verify required assets (properties, media) are ready.
+- Make the factory subclass-friendly so integrations can override behaviour without duplicating logic.
+
+## Deletion
+- Use `delete_remote_product` when products are removed or marked not for sale. Clean up remote dependencies such as variations and images.
+
+## Configurator Tasks
+- Maintain asynchronous tasks that update configurators when rules, variations, or property metadata change. Ensure they avoid redundant remote calls by checking whether updates are actually required.

--- a/OneSila/sales_channels/factories/properties/AGENTS.md
+++ b/OneSila/sales_channels/factories/properties/AGENTS.md
@@ -1,0 +1,18 @@
+# Agent Guidelines for `sales_channels/factories/properties`
+
+## Scope
+Instructions apply to property-related sales channel factories.
+
+## Remote Property Lifecycle
+- Emit `create_remote_property` only when the first `PropertyTranslation` for a public property is saved. Delay remote creation until names are available.
+- Fire `update_remote_property` when translations change, new translations arrive, or `add_to_filters` toggles.
+- Fire `delete_remote_property` during `pre_delete` or when `is_public_information` becomes `False`.
+
+## Select Values
+- Mirror the property rules for `PropertySelectValueTranslation` events. Ensure the parent property is public before creating select values.
+- Sync image updates through `update_remote_property_select_value` and remove values via `delete_remote_property_select_value` when needed.
+
+## Product Properties
+- Before creating remote product properties, confirm both `RemoteProduct` and `RemoteProperty` exist. Include preflight logic to create dependencies if absent.
+- Keep `create_remote_product_property`, `update_remote_product_property`, and `delete_remote_product_property` signals aligned with the local lifecycle, including translation changes.
+- Handle select/multi-select values by verifying remote select values are present prior to pushing updates.

--- a/OneSila/sales_channels/factories/taxes/AGENTS.md
+++ b/OneSila/sales_channels/factories/taxes/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Guidelines for `sales_channels/factories/taxes`
+
+## Scope
+Applies to VAT/tax-related factory code.
+
+## Signal Discipline
+- `create_remote_vat_rate` should be triggered immediately after a `VatRate` is first saved.
+- `update_remote_vat_rate` should only fire when tracked fields (e.g., `name`, percentages) actually change.
+- Keep remote sync idempotent; repeated updates must not duplicate VAT rates remotely.

--- a/OneSila/sales_channels/integrations/AGENTS.md
+++ b/OneSila/sales_channels/integrations/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Guidelines for `sales_channels/integrations`
+
+## Scope
+These rules cover all integration apps under `sales_channels/integrations/`.
+
+## Integration Delivery Order
+1. Handle authentication first (OAuth or API credential storage).
+2. Build **pull** factories before push flows so downstream syncs have dependable local data.
+3. Confirm core infrastructure: `SalesChannel`, `SalesChannelView`, assignments, and shared test mixins must exist.
+4. Import attributes, media, and other dependencies.
+5. Implement product factories once upstream data is reliable.
+6. Only then wire import factories or additional automation.
+
+## Directory Structure & Scaffolding
+- Each integration is a Django app created under this package. Use the `create_sales_channel_integration` command to scaffold and keep parity with existing channels.
+- Required modules include `apps.py` (with a `ready()` importing receivers), `models.py`, `mixins.py`, `factories/`, `flows/`, `receivers.py`, `tasks.py`, `schema/` (types/input/ordering/filters, queries, mutations), and `tests/`.
+- Maintain layered factories: shared base classes in `sales_channels/factories/`, integration-specific specialisations in the app’s `factories/` folder.
+
+## App Registration
+- Add new integrations to `INSTALLED_APPS` using their dotted path (e.g., `sales_channels.integrations.shopify`).
+- Ensure `AppConfig` names follow the `sales_channels.integrations.<integration>` pattern and define a `ready()` method that imports receivers.
+
+## Implementation Guidelines
+- API mixins encapsulate session/auth setup. Keep them reusable for factories and flows.
+- Mirror remote entities with models living inside the integration app. Keep fields lean but sufficient for sync.
+- Factories should expose `.run()` orchestration, guard against missing prerequisites, and remain idempotent.
+- Write smoke scripts/tests that exercise at least one successful `.run()` call per critical factory.
+- When debugging, verify products are assigned to a `SalesChannelView`; missing assignments are a common silent failure.
+
+## Testing & Credentials
+- Add fixtures or mocks so integration tests can run offline. Patch network calls at the module level (see root guidelines for `@patch(...)` usage).
+- Store API credentials in environment variables—never hardcode secrets.

--- a/OneSila/sales_prices/AGENTS.md
+++ b/OneSila/sales_prices/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Guidelines for `sales_prices`
+
+## Scope
+Covers files under `OneSila/sales_prices/`.
+
+## Notes
+- This module currently lacks detailed documentation. Before implementing changes, inspect existing code to understand active pricing flows.
+- Align naming, folder layout, and separation of responsibilities with the project-wide conventions described in the root `AGENTS.md`.
+- Add regression tests whenever modifying price calculations or list management.

--- a/OneSila/translations/AGENTS.md
+++ b/OneSila/translations/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent Guidelines for `translations`
+
+## Scope
+These instructions apply to all files under `OneSila/translations/`.
+
+## Working Principles
+- Maintain the "loose" translation model. Do not attempt to reintroduce `django-translation` or similar tightly coupled systems.
+- Translation support is implemented via bespoke models; keep schema changes additive and backwards compatible.
+- When enhancing translation logic, favour simple data structures that play nicely with polymorphic models.
+- Ensure new functionality includes tests covering multilingual behaviour and fallbacks.


### PR DESCRIPTION
# Summary
- add explicit guidance in the root AGENTS file to run targeted tests via `./manage.py test -k`
- note the sqlite-vs-postgresql caveat so agents know when failures are environment-related

# Related issue
- N/A

# How it was tested
- Documentation-only change; tests not run

------
https://chatgpt.com/codex/tasks/task_e_68cc63b6a5ac832ea575275ea094afb1