### PR TITLE
Add shared mapping mixins and expose eBay mapping state

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/managers.py
+++ b/OneSila/sales_channels/integrations/amazon/managers.py
@@ -1,31 +1,6 @@
 from core.managers import MultiTenantManager, MultiTenantQuerySet
-from django.db.models import BooleanField, Case, Value, When
 from polymorphic.managers import PolymorphicManager, PolymorphicQuerySet
-
-
-class _MappingQuerySetMixin:
-    mapped_field: str
-
-    def annotate_mapping(self):
-        return self.annotate(
-            mapped_locally=Case(
-                When(local_instance__isnull=False, then=Value(True)),
-                default=Value(False),
-                output_field=BooleanField(),
-            ),
-            mapped_remotely=Case(
-                When(**{f"{self.mapped_field}__isnull": False}, then=Value(True)),
-                When(**{f"{self.mapped_field}__exact": ""}, then=Value(False)),
-                default=Value(False),
-                output_field=BooleanField(),
-            ),
-        )
-
-    def filter_mapped_locally(self, value: bool = True):
-        return self.annotate_mapping().filter(mapped_locally=value)
-
-    def filter_mapped_remotely(self, value: bool = True):
-        return self.annotate_mapping().filter(mapped_remotely=value)
+from sales_channels.managers import _MappingManagerMixin, _MappingQuerySetMixin
 
 
 class AmazonPropertyQuerySet(_MappingQuerySetMixin, PolymorphicQuerySet, MultiTenantQuerySet):
