### PR TITLE
Add marketplace metadata to eBay product types

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/models/properties.py
+++ b/OneSila/sales_channels/integrations/ebay/models/properties.py
@@ -173,6 +173,13 @@ class EbayProductType(RemoteObjectMixin, models.Model):
         null=True,
         help_text="Local product type rule associated with this category.",
     )
+    marketplace = models.ForeignKey(
+        'ebay.EbaySalesChannelView',
+        on_delete=models.CASCADE,
+        related_name='product_types',
+        null=True,
+        help_text="Marketplace in which this category applies.",
+    )
     name = models.CharField(
         max_length=255,
         null=True,
@@ -194,9 +201,9 @@ class EbayProductType(RemoteObjectMixin, models.Model):
         verbose_name_plural = _("eBay Product Types")
         constraints = [
             models.UniqueConstraint(
-                fields=['sales_channel', 'remote_id'],
+                fields=['marketplace', 'remote_id'],
                 condition=models.Q(remote_id__isnull=False),
-                name='unique_ebayproducttype_remote_id_per_channel',
+                name='unique_ebayproducttype_remote_id_per_marketplace',
             ),
             models.UniqueConstraint(
                 fields=['sales_channel', 'local_instance'],

--- a/OneSila/sales_channels/integrations/ebay/schema/queries.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/queries.py
@@ -2,6 +2,7 @@ from core.schema.core.queries import node, connection, DjangoListConnection, typ
 from sales_channels.integrations.ebay.schema.types.types import (
     EbaySalesChannelType,
     EbayInternalPropertyType,
+    EbayProductTypeType,
     EbayPropertyType,
     EbayPropertySelectValueType,
     EbaySalesChannelViewType,
@@ -15,6 +16,9 @@ class EbaySalesChannelsQuery:
 
     ebay_property: EbayPropertyType = node()
     ebay_properties: DjangoListConnection[EbayPropertyType] = connection()
+
+    ebay_product_type: EbayProductTypeType = node()
+    ebay_product_types: DjangoListConnection[EbayProductTypeType] = connection()
 
     ebay_internal_property: EbayInternalPropertyType = node()
     ebay_internal_properties: DjangoListConnection[EbayInternalPropertyType] = connection()

--- a/OneSila/sales_channels/integrations/ebay/schema/types/__init__.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/__init__.py
@@ -1,14 +1,17 @@
-from .filters import EbaySalesChannelFilter
-from .ordering import EbaySalesChannelOrder
+from .filters import EbayProductTypeFilter, EbaySalesChannelFilter
+from .ordering import EbayProductTypeOrder, EbaySalesChannelOrder
 from .input import EbaySalesChannelInput, EbaySalesChannelPartialInput, EbayValidateAuthInput
-from .types import EbaySalesChannelType, EbayRedirectUrlType
+from .types import EbayProductTypeType, EbaySalesChannelType, EbayRedirectUrlType
 
 __all__ = [
+    "EbayProductTypeFilter",
     "EbaySalesChannelFilter",
+    "EbayProductTypeOrder",
     "EbaySalesChannelOrder",
     "EbaySalesChannelInput",
     "EbaySalesChannelPartialInput",
     "EbayValidateAuthInput",
+    "EbayProductTypeType",
     "EbaySalesChannelType",
     "EbayRedirectUrlType",
 ]

--- a/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
@@ -5,11 +5,16 @@ from core.schema.core.types.types import auto
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
     EbayInternalProperty,
+    EbayProductType,
     EbayProperty,
     EbayPropertySelectValue,
     EbaySalesChannelView,
 )
-from properties.schema.types.filters import PropertyFilter, PropertySelectValueFilter
+from properties.schema.types.filters import (
+    ProductPropertiesRuleFilter,
+    PropertyFilter,
+    PropertySelectValueFilter,
+)
 from sales_channels.schema.types.filters import SalesChannelFilter, SalesChannelViewFilter
 from sales_channels.integrations.ebay.managers import (
     EbayPropertyQuerySet,
@@ -26,6 +31,15 @@ from sales_channels.schema.types.filter_mixins import (
 class EbaySalesChannelFilter(SearchFilterMixin):
     active: auto
     hostname: auto
+
+
+@filter(EbayProductType)
+class EbayProductTypeFilter(SearchFilterMixin, GeneralMappedLocallyFilterMixin, GeneralMappedRemotelyFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]
+    local_instance: Optional[ProductPropertiesRuleFilter]
+    marketplace: Optional[SalesChannelViewFilter]
+    imported: auto
 
 
 @filter(EbayProperty)

--- a/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
@@ -3,6 +3,7 @@ from core.schema.core.types.types import auto
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
     EbayInternalProperty,
+    EbayProductType,
     EbayProperty,
     EbayPropertySelectValue,
     EbaySalesChannelView,
@@ -11,6 +12,11 @@ from sales_channels.integrations.ebay.models import (
 
 @order(EbaySalesChannel)
 class EbaySalesChannelOrder:
+    id: auto
+
+
+@order(EbayProductType)
+class EbayProductTypeOrder:
     id: auto
 
 

--- a/OneSila/sales_channels/integrations/ebay/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/types.py
@@ -11,6 +11,7 @@ from core.schema.core.types.types import (
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
     EbayInternalProperty,
+    EbayProductType,
     EbayProperty,
     EbayPropertySelectValue,
     EbaySalesChannelView,
@@ -18,6 +19,7 @@ from sales_channels.integrations.ebay.models import (
 from sales_channels.integrations.ebay.schema.types.filters import (
     EbaySalesChannelFilter,
     EbayInternalPropertyFilter,
+    EbayProductTypeFilter,
     EbayPropertyFilter,
     EbayPropertySelectValueFilter,
     EbaySalesChannelViewFilter,
@@ -25,6 +27,7 @@ from sales_channels.integrations.ebay.schema.types.filters import (
 from sales_channels.integrations.ebay.schema.types.ordering import (
     EbaySalesChannelOrder,
     EbayInternalPropertyOrder,
+    EbayProductTypeOrder,
     EbayPropertyOrder,
     EbayPropertySelectValueOrder,
     EbaySalesChannelViewOrder,
@@ -46,6 +49,36 @@ class EbaySalesChannelType(relay.Node, GetQuerysetMultiTenantMixin):
     @field()
     def saleschannel_ptr(self, info) -> str:
         return self.saleschannel_ptr
+
+
+@type(
+    EbayProductType,
+    filters=EbayProductTypeFilter,
+    order=EbayProductTypeOrder,
+    pagination=True,
+    fields="__all__",
+)
+class EbayProductTypeType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'EbaySalesChannelType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]
+    local_instance: Optional[Annotated[
+        'ProductPropertiesRuleType',
+        lazy("properties.schema.types.types")
+    ]]
+    marketplace: Annotated[
+        'SalesChannelViewType',
+        lazy("sales_channels.schema.types.types")
+    ]
+
+    @field()
+    def mapped_locally(self, info) -> bool:
+        return self.mapped_locally
+
+    @field()
+    def mapped_remotely(self, info) -> bool:
+        return self.mapped_remotely
 
 
 @type(

--- a/OneSila/sales_channels/integrations/ebay/tasks.py
+++ b/OneSila/sales_channels/integrations/ebay/tasks.py
@@ -54,3 +54,18 @@ def ebay_translate_select_value_task(select_value_id: int):
         property_code_attr="ebay_property.remote_id",
     )
     flow.flow()
+
+
+@db_task()
+def ebay_translate_product_type_task(product_type_id: int):
+    from sales_channels.integrations.ebay.models import EbayProductType
+
+    instance = EbayProductType.objects.get(id=product_type_id)
+    flow = TranslateRemotePropertyFlow(
+        instance=instance,
+        integration_label="eBay",
+        remote_name_fields=("name", "remote_id"),
+        translation_field="translated_name",
+        remote_identifier_attr="remote_id",
+    )
+    flow.flow()


### PR DESCRIPTION
## Summary
- add marketplace relationship to eBay product types and scope the remote_id uniqueness to that marketplace
- ensure schema imports assign the marketplace when syncing categories and expose a translation task for product types
- expose eBay product types through GraphQL with filters, ordering, and queries

## Testing
- python -m compileall OneSila/sales_channels/integrations/ebay

------
https://chatgpt.com/codex/tasks/task_e_68cd76899f18832eac13578d7cdb8c1d

## Summary by Sourcery

Add marketplace metadata to EbayProductType, scope remote_id uniqueness per marketplace, adjust the sync factory to set the marketplace, and expose product types via GraphQL with translation support.

New Features:
- Add marketplace foreign key to EbayProductType model with unique remote_id constraint scoped per marketplace
- Expose EbayProductType through GraphQL with filters, ordering, pagination, and mapped_locally/remotely fields
- Add GraphQL queries and connections for fetching single and list ebay_product_type resources
- Introduce a translation task for syncing remote eBay product type names

Enhancements:
- Update factory sync logic to assign and update marketplace when creating or updating EbayProductType records