### PR TITLE
Use local session and cache backends for agent

### DIFF
--- a/OneSila/OneSila/settings/agent.py
+++ b/OneSila/OneSila/settings/agent.py
@@ -21,6 +21,15 @@ DATABASES = {
     }
 }
 
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "agent-default",
+    }
+}
+
 # Static/media roots in /tmp
 STATIC_ROOT = os.path.join(tempfile.gettempdir(), "static")
 MEDIA_ROOT = os.path.join(tempfile.gettempdir(), "media")


### PR DESCRIPTION
## Summary
- configure the agent settings to use the database-backed Django session engine instead of the Redis cache
- replace the inherited Redis cache configuration with a local in-memory cache for agent runs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc93a9f480832eab266cb00cbb6f7c

## Summary by Sourcery

Use Django's DB-backed session engine and locmem cache for the agent settings instead of Redis

Enhancements:
- Switch agent session storage to Django's database-backed session engine
- Replace Redis cache with a local in-memory cache for agent runs