@@ -51,19 +26,6 @@ class AmazonPropertySelectValueQuerySet(_MappingQuerySetMixin, MultiTenantQueryS
 
 class AmazonProductTypeQuerySet(_MappingQuerySetMixin, MultiTenantQuerySet):
     mapped_field = "product_type_code"
-
-
-class _MappingManagerMixin:
-    queryset_class = None
-
-    def get_queryset(self):
-        return self.queryset_class(self.model, using=self._db).annotate_mapping()
-
-    def filter_mapped_locally(self, value: bool = True):
-        return self.get_queryset().filter_mapped_locally(value)
-
-    def filter_mapped_remotely(self, value: bool = True):
-        return self.get_queryset().filter_mapped_remotely(value)
 
 
 class AmazonPropertyManager(_MappingManagerMixin, PolymorphicManager, MultiTenantManager):

--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -34,6 +34,11 @@ from properties.schema.types.filters import (
     ProductPropertyFilter,
 )
 from products.schema.types.filters import ProductFilter
+from sales_channels.schema.types.filter_mixins import (
+    DependentMappedLocallyFilterMixin,
+    GeneralMappedLocallyFilterMixin,
+    GeneralMappedRemotelyFilterMixin,
+)
 from sales_channels.schema.types.filters import (
     SalesChannelFilter,
     SalesChannelViewFilter,
@@ -58,72 +63,34 @@ class AmazonSalesChannelViewFilter(SearchFilterMixin):
 
 
 @filter(AmazonProperty)
-class AmazonPropertyFilter(SearchFilterMixin):
+class AmazonPropertyFilter(SearchFilterMixin, DependentMappedLocallyFilterMixin, GeneralMappedRemotelyFilterMixin):
     id: auto
     sales_channel: Optional[SalesChannelFilter]
     local_instance: Optional[PropertyFilter]
     allows_unmapped_values: auto
     type: auto
 
-    @custom_filter
-    def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
-
-        if value not in (None, UNSET):
-            if isinstance(queryset, AmazonPropertyQuerySet):
-                queryset = queryset.filter_mapped_locally(value)
-            elif isinstance(queryset, AmazonPropertySelectValueQuerySet):
-                queryset = queryset.filter_amazon_property_mapped_locally(value)
-            else:
-                raise Exception(f"Unexpected queryset class: {type(queryset)}")
-
-        return queryset, Q()
-
-    @custom_filter
-    def mapped_remotely(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
-        if value not in (None, UNSET):
-            queryset = queryset.filter_mapped_remotely(value)
-        return queryset, Q()
+    mapped_locally_querysets = (
+        (AmazonPropertyQuerySet, "filter_mapped_locally"),
+        (AmazonPropertySelectValueQuerySet, "filter_amazon_property_mapped_locally"),
+    )
 
 
 @filter(AmazonPropertySelectValue)
-class AmazonPropertySelectValueFilter(SearchFilterMixin):
+class AmazonPropertySelectValueFilter(SearchFilterMixin, GeneralMappedLocallyFilterMixin, GeneralMappedRemotelyFilterMixin):
     id: auto
     sales_channel: Optional[SalesChannelFilter]
     amazon_property: Optional[AmazonPropertyFilter]
     local_instance: Optional[PropertySelectValueFilter]
     marketplace: Optional[SalesChannelViewFilter]
 
-    @custom_filter
-    def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
-        if value not in (None, UNSET):
-            queryset = queryset.filter_mapped_locally(value)
-        return queryset, Q()
-
-    @custom_filter
-    def mapped_remotely(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
-        if value not in (None, UNSET):
-            queryset = queryset.filter_mapped_remotely(value)
-        return queryset, Q()
-
 
 @filter(AmazonProductType)
-class AmazonProductTypeFilter(SearchFilterMixin):
+class AmazonProductTypeFilter(SearchFilterMixin, GeneralMappedLocallyFilterMixin, GeneralMappedRemotelyFilterMixin):
     id: auto
     product_type_code: auto
     sales_channel: Optional[SalesChannelFilter]
     local_instance: Optional[ProductPropertiesRuleFilter]
-
-    @custom_filter
-    def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
-        if value not in (None, UNSET):
-            queryset = queryset.filter_mapped_locally(value)
-        return queryset, Q()
-
-    @custom_filter
-    def mapped_remotely(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
-        if value not in (None, UNSET):
-            queryset = queryset.filter_mapped_remotely(value)
-        return queryset, Q()
 
 
 @filter(AmazonProductTypeItem)

--- a/OneSila/sales_channels/integrations/ebay/managers.py
+++ b/OneSila/sales_channels/integrations/ebay/managers.py
@@ -1,0 +1,50 @@
+from core.managers import MultiTenantManager, MultiTenantQuerySet
+from django.db.models import BooleanField, Case, Value, When
+from polymorphic.managers import PolymorphicManager, PolymorphicQuerySet
+
+from sales_channels.managers import _MappingManagerMixin, _MappingQuerySetMixin
+
+
+class EbayPropertyQuerySet(_MappingQuerySetMixin, PolymorphicQuerySet, MultiTenantQuerySet):
+    mapped_field = "remote_id"
+
+
+class EbayInternalPropertyQuerySet(_MappingQuerySetMixin, MultiTenantQuerySet):
+    mapped_field = "remote_id"
+
+
+class EbayPropertySelectValueQuerySet(_MappingQuerySetMixin, MultiTenantQuerySet):
+    mapped_field = "remote_id"
+
+    def annotate_mapping(self):
+        base = super().annotate_mapping()
+        return base.annotate(
+            ebay_property_mapped_locally=Case(
+                When(ebay_property__local_instance__isnull=False, then=Value(True)),
+                default=Value(False),
+                output_field=BooleanField(),
+            )
+        )
+
+    def filter_ebay_property_mapped_locally(self, value: bool = True):
+        return self.annotate_mapping().filter(ebay_property_mapped_locally=value)
+
+
+class EbayProductTypeQuerySet(_MappingQuerySetMixin, MultiTenantQuerySet):
+    mapped_field = "remote_id"
+
+
+class EbayPropertyManager(_MappingManagerMixin, PolymorphicManager, MultiTenantManager):
+    queryset_class = EbayPropertyQuerySet
+
+
+class EbayInternalPropertyManager(_MappingManagerMixin, MultiTenantManager):
+    queryset_class = EbayInternalPropertyQuerySet
+
+
+class EbayPropertySelectValueManager(_MappingManagerMixin, MultiTenantManager):
+    queryset_class = EbayPropertySelectValueQuerySet
+
+
+class EbayProductTypeManager(_MappingManagerMixin, MultiTenantManager):
+    queryset_class = EbayProductTypeQuerySet

--- a/OneSila/sales_channels/integrations/ebay/models/properties.py
+++ b/OneSila/sales_channels/integrations/ebay/models/properties.py
@@ -14,6 +14,12 @@ from sales_channels.models.properties import (
 from sales_channels.integrations.ebay.constants import (
     EBAY_INTERNAL_PROPERTY_DEFAULTS,
 )
+from sales_channels.integrations.ebay.managers import (
+    EbayInternalPropertyManager,
+    EbayProductTypeManager,
+    EbayPropertyManager,
+    EbayPropertySelectValueManager,
+)
 
 
 class EbayProperty(RemoteProperty):
@@ -58,6 +64,8 @@ class EbayProperty(RemoteProperty):
         blank=True,
         help_text="Format specification returned by eBay (aspectFormat).",
     )
+
+    objects = EbayPropertyManager()
 
     class Meta:
         verbose_name = _("eBay Property")
@@ -108,6 +116,8 @@ class EbayInternalProperty(RemoteObjectMixin, models.Model):
     def __str__(self):
         return f"{self.code} ({self.sales_channel})"
 
+    objects = EbayInternalPropertyManager()
+
 class EbayPropertySelectValue(RemoteObjectMixin, models.Model):
     """eBay attribute value model with localization support."""
 
@@ -149,6 +159,8 @@ class EbayPropertySelectValue(RemoteObjectMixin, models.Model):
     def __str__(self):
         return f"{self.localized_value} ({self.marketplace})"
 
+    objects = EbayPropertySelectValueManager()
+
 
 class EbayProductType(RemoteObjectMixin, models.Model):
     """eBay product type (category) representation."""
@@ -172,6 +184,8 @@ class EbayProductType(RemoteObjectMixin, models.Model):
         help_text="Category name translated into the company language.",
     )
     imported = models.BooleanField(default=True)
+
+    objects = EbayProductTypeManager()
 
     class Meta:
         verbose_name = _("eBay Product Type")

--- a/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
@@ -11,6 +11,15 @@ from sales_channels.integrations.ebay.models import (
 )
 from properties.schema.types.filters import PropertyFilter, PropertySelectValueFilter
 from sales_channels.schema.types.filters import SalesChannelFilter, SalesChannelViewFilter
+from sales_channels.integrations.ebay.managers import (
+    EbayPropertyQuerySet,
+    EbayPropertySelectValueQuerySet,
+)
+from sales_channels.schema.types.filter_mixins import (
+    DependentMappedLocallyFilterMixin,
+    GeneralMappedLocallyFilterMixin,
+    GeneralMappedRemotelyFilterMixin,
+)
 
 
 @filter(EbaySalesChannel)
@@ -20,16 +29,21 @@ class EbaySalesChannelFilter(SearchFilterMixin):
 
 
 @filter(EbayProperty)
-class EbayPropertyFilter(SearchFilterMixin):
+class EbayPropertyFilter(SearchFilterMixin, DependentMappedLocallyFilterMixin, GeneralMappedRemotelyFilterMixin):
     id: auto
     sales_channel: Optional[SalesChannelFilter]
     local_instance: Optional[PropertyFilter]
     allow_multiple: auto
     # type: auto
 
+    mapped_locally_querysets = (
+        (EbayPropertyQuerySet, "filter_mapped_locally"),
+        (EbayPropertySelectValueQuerySet, "filter_ebay_property_mapped_locally"),
+    )
+
 
 @filter(EbayInternalProperty)
-class EbayInternalPropertyFilter(SearchFilterMixin):
+class EbayInternalPropertyFilter(SearchFilterMixin, GeneralMappedLocallyFilterMixin, GeneralMappedRemotelyFilterMixin):
     id: auto
     sales_channel: Optional[SalesChannelFilter]
     local_instance: Optional[PropertyFilter]
@@ -38,7 +52,7 @@ class EbayInternalPropertyFilter(SearchFilterMixin):
 
 
 @filter(EbayPropertySelectValue)
-class EbayPropertySelectValueFilter(SearchFilterMixin):
+class EbayPropertySelectValueFilter(SearchFilterMixin, GeneralMappedLocallyFilterMixin, GeneralMappedRemotelyFilterMixin):
     id: auto
     sales_channel: Optional[SalesChannelFilter]
     ebay_property: Optional[EbayPropertyFilter]

--- a/OneSila/sales_channels/integrations/ebay/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/types.py
@@ -69,6 +69,14 @@ class EbayPropertyType(relay.Node, GetQuerysetMultiTenantMixin):
         lazy("sales_channels.integrations.ebay.schema.types.types")
     ]]
 
+    @field()
+    def mapped_locally(self, info) -> bool:
+        return self.mapped_locally
+
+    @field()
+    def mapped_remotely(self, info) -> bool:
+        return self.mapped_remotely
+
 
 @type(
     EbayInternalProperty,
@@ -86,6 +94,14 @@ class EbayInternalPropertyType(relay.Node, GetQuerysetMultiTenantMixin):
         'PropertyType',
         lazy("properties.schema.types.types")
     ]]
+
+    @field()
+    def mapped_locally(self, info) -> bool:
+        return self.mapped_locally
+
+    @field()
+    def mapped_remotely(self, info) -> bool:
+        return self.mapped_remotely
 
 
 @type(
@@ -109,6 +125,14 @@ class EbayPropertySelectValueType(relay.Node, GetQuerysetMultiTenantMixin):
         'PropertySelectValueType',
         lazy("properties.schema.types.types")
     ]]
