### PR TITLE
Treat empty main translations as missing

### DIFF
--- a/OneSila/properties/schema/types/filters.py
+++ b/OneSila/properties/schema/types/filters.py
@@ -54,7 +54,7 @@ class PropertyFilter(SearchFilterMixin, ExcluideDemoDataFilterMixin):
         if value not in (None, UNSET):
             condition = Q(
                 propertytranslation__language=F("multi_tenant_company__language")
-            )
+            ) & ~Q(propertytranslation__name="")
             if value:
                 queryset = queryset.exclude(condition)
             else:
@@ -137,7 +137,7 @@ class PropertySelectValueFilter(SearchFilterMixin, ExcluideDemoDataFilterMixin):
                 propertyselectvaluetranslation__language=F(
                     "multi_tenant_company__language"
                 )
-            )
+            ) & ~Q(propertyselectvaluetranslation__value="")
             if value:
                 queryset = queryset.exclude(condition)
             else:

--- a/OneSila/properties/tests/tests_filters.py
+++ b/OneSila/properties/tests/tests_filters.py
@@ -31,7 +31,7 @@ class PropertyFilterTranslationTestCase(TransactionTestCaseMixin, TransactionTes
         PropertyTranslation.objects.create(
             property=self.p1,
             language="en",
-            name="Color",
+            name="",
             multi_tenant_company=self.multi_tenant_company,
         )
         self.p2 = Property.objects.create(
@@ -78,14 +78,14 @@ class PropertyFilterTranslationTestCase(TransactionTestCaseMixin, TransactionTes
             PROPERTIES_MISSING_MAIN_TRANSLATION_QUERY,
             {"missingMainTranslation": True},
         )
-        self.assertSetEqual(ids, {self.p3.id})
+        self.assertSetEqual(ids, {self.p1.id, self.p3.id})
 
     def test_property_missing_main_translation_false(self):
         ids = self._query_ids(
             PROPERTIES_MISSING_MAIN_TRANSLATION_QUERY,
             {"missingMainTranslation": False},
         )
-        self.assertSetEqual(ids, {self.p1.id, self.p2.id})
+        self.assertSetEqual(ids, {self.p2.id})
 
     def test_property_missing_translations_true(self):
         ids = self._query_ids(
@@ -131,7 +131,7 @@ class PropertySelectValueFilterTranslationTestCase(TransactionTestCaseMixin, Tra
         PropertySelectValueTranslation.objects.create(
             propertyselectvalue=self.v1,
             language="en",
-            value="Red",
+            value="",
             multi_tenant_company=self.multi_tenant_company,
         )
         self.v2 = PropertySelectValue.objects.create(
@@ -174,14 +174,14 @@ class PropertySelectValueFilterTranslationTestCase(TransactionTestCaseMixin, Tra
             PROPERTY_SELECT_VALUES_MISSING_MAIN_TRANSLATION_QUERY,
             {"missingMainTranslation": True},
         )
-        self.assertSetEqual(ids, {self.v3.id})
+        self.assertSetEqual(ids, {self.v1.id, self.v3.id})
 
     def test_property_select_value_missing_main_translation_false(self):
         ids = self._query_ids(
             PROPERTY_SELECT_VALUES_MISSING_MAIN_TRANSLATION_QUERY,
             {"missingMainTranslation": False},
         )
-        self.assertSetEqual(ids, {self.v1.id, self.v2.id})
+        self.assertSetEqual(ids, {self.v2.id})
 
     def test_property_select_value_missing_translations_true(self):
         ids = self._query_ids(


### PR DESCRIPTION
## Summary
- treat empty translations in the main language as missing for property and property select value filters
- extend filter tests to cover translations stored as empty strings

## Testing
- python OneSila/manage.py test properties.tests.tests_filters *(fails: PostgreSQL test database connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68d17897c928832eb5200311836a9619