### PR TITLE
Use get_or_create for eBay product types

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/full_schema.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/full_schema.py
@@ -146,28 +146,16 @@ class EbayProductTypeRuleFactory(GetEbayAPIMixin):
             logger.warning("Unable to determine remote_id for eBay category. Skipping sync.")
             return None
 
-        product_type = EbayProductType.objects.filter(
+        defaults: dict[str, Any] = {}
+        if name:
+            defaults["name"] = name
+        product_type, _ = EbayProductType.objects.get_or_create(
             sales_channel=self.sales_channel,
             multi_tenant_company=self.multi_tenant_company,
             marketplace=self.view,
             remote_id=str(remote_id),
-        ).first()
-
-        if product_type is None:
-            product_type = EbayProductType.objects.filter(
-                sales_channel=self.sales_channel,
-                multi_tenant_company=self.multi_tenant_company,
-                marketplace__isnull=True,
-                remote_id=str(remote_id),
-            ).first()
-
-        if product_type is None:
-            product_type = EbayProductType.objects.create(
-                sales_channel=self.sales_channel,
-                multi_tenant_company=self.multi_tenant_company,
-                marketplace=self.view,
-                remote_id=str(remote_id),
-            )
+            defaults=defaults,
+        )
 
         update_fields: list[str] = []
         if product_type.marketplace_id != getattr(self.view, "id", None):


### PR DESCRIPTION
## Summary
- replace the manual EbayProductType lookup chain with get_or_create
- initialize defaults with the remote name when available while preserving subsequent updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd8cf7c30c832eb3487069f49b22d3

## Summary by Sourcery

Simplify eBay product type synchronization by replacing the manual lookup and creation chain with a single get_or_create call and initializing the name via defaults when available

Enhancements:
- Use Django get_or_create for EbayProductType retrieval and creation
- Initialize the product type name through get_or_create defaults instead of assigning post-creation