### PR TITLE
Add bullet point index support to AI translation flow

### DIFF
--- a/OneSila/llm/schema/mutations.py
+++ b/OneSila/llm/schema/mutations.py
@@ -88,10 +88,13 @@ class LlmMutation:
                                                    product=product,
                                                    content_type=content_type,
                                                    sales_channel=sales_channel,
-                                                   return_one_bullet_point=instance.return_one_bullet_point or False)
+                                                   return_one_bullet_point=instance.return_one_bullet_point or False,
+                                                   bullet_point_index=instance.bullet_point_index)
         content_generator.flow()
 
-        return AiContent(content=content_generator.translated_content, points=content_generator.used_points)
+        return AiContent(content=content_generator.translated_content,
+                         points=content_generator.used_points,
+                         bullet_point_index=content_generator.bullet_point_index)
 
     @strawberry_django.mutation(handle_django_errors=True, extensions=default_extensions)
     def bulk_translate_ai_content(self, instance: AIBulkTranslationInput, info: Info) -> AiTaskResponse:

--- a/OneSila/llm/schema/types/input.py
+++ b/OneSila/llm/schema/types/input.py
@@ -49,6 +49,7 @@ class AITranslationInput:
     product_content_type: Optional[ContentAiGenerateType] = None
     sales_channel: Optional[SalesChannelPartialInput] = None
     return_one_bullet_point: Optional[bool] = False
+    bullet_point_index: Optional[int] = None
 
 
 @strawberry_input

--- a/OneSila/llm/schema/types/types.py
+++ b/OneSila/llm/schema/types/types.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from core.schema.core.types.types import relay, type, strawberry_type, GetQuerysetMultiTenantMixin
 from .filters import BrandCustomPromptFilter
@@ -11,6 +11,7 @@ from llm.models import BrandCustomPrompt
 class AiContent:
     content: str
     points: str
+    bullet_point_index: Optional[int] = None
 
 
 @strawberry_type


### PR DESCRIPTION
## Summary
- add optional bullet_point_index to AI translation input and response payloads
- pass the provided bullet point index to the translation flow and include it in the GraphQL output
- update the translation flow to validate and use the explicit bullet point index when translating a single bullet point

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1db9376f0832eaed2aa827d0ab790

## Summary by Sourcery

Add support for optional bullet_point_index in the AI translation flow and GraphQL schema

New Features:
- Accept bullet_point_index in AITranslationInput and propagate it through AITranslateContentFlow
- Validate and apply bullet_point_index when translating a single bullet point
- Include bullet_point_index in the AiContent GraphQL response

Enhancements:
- Reset bullet_point_index state after translation to prevent stale values