+
+    @field()
+    def mapped_locally(self, info) -> bool:
+        return self.mapped_locally
+
+    @field()
+    def mapped_remotely(self, info) -> bool:
+        return self.mapped_remotely
 
 
 @type(

--- a/OneSila/sales_channels/managers.py
+++ b/OneSila/sales_channels/managers.py
@@ -1,5 +1,44 @@
 from core.managers import MultiTenantManager, MultiTenantQuerySet
+from django.db.models import BooleanField, Case, Value, When
 from polymorphic.managers import PolymorphicManager, PolymorphicQuerySet
+
+
+class _MappingQuerySetMixin:
+    mapped_field: str
+
+    def annotate_mapping(self):
+        return self.annotate(
+            mapped_locally=Case(
+                When(local_instance__isnull=False, then=Value(True)),
+                default=Value(False),
+                output_field=BooleanField(),
+            ),
+            mapped_remotely=Case(
+                When(**{f"{self.mapped_field}__isnull": False}, then=Value(True)),
+                When(**{f"{self.mapped_field}__exact": ""}, then=Value(False)),
+                default=Value(False),
+                output_field=BooleanField(),
+            ),
+        )
+
+    def filter_mapped_locally(self, value: bool = True):
+        return self.annotate_mapping().filter(mapped_locally=value)
+
+    def filter_mapped_remotely(self, value: bool = True):
+        return self.annotate_mapping().filter(mapped_remotely=value)
+
+
+class _MappingManagerMixin:
+    queryset_class = None
+
+    def get_queryset(self):
+        return self.queryset_class(self.model, using=self._db).annotate_mapping()
+
+    def filter_mapped_locally(self, value: bool = True):
+        return self.get_queryset().filter_mapped_locally(value)
+
+    def filter_mapped_remotely(self, value: bool = True):
+        return self.get_queryset().filter_mapped_remotely(value)
 
 class RemoteProductConfiguratorQuerySet(PolymorphicQuerySet, MultiTenantQuerySet):
     """

--- a/OneSila/sales_channels/schema/types/filter_mixins.py
+++ b/OneSila/sales_channels/schema/types/filter_mixins.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from core.managers import QuerySet
+from django.db.models import Q
+from strawberry import UNSET
+from strawberry_django import filter_field as custom_filter
+
+
+class DependentMappedLocallyFilterMixin:
+    mapped_locally_querysets: Iterable[tuple[type[QuerySet], str]] = ()
+
+    @custom_filter
+    def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
+
+        if value not in (None, UNSET):
+            for queryset_class, method_name in self.mapped_locally_querysets:
+                if isinstance(queryset, queryset_class):
+                    queryset = getattr(queryset, method_name)(value)
+                    break
+            else:
+                raise Exception(f"Unexpected queryset class: {type(queryset)}")
+
+        return queryset, Q()
+
+
+class GeneralMappedRemotelyFilterMixin:
+
+    @custom_filter
+    def mapped_remotely(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
+        if value not in (None, UNSET):
+            queryset = queryset.filter_mapped_remotely(value)
+        return queryset, Q()
+
+
+class GeneralMappedLocallyFilterMixin:
+
+    @custom_filter
+    def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
+        if value not in (None, UNSET):
+            queryset = queryset.filter_mapped_locally(value)
+        return queryset, Q()


### PR DESCRIPTION
## Summary
- promote the mapping queryset/manager helpers to `sales_channels.managers` and add reusable mapping filter mixins
- wire eBay property-related models to new annotated querysets/managers and surface mapped state fields in the GraphQL types
- update Amazon/eBay filters to use the new mixins for consistent mapped_locally/mapped_remotely handling

## Testing
- python manage.py test sales_channels.integrations.ebay.tests.tests_factories --settings OneSila.settings.agent *(fails: ModuleNotFoundError: No module named 'ebay_rest')*

------
https://chatgpt.com/codex/tasks/task_e_68cd1ba1bd54832eb9018327e7ec27e8

## Summary by Sourcery

Introduce reusable mapping mixins for mapping annotation and filtering, and apply them to both Amazon and eBay integrations to consistently expose mapped_locally and mapped_remotely state in filters and GraphQL types.

New Features:
- Create dedicated eBay managers using the shared mapping mixins and wire them into eBay property and product type models.
- Add mapped_locally and mapped_remotely fields to eBay GraphQL types to expose mapping state.
- Update eBay filter classes to leverage the new mapping mixins for consistent mapped_locally/remotely behavior.

Enhancements:
- Extract common mapping annotation and filtering logic into `_MappingQuerySetMixin` and `_MappingManagerMixin` in `sales_channels.managers`.
- Add `DependentMappedLocallyFilterMixin`, `GeneralMappedLocallyFilterMixin`, and `GeneralMappedRemotelyFilterMixin` to DRY up mapped_locally/remotely filters.
- Refactor Amazon filter classes to use the new filter mixins and remove custom mapping methods.