### PR TITLE
Ensure strawberry mutations enforce tenant scoping

### DIFF
--- a/OneSila/products/schema/mutations/mutation_type.py
+++ b/OneSila/products/schema/mutations/mutation_type.py
@@ -141,8 +141,12 @@ class ProductsMutation:
         create_as_alias: bool = False,
     ) -> ProductType:
         multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
-        instance = Product.objects.get(id=product.id.node_id)
-        if instance.multi_tenant_company != multi_tenant_company:
+        try:
+            instance = Product.objects.get(
+                id=product.id.node_id,
+                multi_tenant_company=multi_tenant_company,
+            )
+        except Product.DoesNotExist:
             raise PermissionError("Invalid company")
         duplicated = Product.objects.duplicate_product(
             instance, sku=sku, create_as_alias=create_as_alias


### PR DESCRIPTION
## Summary
- enforce multi-tenant filtering within property, product, and webhook mutations to prevent cross-tenant access
- raise explicit permission errors when requested resources do not belong to the current tenant

## Testing
- python -m compileall OneSila/properties/schema/mutations/mutation_type.py OneSila/products/schema/mutations/mutation_type.py OneSila/webhooks/schema/mutations.py

------
https://chatgpt.com/codex/tasks/task_e_68d17a28cc20832eb3d21cf47cb271e3

## Summary by Sourcery

Enforce tenant scoping on GraphQL mutations by filtering database queries with multi_tenant_company and raising PermissionError for cross-tenant access

Enhancements:
- Enforce multi-tenant filtering on PropertySelectValue, Property, ProductProperty, Product, WebhookDelivery, and WebhookIntegration lookups in GraphQL mutations
- Raise explicit PermissionError when requested resources do not belong to the current tenant