### PR TITLE
Update Amazon assignment validation logic

### DIFF
--- a/OneSila/sales_channels/schema/mutations/mutation_type.py
+++ b/OneSila/sales_channels/schema/mutations/mutation_type.py
@@ -7,7 +7,7 @@ from ..types.input import SalesChannelImportInput, SalesChannelImportPartialInpu
     SalesChannelIntegrationPricelistInput, SalesChannelIntegrationPricelistPartialInput, SalesChannelViewInput, \
     SalesChannelViewPartialInput, SalesChannelViewAssignInput, SalesChannelViewAssignPartialInput, \
     RemoteLanguagePartialInput, RemoteCurrencyPartialInput, ImportPropertyInput
-from .validators import validate_sku_conflicts, validate_amazon_first_assignment
+from .validators import validate_sku_conflicts, validate_amazon_assignment
 
 
 @type(name='Mutation')
@@ -45,12 +45,12 @@ class SalesChannelsMutation:
 
     create_sales_channel_view_assign: SalesChannelViewAssignType = create(
         SalesChannelViewAssignInput,
-        validators=[validate_sku_conflicts, validate_amazon_first_assignment],
+        validators=[validate_sku_conflicts, validate_amazon_assignment],
     )
     resync_sales_channel_view_assign: SalesChannelViewAssignType = resync_sales_channel_assign()
     create_sales_channel_view_assigns: List[SalesChannelViewAssignType] = create(
         SalesChannelViewAssignInput,
-        validators=[validate_sku_conflicts, validate_amazon_first_assignment],
+        validators=[validate_sku_conflicts, validate_amazon_assignment],
     )
     update_sales_channel_view_assign: SalesChannelViewAssignType = update(SalesChannelViewAssignPartialInput)
     delete_sales_channel_view_assign: SalesChannelViewAssignType = delete()


### PR DESCRIPTION
## Summary
- rename the Amazon assignment validator hook to `validate_amazon_assignment`
- extend the validator to require browse nodes and variation themes on first assignment and enforce existing ASINs for subsequent assignments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1835ae3f4832e98c2ce176a7d6780

## Summary by Sourcery

Improve Amazon assignment validation by renaming the validator and adding stricter checks for required fields on first assignment and requiring an existing ASIN for subsequent assignments.

Enhancements:
- Rename Amazon assignment validator hook to validate_amazon_assignment
- Require browse nodes and variation themes on initial Amazon assignment
- Enforce the presence of an existing ASIN before allowing subsequent Amazon assignments