### PR TITLE
Refine bullet translation options

### DIFF
--- a/OneSila/llm/factories/content.py
+++ b/OneSila/llm/factories/content.py
@@ -1,3 +1,5 @@
+from typing import Optional, List
+
 from .mixins import ContentLLMMixin, AskGPTMixin
 from integrations.constants import (
     MAGENTO_INTEGRATION,
@@ -366,12 +368,21 @@ class ShortDescriptionLLM(DescriptionGenLLM):
 class BulletPointsLLM(ContentLLMMixin):
     """Generate bullet points for a product."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, return_one: bool = False, existing_bullet_points: Optional[List[str]] = None, **kwargs):
+        self.return_one = return_one
+        self.existing_bullet_points = existing_bullet_points or []
         super().__init__(*args, **kwargs)
         self.bullet_points: list[str] = []
 
     @property
     def system_prompt(self):
+        if self.return_one:
+            return (
+                "Generate exactly one concise and unique bullet point in the given language "
+                "describing the product. Respond ONLY with a JSON array containing a single "
+                "string. Do not repeat or rephrase any of the existing bullet points."
+            )
+
         return (
             "Generate a short list (max 5 items) of concise bullet points in the "
             "given language describing the product. Respond ONLY with a JSON array "
@@ -400,6 +411,28 @@ class BulletPointsLLM(ContentLLMMixin):
             prompt += f"""
             ##Brand Personality##
             {self.brand_prompt}
+            """
+
+        if self.return_one:
+            prompt += "\n##Instructions##\nGenerate a single additional bullet point that complements the product.\n"
+            if self.existing_bullet_points:
+                existing = "\n".join(self.existing_bullet_points)
+                prompt += f"""
+                ##Existing Bullet Points##
+                {existing}
+                \nEnsure the new bullet point is unique and does not repeat or rephrase any of the existing ones.
+                """
+            else:
+                prompt += "Ensure the bullet point is unique.\n"
+
+        if self.sales_channel_type == AMAZON_INTEGRATION:
+            prompt += """
+            ##Amazon Bullet Point Guidelines##
+            These bullet points will be published on an Amazon product detail page. Follow these rules:
+            - Highlight concrete product features and benefits with customer-focused language.
+            - Keep each bullet point under 200 characters and avoid special characters or emojis.
+            - Do not include pricing, promotions, shipping information, or subjective claims.
+            - Maintain a professional, informative tone optimized for keyword visibility.
             """
         return prompt
 

--- a/OneSila/llm/flows/generate_bullet_points.py
+++ b/OneSila/llm/flows/generate_bullet_points.py
@@ -2,17 +2,39 @@ from llm.factories.content import BulletPointsLLM
 
 
 class AIGenerateBulletPointsFlow:
-    def __init__(self, product, language):
+    def __init__(self, product, language, return_one=False):
         self.product = product
         self.language = language
-        self.factory = BulletPointsLLM(product=product, language_code=language)
+        self.return_one = return_one
+        self.existing_bullet_points = self._get_existing_bullet_points()
+        self.factory = BulletPointsLLM(
+            product=product,
+            language_code=language,
+            return_one=return_one,
+            existing_bullet_points=self.existing_bullet_points,
+        )
         self.generated_points = []
         self.used_points = 0
+
+    def _get_existing_bullet_points(self):
+        translations = self.product.translations.prefetch_related("bullet_points")
+        translation = translations.filter(language=self.language).first() or translations.first()
+
+        if not translation:
+            return []
+
+        return [
+            bp
+            for bp in translation.bullet_points.order_by("sort_order").values_list("text", flat=True)
+            if bp
+        ]
 
     def generate_points(self):
         self.factory.generate_response()
         process = self.factory.ai_process
         self.generated_points = self.factory.bullet_points
+        if self.return_one and self.generated_points:
+            self.generated_points = self.generated_points[:1]
         self.used_points = process.transaction.points
 
     def flow(self):

--- a/OneSila/llm/schema/mutations.py
+++ b/OneSila/llm/schema/mutations.py
@@ -54,7 +54,11 @@ class LlmMutation:
 
         product = Product.objects.get(id=instance.id.node_id, multi_tenant_company=multi_tenant_company)
 
-        flow = AIGenerateBulletPointsFlow(product=product, language=instance.language_code)
+        flow = AIGenerateBulletPointsFlow(
+            product=product,
+            language=instance.language_code,
+            return_one=instance.return_one or False,
+        )
         flow.flow()
 
         bullets = [BulletPoint(text=bp) for bp in flow.generated_points]
@@ -83,7 +87,8 @@ class LlmMutation:
                                                    to_language_code=instance.to_language_code,
                                                    product=product,
                                                    content_type=content_type,
-                                                   sales_channel=sales_channel)
+                                                   sales_channel=sales_channel,
+                                                   return_one_bullet_point=instance.return_one_bullet_point or False)
         content_generator.flow()
 
         return AiContent(content=content_generator.translated_content, points=content_generator.used_points)

--- a/OneSila/llm/schema/types/input.py
+++ b/OneSila/llm/schema/types/input.py
@@ -48,6 +48,7 @@ class AITranslationInput:
     product: Optional[ProductPartialInput] = None
     product_content_type: Optional[ContentAiGenerateType] = None
     sales_channel: Optional[SalesChannelPartialInput] = None
+    return_one_bullet_point: Optional[bool] = False
 
 
 @strawberry_input
@@ -63,6 +64,7 @@ class AIBulkTranslationInput:
 @partial(Product, fields="__all__")
 class ProductAiBulletPointsInput(NodeInput):
     language_code: str
+    return_one: Optional[bool] = False
 
 
 @input(BrandCustomPrompt, fields="__all__")


### PR DESCRIPTION
## Summary
- rename the translation input flag to `return_one_bullet_point` and thread the new name through the flow
- update the translation flow internals to use the renamed flag consistently
- enrich the bullet-point generation prompt with Amazon-specific guidance when applicable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1ab232c88832e84a03d8013c7b69f