### PR TITLE
Restore Amazon variation theme marketplace payload

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -2,7 +2,6 @@ from core.logging_helpers import timeit_and_log
 from properties.models import Property, PropertyTranslation
 from sales_channels.integrations.amazon.constants import AMAZON_PATCH_SKIP_KEYS
 from sales_channels.integrations.amazon.models.properties import AmazonProperty
-import copy
 import json
 
 from django.conf import settings
@@ -496,33 +495,6 @@ class GetAmazonAPIMixin:
             if key in skip_keys:
                 continue
             current_value = current_attributes.get(key)
-
-            if key == "variation_theme" and isinstance(new_value, list):
-                current_list = current_value if isinstance(current_value, list) else []
-                current_copy = copy.deepcopy(current_list)
-                existing_names = {
-                    item.get("name")
-                    for item in current_copy
-                    if isinstance(item, dict) and item.get("name")
-                }
-
-                merged_value = copy.deepcopy(current_copy)
-                added = False
-                for item in new_value:
-                    if not isinstance(item, dict):
-                        continue
-                    name = item.get("name")
-                    if not name or name in existing_names:
-                        continue
-                    merged_value.append(item)
-                    existing_names.add(name)
-                    added = True
-
-                if added:
-                    new_value = merged_value
-                    current_value = current_copy
-                elif existing_names:
-                    continue
 
             new_value = clean(new_value)
             path = f"/attributes/{key}"

--- a/OneSila/sales_channels/integrations/amazon/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/products.py
@@ -661,7 +661,7 @@ class AmazonProductBaseFactory(GetAmazonAPIMixin, RemoteProductSyncFactory):
             theme = self._get_variation_theme(self.local_instance)
 
         if theme:
-            attrs["variation_theme"] = [{"name": theme}]
+            attrs["variation_theme"] = [{"name": theme, "marketplace_id": self.view.remote_id}]
 
         if self.is_variation:
             attrs["parentage_level"] = [

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py
@@ -720,34 +720,6 @@ class AmazonProductFactoriesTest(DisableWooCommerceSignalsMixin, TransactionTest
             [],
         )
 
-    def test_build_patches_skips_existing_variation_theme(self):
-        mixin = GetAmazonAPIMixin()
-        current = {"variation_theme": [{"name": "COLOR/SIZE"}]}
-        new = {"variation_theme": [{"name": "COLOR/SIZE"}]}
-
-        self.assertEqual(mixin._build_patches(current, new), [])
-
-    def test_build_patches_appends_missing_variation_theme(self):
-        mixin = GetAmazonAPIMixin()
-        current = {"variation_theme": [{"name": "COLOR/SIZE", "marketplace_id": "GB"}]}
-        new = {"variation_theme": [{"name": "SIZE"}]}
-
-        patches = mixin._build_patches(current, new)
-
-        self.assertEqual(
-            patches,
-            [
-                {
-                    "op": "replace",
-                    "path": "/attributes/variation_theme",
-                    "value": [
-                        {"name": "COLOR/SIZE", "marketplace_id": "GB"},
-                        {"name": "SIZE"},
-                    ],
-                }
-            ],
-        )
-
     def test_replace_tokens_drops_empty_units(self):
         mixin = AmazonProductPropertyBaseMixin()
         data = {
@@ -2631,7 +2603,7 @@ class AmazonConfigurableProductFlowTest(DisableWooCommerceSignalsMixin, Transact
         child_body = next(b for b in bodies if b["attributes"].get("parentage_level", [{}])[0]["value"] == "child")
 
         # Shared expectations
-        expected_theme = [{"name": "COLOR/SIZE"}]
+        expected_theme = [{"name": "COLOR/SIZE", "marketplace_id": self.view.remote_id}]
 
         self.assertEqual(parent_body["attributes"].get("variation_theme"), expected_theme)
         self.assertEqual(parent_body["attributes"].get("parentage_level"),
@@ -2677,7 +2649,7 @@ class AmazonConfigurableProductFlowTest(DisableWooCommerceSignalsMixin, Transact
 
         body = mock_instance.put_listings_item.call_args.kwargs.get("body")
         attrs = body.get("attributes", {})
-        expected_theme = [{"name": "COLOR/SIZE"}]
+        expected_theme = [{"name": "COLOR/SIZE", "marketplace_id": self.view.remote_id}]
         expected_parentage = [{"value": "child", "marketplace_id": self.view.remote_id}]
         expected_rel = [
             {

--- a/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_property_factories.py
+++ b/OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_property_factories.py
@@ -359,7 +359,7 @@ class AmazonVariationThemeTest(DisableWooCommerceSignalsMixin, TestCase, AmazonP
         )
         attrs = fac.build_variation_attributes()
 
-        expected_theme = [{"name": "COLOR/SIZE"}]
+        expected_theme = [{"name": "COLOR/SIZE", "marketplace_id": self.view.remote_id}]
         expected_parentage = [{"value": "child", "marketplace_id": self.view.remote_id}]
         expected_rel = [
             {


### PR DESCRIPTION
## Summary
- remove the variation theme merge logic from `GetAmazonAPIMixin._build_patches`
- include the marketplace identifier in generated variation theme payloads and tests

## Testing
- pytest OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_factories.py OneSila/sales_channels/integrations/amazon/tests/tests_factories/tests_product_property_factories.py *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68cddee3a794832eac8fe45822efc442