### PR TITLE
Fix dependent mapped locally filter mixin

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/amazon/schema/types/filters.py
@@ -70,10 +70,11 @@ class AmazonPropertyFilter(SearchFilterMixin, DependentMappedLocallyFilterMixin,
     allows_unmapped_values: auto
     type: auto
 
-    # mapped_locally_querysets = (
-    #     (AmazonPropertyQuerySet, "filter_mapped_locally"),
-    #     (AmazonPropertySelectValueQuerySet, "filter_amazon_property_mapped_locally"),
-    # )
+    def get_mapped_locally_querysets(self):
+        return (
+            (AmazonPropertyQuerySet, "filter_mapped_locally"),
+            (AmazonPropertySelectValueQuerySet, "filter_amazon_property_mapped_locally"),
+        )
 
 
 @filter(AmazonPropertySelectValue)

--- a/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
@@ -36,10 +36,11 @@ class EbayPropertyFilter(SearchFilterMixin, DependentMappedLocallyFilterMixin, G
     allows_unmapped_values: auto
     type: auto
 
-    # mapped_locally_querysets = (
-    #     (EbayPropertyQuerySet, "filter_mapped_locally"),
-    #     (EbayPropertySelectValueQuerySet, "filter_ebay_property_mapped_locally"),
-    # )
+    def get_mapped_locally_querysets(self):
+        return (
+            (EbayPropertyQuerySet, "filter_mapped_locally"),
+            (EbayPropertySelectValueQuerySet, "filter_ebay_property_mapped_locally"),
+        )
 
 
 @filter(EbayInternalProperty)

--- a/OneSila/sales_channels/schema/types/filter_mixins.py
+++ b/OneSila/sales_channels/schema/types/filter_mixins.py
@@ -10,23 +10,26 @@ from strawberry_django import filter_field as custom_filter
 from core.schema.core.types.filters import AnnotationMergerMixin
 
 
-class DependentMappedLocallyFilterMixin:
-    # @TODO: This is broken
-    pass
-    # mapped_locally_querysets: Iterable[tuple[type[QuerySet], str]] = ()
-    #
-    # @custom_filter
-    # def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
-    #
-    #     if value not in (None, UNSET):
-    #         for queryset_class, method_name in self.mapped_locally_querysets:
-    #             if isinstance(queryset, queryset_class):
-    #                 queryset = getattr(queryset, method_name)(value)
-    #                 break
-    #         else:
-    #             raise Exception(f"Unexpected queryset class: {type(queryset)}")
-    #
-    #     return queryset, Q()
+class DependentMappedLocallyFilterMixin(AnnotationMergerMixin):
+    mapped_locally: Optional[bool]
+
+    def get_mapped_locally_querysets(self) -> Iterable[tuple[type[QuerySet], str]]:
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement get_mapped_locally_querysets()",
+        )
+
+    @custom_filter
+    def mapped_locally(self, queryset, value: bool, prefix: str) -> tuple[QuerySet, Q]:
+
+        if value not in (None, UNSET):
+            for queryset_class, method_name in self.get_mapped_locally_querysets():
+                if isinstance(queryset, queryset_class):
+                    queryset = getattr(queryset, method_name)(value)
+                    break
+            else:
+                raise Exception(f"Unexpected queryset class: {type(queryset)}")
+
+        return queryset, Q()
 
 
 class GeneralMappedRemotelyFilterMixin(AnnotationMergerMixin):


### PR DESCRIPTION
## Summary
- implement DependentMappedLocallyFilterMixin to provide mapped_locally support and require explicit queryset mappings
- wire Amazon and Ebay property filters to return the appropriate mapped locally querysets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd23483838832eac5d6c0f27a35fce