### PR TITLE
Ensure variation attributes preserved for offer-only listings

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -380,6 +380,12 @@ class GetAmazonAPIMixin:
                 else []
             )
             if allowed_keys:
+                always_included_keys = {
+                    "variation_theme",
+                    "child_parent_sku_relationship",
+                    "parentage_level",
+                }
+                allowed_keys = set(allowed_keys) | always_included_keys
                 attributes = {k: v for k, v in (attributes or {}).items() if k in allowed_keys}
 
         return {
@@ -414,6 +420,12 @@ class GetAmazonAPIMixin:
             "VALIDATION_PREVIEW" if settings.DEBUG or force_validation_only else None,
             pprint.pformat(body),
         )
+
+        if body.get("requirements") == "LISTING_OFFER_ONLY":
+            logger.info(
+                "create_product initial attributes for LISTING_OFFER_ONLY: %s",
+                pprint.pformat(attributes),
+            )
 
         response = listings.put_listings_item(
             **self._build_listing_kwargs(sku, marketplace_id, body, force_validation_only))


### PR DESCRIPTION
## Summary
- ensure LISTING_OFFER_ONLY filtering keeps variation-related attributes even when not required
- add debug logging to capture original attributes when sending LISTING_OFFER_ONLY requests

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d185fe5670832eb83d2c9e95fd3584

## Summary by Sourcery

Ensure variation-related attributes are retained for offer-only listings and add debug logging for initial attributes in LISTING_OFFER_ONLY requests

Enhancements:
- Always include variation_theme, child_parent_sku_relationship, and parentage_level keys when cleaning listing data
- Add info-level logging of initial attributes when creating LISTING_OFFER_ONLY listings