### PR TITLE
Add items relation to eBay product type GraphQL type

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/types.py
@@ -74,6 +74,10 @@ class EbayProductTypeType(relay.Node, GetQuerysetMultiTenantMixin):
         'SalesChannelViewType',
         lazy("sales_channels.schema.types.types")
     ]
+    items: List[Annotated[
+        'EbayProductTypeItemType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]]
 
     @field()
     def mapped_locally(self, info) -> bool:


### PR DESCRIPTION
## Summary
- expose the list of associated product type items on the eBay product type GraphQL type

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2e28772d0832e94ed6dff3deb1896