### PR TITLE
Add eBay product type update mutation

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/mutations.py
@@ -5,6 +5,7 @@ from sales_channels.integrations.ebay.schema.types.input import (
     EbaySalesChannelInput,
     EbaySalesChannelPartialInput,
     EbayValidateAuthInput,
+    EbayProductTypePartialInput,
     EbayInternalPropertyPartialInput,
     EbayPropertyPartialInput,
     EbayPropertySelectValuePartialInput,
@@ -13,6 +14,7 @@ from sales_channels.integrations.ebay.schema.types.input import (
 from sales_channels.integrations.ebay.schema.types.types import (
     EbaySalesChannelType,
     EbayRedirectUrlType,
+    EbayProductTypeType,
     EbayInternalPropertyType,
     EbayPropertyType,
     EbayPropertySelectValueType,
@@ -35,6 +37,8 @@ class EbaySalesChannelMutation:
     create_ebay_sales_channels: List[EbaySalesChannelType] = create(EbaySalesChannelInput)
 
     update_ebay_sales_channel: EbaySalesChannelType = update(EbaySalesChannelPartialInput)
+
+    update_ebay_product_type: EbayProductTypeType = update(EbayProductTypePartialInput)
 
     update_ebay_property: EbayPropertyType = update(EbayPropertyPartialInput)
     update_ebay_internal_property: EbayInternalPropertyType = update(EbayInternalPropertyPartialInput)

--- a/OneSila/sales_channels/integrations/ebay/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/input.py
@@ -2,6 +2,7 @@ from core.schema.core.types.input import NodeInput, input, partial, strawberry_i
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
     EbayInternalProperty,
+    EbayProductType,
     EbayProperty,
     EbayPropertySelectValue,
     EbaySalesChannelView,
@@ -41,6 +42,11 @@ class EbayInternalPropertyInput:
 
 @partial(EbayInternalProperty, fields="__all__")
 class EbayInternalPropertyPartialInput(NodeInput):
+    pass
+
+
+@partial(EbayProductType, fields="__all__")
+class EbayProductTypePartialInput(NodeInput):
     pass
 
 


### PR DESCRIPTION
## Summary
- add the eBay product type partial input to the schema inputs
- expose the update_ebay_product_type mutation for GraphQL clients

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d25b5ebd50832ea13f82a39f274757

## Summary by Sourcery

Add GraphQL partial input type for eBay product types and expose an update_ebay_product_type mutation

New Features:
- Introduce EbayProductTypePartialInput to the GraphQL schema
- Expose update_ebay_product_type mutation for updating eBay product types