### PR TITLE
Add GraphQL access for eBay product type items

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/schema/queries.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/queries.py
@@ -3,6 +3,7 @@ from sales_channels.integrations.ebay.schema.types.types import (
     EbaySalesChannelType,
     EbayInternalPropertyType,
     EbayProductTypeType,
+    EbayProductTypeItemType,
     EbayPropertyType,
     EbayPropertySelectValueType,
     EbaySalesChannelViewType,
@@ -19,6 +20,9 @@ class EbaySalesChannelsQuery:
 
     ebay_product_type: EbayProductTypeType = node()
     ebay_product_types: DjangoListConnection[EbayProductTypeType] = connection()
+
+    ebay_product_type_item: EbayProductTypeItemType = node()
+    ebay_product_type_items: DjangoListConnection[EbayProductTypeItemType] = connection()
 
     ebay_internal_property: EbayInternalPropertyType = node()
     ebay_internal_properties: DjangoListConnection[EbayInternalPropertyType] = connection()

--- a/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
@@ -6,12 +6,14 @@ from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
     EbayInternalProperty,
     EbayProductType,
+    EbayProductTypeItem,
     EbayProperty,
     EbayPropertySelectValue,
     EbaySalesChannelView,
 )
 from properties.schema.types.filters import (
     ProductPropertiesRuleFilter,
+    ProductPropertiesRuleItemFilter,
     PropertyFilter,
     PropertySelectValueFilter,
 )
@@ -40,6 +42,15 @@ class EbayProductTypeFilter(SearchFilterMixin, GeneralMappedLocallyFilterMixin, 
     local_instance: Optional[ProductPropertiesRuleFilter]
     marketplace: Optional[SalesChannelViewFilter]
     imported: auto
+
+
+@filter(EbayProductTypeItem)
+class EbayProductTypeItemFilter(SearchFilterMixin):
+    id: auto
+    product_type: Optional[EbayProductTypeFilter]
+    local_instance: Optional[ProductPropertiesRuleItemFilter]
+    ebay_property: Optional['EbayPropertyFilter']
+    remote_type: auto
 
 
 @filter(EbayProperty)

--- a/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
@@ -4,6 +4,7 @@ from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
     EbayInternalProperty,
     EbayProductType,
+    EbayProductTypeItem,
     EbayProperty,
     EbayPropertySelectValue,
     EbaySalesChannelView,
@@ -17,6 +18,11 @@ class EbaySalesChannelOrder:
 
 @order(EbayProductType)
 class EbayProductTypeOrder:
+    id: auto
+
+
+@order(EbayProductTypeItem)
+class EbayProductTypeItemOrder:
     id: auto
 
 

--- a/OneSila/sales_channels/integrations/ebay/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/types.py
@@ -12,6 +12,7 @@ from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
     EbayInternalProperty,
     EbayProductType,
+    EbayProductTypeItem,
     EbayProperty,
     EbayPropertySelectValue,
     EbaySalesChannelView,
@@ -20,6 +21,7 @@ from sales_channels.integrations.ebay.schema.types.filters import (
     EbaySalesChannelFilter,
     EbayInternalPropertyFilter,
     EbayProductTypeFilter,
+    EbayProductTypeItemFilter,
     EbayPropertyFilter,
     EbayPropertySelectValueFilter,
     EbaySalesChannelViewFilter,
@@ -28,6 +30,7 @@ from sales_channels.integrations.ebay.schema.types.ordering import (
     EbaySalesChannelOrder,
     EbayInternalPropertyOrder,
     EbayProductTypeOrder,
+    EbayProductTypeItemOrder,
     EbayPropertyOrder,
     EbayPropertySelectValueOrder,
     EbaySalesChannelViewOrder,
@@ -79,6 +82,28 @@ class EbayProductTypeType(relay.Node, GetQuerysetMultiTenantMixin):
     @field()
     def mapped_remotely(self, info) -> bool:
         return self.mapped_remotely
+
+
+@type(
+    EbayProductTypeItem,
+    filters=EbayProductTypeItemFilter,
+    order=EbayProductTypeItemOrder,
+    pagination=True,
+    fields="__all__",
+)
+class EbayProductTypeItemType(relay.Node, GetQuerysetMultiTenantMixin):
+    product_type: Annotated[
+        'EbayProductTypeType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]
+    ebay_property: Annotated[
+        'EbayPropertyType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]
+    local_instance: Optional[Annotated[
+        'ProductPropertiesRuleItemType',
+        lazy("properties.schema.types.types")
+    ]]
 
 
 @type(


### PR DESCRIPTION
## Summary
- add a Strawberry type, filter, and ordering definition for eBay product type items
- expose node and connection queries so the items can be retrieved through the API

## Testing
- python manage.py test sales_channels.integrations.ebay.tests.tests_schemas.tests_queries --settings OneSila.settings.agent

------
https://chatgpt.com/codex/tasks/task_e_68d2589aa724832eb3a0160d70f42284