### PR TITLE
Expose search field on SalesChannelViewFilter

### DIFF
--- a/OneSila/sales_channels/managers.py
+++ b/OneSila/sales_channels/managers.py
@@ -88,6 +88,17 @@ class RemoteProductConfiguratorManager(PolymorphicManager, MultiTenantManager):
         return self.get_queryset().create_from_remote_product(*args, **kwargs)
 
 
+class SalesChannelViewQuerySet(PolymorphicQuerySet, MultiTenantQuerySet):
+    """QuerySet for :class:`SalesChannelView` with multitenancy and polymorphic support."""
+
+
+class SalesChannelViewManager(PolymorphicManager, MultiTenantManager):
+    """Manager for :class:`SalesChannelView` providing search and multitenancy."""
+
+    def get_queryset(self):
+        return SalesChannelViewQuerySet(self.model, using=self._db)
+
+
 class SalesChannelViewAssignQuerySet(PolymorphicQuerySet, MultiTenantQuerySet):
     """QuerySet for :class:`SalesChannelViewAssign` with multitenancy and polymorphic support."""
 

--- a/OneSila/sales_channels/models/sales_channels.py
+++ b/OneSila/sales_channels/models/sales_channels.py
@@ -5,7 +5,7 @@ from polymorphic.models import PolymorphicModel
 from core.helpers import get_languages
 from integrations.models import Integration
 from sales_channels.models.mixins import RemoteObjectMixin
-from sales_channels.managers import SalesChannelViewAssignManager
+from sales_channels.managers import SalesChannelViewAssignManager, SalesChannelViewManager
 
 import logging
 
@@ -132,9 +132,12 @@ class SalesChannelView(PolymorphicModel, RemoteObjectMixin, models.Model):
     name = models.CharField(max_length=216, null=True, blank=True)
     url = models.CharField(max_length=512, null=True, blank=True)
 
+    objects = SalesChannelViewManager()
+
     class Meta:
         verbose_name = 'Sales Channel View'
         verbose_name_plural = 'Sales Channel Views'
+        search_terms = ['name']
 
     def __str__(self):
         return str(self.name)

--- a/OneSila/sales_channels/schema/types/filters.py
+++ b/OneSila/sales_channels/schema/types/filters.py
@@ -157,6 +157,7 @@ class SalesChannelImportFilter(SearchFilterMixin):
 
 @filter(SalesChannelView)
 class SalesChannelViewFilter(SearchFilterMixin):
+    search: Optional[str]
     id: auto
     remote_id: auto
     sales_channel: Optional[SalesChannelFilter]


### PR DESCRIPTION
## Summary
- expose the GraphQL `search` field on `SalesChannelViewFilter` so clients can leverage the new manager-backed search by name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2ed637cec832e996f5f098bb3985b