### PR TITLE
Add copy content option when creating alias products

### DIFF
--- a/OneSila/imports_exports/factories/variations.py
+++ b/OneSila/imports_exports/factories/variations.py
@@ -270,6 +270,7 @@ class ImportAliasVariationInstance(AbstractImportInstance):
         - `parent_product` (product it points to)
         - `alias_copy_images` (bool)
         - `alias_copy_product_properties` (bool)
+        - `alias_copy_content` (bool)
     """
 
     def __init__(self, data: dict, import_process=None, parent_product=None, alias_product=None, instance=None, sales_channel=None):
@@ -282,6 +283,7 @@ class ImportAliasVariationInstance(AbstractImportInstance):
         self.set_field_if_exists('parent_product_data')
         self.set_field_if_exists('alias_copy_images', default_value=False)
         self.set_field_if_exists('alias_copy_product_properties', default_value=False)
+        self.set_field_if_exists('alias_copy_content', default_value=True)
 
         if hasattr(self, 'variation_data'):
             if isinstance(self.variation_data, dict):
@@ -321,11 +323,16 @@ class ImportAliasVariationInstance(AbstractImportInstance):
 
     def process_logic(self):
 
-        if self.created and (self.alias_copy_images or self.alias_copy_product_properties):
+        if self.created and (
+            self.alias_copy_images
+            or self.alias_copy_product_properties
+            or self.alias_copy_content
+        ):
             AliasProduct.objects.copy_from_parent(
                 self.alias_product,
                 copy_images=self.alias_copy_images,
-                copy_properties=self.alias_copy_product_properties
+                copy_properties=self.alias_copy_product_properties,
+                copy_content=self.alias_copy_content,
             )
 
         self.instance = self.alias_product

--- a/OneSila/products/managers.py
+++ b/OneSila/products/managers.py
@@ -234,13 +234,68 @@ class VariationManager(ProductManager):
 
 class AliasProductQuerySet(QuerySetProxyModelMixin, ProductQuerySet):
 
-    def copy_from_parent(self, alias_product, *, copy_images=False, copy_properties=False):
+    def copy_from_parent(
+        self,
+        alias_product,
+        *,
+        copy_images=False,
+        copy_properties=False,
+        copy_content=True,
+    ):
         from media.models import MediaProductThrough
         from properties.models import ProductProperty, Property, ProductPropertyTextTranslation
+        from .models import ProductTranslation, ProductTranslationBulletPoint
 
         parent = alias_product.alias_parent_product
         if not parent:
             raise ValueError("Alias product must have an alias_parent_product set.")
+
+        if copy_content:
+            default_translations = parent.translations.filter(sales_channel__isnull=True).prefetch_related("bullet_points")
+            for trans in default_translations:
+                alias_translation, created = ProductTranslation.objects.get_or_create(
+                    product=alias_product,
+                    language=trans.language,
+                    sales_channel=None,
+                    defaults={
+                        "name": trans.name,
+                        "short_description": trans.short_description,
+                        "description": trans.description,
+                        "url_key": trans.url_key,
+                        "multi_tenant_company": parent.multi_tenant_company,
+                    },
+                )
+
+                if not created:
+                    alias_translation.name = trans.name
+                    alias_translation.short_description = trans.short_description
+                    alias_translation.description = trans.description
+                    alias_translation.url_key = trans.url_key
+                    alias_translation.multi_tenant_company = parent.multi_tenant_company
+                    alias_translation.save(
+                        update_fields=[
+                            "name",
+                            "short_description",
+                            "description",
+                            "url_key",
+                            "multi_tenant_company",
+                        ]
+                    )
+
+                alias_translation.bullet_points.all().delete()
+                bullet_points = list(trans.bullet_points.all())
+                if bullet_points:
+                    ProductTranslationBulletPoint.objects.bulk_create(
+                        [
+                            ProductTranslationBulletPoint(
+                                product_translation=alias_translation,
+                                text=bp.text,
+                                sort_order=bp.sort_order,
+                                multi_tenant_company=alias_translation.multi_tenant_company,
+                            )
+                            for bp in bullet_points
+                        ]
+                    )
 
         if copy_images:
             parent_images = parent.mediaproductthrough_set.all()

--- a/OneSila/products/schema/mutations/mutation_classes.py
+++ b/OneSila/products/schema/mutations/mutation_classes.py
@@ -27,7 +27,8 @@ class AliasProductCreateMutation(TranslatableCreateMutation):
             AliasProduct.objects.copy_from_parent(
                 instance,
                 copy_images=data.get("alias_copy_images", False),
-                copy_properties=data.get("alias_copy_product_properties", False)
+                copy_properties=data.get("alias_copy_product_properties", False),
+                copy_content=data.get("alias_copy_content", True),
             )
 
         instance.refresh_from_db()

--- a/OneSila/products/schema/types/input.py
+++ b/OneSila/products/schema/types/input.py
@@ -24,6 +24,7 @@ class ProductInput:
     name: str
     alias_copy_images: bool
     alias_copy_product_properties: bool
+    alias_copy_content: bool = True
 
 
 @partial(Product, fields="__all__")


### PR DESCRIPTION
## Summary
- add copy_content support to alias product copy routine to duplicate default translations and bullet points
- expose the copy_content flag in GraphQL product creation inputs and alias creation mutation
- ensure imports trigger translation copying by default and add coverage for enabling/disabling content copy

## Testing
- `python OneSila/manage.py test products.tests.tests_models.AlasProductTestCase.test_copy_from_parent_copies_default_translations` *(fails: database server for tests is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd781fda6c832eb3562f537cf8af28

## Summary by Sourcery

Add support for copying product content (translations and bullet points) to alias products, expose the option in GraphQL and import pipelines, and include tests for default and disabled behavior.

New Features:
- Introduce copy_content flag to AliasProduct.copy_from_parent to duplicate default translations and bullet points
- Expose alias_copy_content option in GraphQL product creation inputs and alias creation mutation
- Support alias_copy_content flag in import factories to control content copying during imports

Tests:
- Add tests to verify that default translations and bullet points are copied to alias products
- Add tests to ensure content copying is skipped when copy_content is disabled