### PR TITLE
Add GraphQL support for eBay import processes

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/mutations.py
@@ -9,6 +9,8 @@ from sales_channels.integrations.ebay.schema.types.input import (
     EbayInternalPropertyPartialInput,
     EbayPropertyPartialInput,
     EbayPropertySelectValuePartialInput,
+    EbaySalesChannelImportInput,
+    EbaySalesChannelImportPartialInput,
     EbaySalesChannelViewPartialInput,
 )
 from sales_channels.integrations.ebay.schema.types.types import (
@@ -19,6 +21,7 @@ from sales_channels.integrations.ebay.schema.types.types import (
     EbayPropertyType,
     EbayPropertySelectValueType,
     EbaySalesChannelViewType,
+    EbaySalesChannelImportType,
     SuggestedEbayCategory,
     SuggestedEbayCategoryEntry,
 )
@@ -44,6 +47,9 @@ class EbaySalesChannelMutation:
     update_ebay_internal_property: EbayInternalPropertyType = update(EbayInternalPropertyPartialInput)
     update_ebay_property_select_value: EbayPropertySelectValueType = update(EbayPropertySelectValuePartialInput)
     update_ebay_sales_channel_view: EbaySalesChannelViewType = update(EbaySalesChannelViewPartialInput)
+
+    create_ebay_import_process: EbaySalesChannelImportType = create(EbaySalesChannelImportInput)
+    update_ebay_import_process: EbaySalesChannelImportType = update(EbaySalesChannelImportPartialInput)
 
     @strawberry_django.mutation(handle_django_errors=True, extensions=default_extensions)
     def get_ebay_redirect_url(self, instance: EbaySalesChannelPartialInput, info: Info) -> EbayRedirectUrlType:

--- a/OneSila/sales_channels/integrations/ebay/schema/queries.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/queries.py
@@ -7,6 +7,7 @@ from sales_channels.integrations.ebay.schema.types.types import (
     EbayPropertyType,
     EbayPropertySelectValueType,
     EbaySalesChannelViewType,
+    EbaySalesChannelImportType,
 )
 
 
@@ -30,3 +31,6 @@ class EbaySalesChannelsQuery:
 
     ebay_sales_channel_view: EbaySalesChannelViewType = node()
     ebay_sales_channel_views: DjangoListConnection[EbaySalesChannelViewType] = connection()
+
+    ebay_import_process: EbaySalesChannelImportType = node()
+    ebay_import_processes: DjangoListConnection[EbaySalesChannelImportType] = connection()

--- a/OneSila/sales_channels/integrations/ebay/schema/subscriptions.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/subscriptions.py
@@ -1,6 +1,6 @@
 from core.schema.core.subscriptions import type, subscription, Info, AsyncGenerator, model_subscriber
-from sales_channels.integrations.ebay.models import EbaySalesChannel
-from sales_channels.integrations.ebay.schema.types.types import EbaySalesChannelType
+from sales_channels.integrations.ebay.models import EbaySalesChannel, EbaySalesChannelImport
+from sales_channels.integrations.ebay.schema.types.types import EbaySalesChannelType, EbaySalesChannelImportType
 
 
 @type(name='Subscription')
@@ -8,4 +8,9 @@ class EbaySalesChannelsSubscription:
     @subscription
     async def ebay_channel(self, info: Info, pk: str) -> AsyncGenerator[EbaySalesChannelType, None]:
         async for i in model_subscriber(info=info, pk=pk, model=EbaySalesChannel):
+            yield i
+
+    @subscription
+    async def ebay_import_process(self, info: Info, pk: str) -> AsyncGenerator[EbaySalesChannelImportType, None]:
+        async for i in model_subscriber(info=info, pk=pk, model=EbaySalesChannelImport):
             yield i

--- a/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
@@ -9,6 +9,7 @@ from sales_channels.integrations.ebay.models import (
     EbayProductTypeItem,
     EbayProperty,
     EbayPropertySelectValue,
+    EbaySalesChannelImport,
     EbaySalesChannelView,
 )
 from properties.schema.types.filters import (
@@ -97,3 +98,11 @@ class EbaySalesChannelViewFilter(SearchFilterMixin):
     id: auto
     sales_channel: Optional[SalesChannelFilter]
     is_default: auto
+
+
+@filter(EbaySalesChannelImport)
+class EbaySalesChannelImportFilter(SearchFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]
+    status: auto
+    type: auto

--- a/OneSila/sales_channels/integrations/ebay/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/input.py
@@ -5,6 +5,7 @@ from sales_channels.integrations.ebay.models import (
     EbayProductType,
     EbayProperty,
     EbayPropertySelectValue,
+    EbaySalesChannelImport,
     EbaySalesChannelView,
 )
 
@@ -57,6 +58,16 @@ class EbayPropertySelectValueInput:
 
 @partial(EbayPropertySelectValue, fields="__all__")
 class EbayPropertySelectValuePartialInput(NodeInput):
+    pass
+
+
+@input(EbaySalesChannelImport, exclude=['saleschannelimport_ptr', 'import_ptr'])
+class EbaySalesChannelImportInput:
+    pass
+
+
+@partial(EbaySalesChannelImport, fields="__all__")
+class EbaySalesChannelImportPartialInput(NodeInput):
     pass
 
 

--- a/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
@@ -7,6 +7,7 @@ from sales_channels.integrations.ebay.models import (
     EbayProductTypeItem,
     EbayProperty,
     EbayPropertySelectValue,
+    EbaySalesChannelImport,
     EbaySalesChannelView,
 )
 
@@ -43,4 +44,9 @@ class EbayPropertySelectValueOrder:
 
 @order(EbaySalesChannelView)
 class EbaySalesChannelViewOrder:
+    id: auto
+
+
+@order(EbaySalesChannelImport)
+class EbaySalesChannelImportOrder:
     id: auto

--- a/OneSila/sales_channels/integrations/ebay/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/types.py
@@ -8,6 +8,8 @@ from core.schema.core.types.types import (
     field,
     lazy,
 )
+from strawberry.relay import to_base64
+from imports_exports.schema.queries import ImportType
 from sales_channels.integrations.ebay.models import (
     EbaySalesChannel,
     EbayInternalProperty,
@@ -15,6 +17,7 @@ from sales_channels.integrations.ebay.models import (
     EbayProductTypeItem,
     EbayProperty,
     EbayPropertySelectValue,
+    EbaySalesChannelImport,
     EbaySalesChannelView,
 )
 from sales_channels.integrations.ebay.schema.types.filters import (
@@ -24,6 +27,7 @@ from sales_channels.integrations.ebay.schema.types.filters import (
     EbayProductTypeItemFilter,
     EbayPropertyFilter,
     EbayPropertySelectValueFilter,
+    EbaySalesChannelImportFilter,
     EbaySalesChannelViewFilter,
 )
 from sales_channels.integrations.ebay.schema.types.ordering import (
@@ -33,6 +37,7 @@ from sales_channels.integrations.ebay.schema.types.ordering import (
     EbayProductTypeItemOrder,
     EbayPropertyOrder,
     EbayPropertySelectValueOrder,
+    EbaySalesChannelImportOrder,
     EbaySalesChannelViewOrder,
 )
 
@@ -199,6 +204,30 @@ class EbayPropertySelectValueType(relay.Node, GetQuerysetMultiTenantMixin):
     @field()
     def mapped_remotely(self, info) -> bool:
         return self.mapped_remotely
+
+
+@type(
+    EbaySalesChannelImport,
+    filters=EbaySalesChannelImportFilter,
+    order=EbaySalesChannelImportOrder,
+    pagination=True,
+    fields="__all__",
+)
+class EbaySalesChannelImportType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'EbaySalesChannelType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]
+
+    @field()
+    def import_id(self, info) -> str:
+        return to_base64(ImportType, self.pk)
+
+    @field()
+    def proxy_id(self, info) -> str:
+        from sales_channels.schema.types.types import SalesChannelImportType
+
+        return to_base64(SalesChannelImportType, self.pk)
 
 
 @type(


### PR DESCRIPTION
## Summary
- add GraphQL types, filters, ordering, and inputs for `EbaySalesChannelImport`
- expose import process queries, mutations, and subscriptions for the eBay integration

## Testing
- python -m compileall OneSila/sales_channels/integrations/ebay/schema

------
https://chatgpt.com/codex/tasks/task_e_68d2f335628c832ea0ea04184c8f13f7