### PR TITLE
Add eBay currency GraphQL queries and mutation

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/mutations.py
@@ -12,6 +12,7 @@ from sales_channels.integrations.ebay.schema.types.input import (
     EbaySalesChannelImportInput,
     EbaySalesChannelImportPartialInput,
     EbaySalesChannelViewPartialInput,
+    EbayCurrencyPartialInput,
 )
 from sales_channels.integrations.ebay.schema.types.types import (
     EbaySalesChannelType,
@@ -22,6 +23,7 @@ from sales_channels.integrations.ebay.schema.types.types import (
     EbayPropertySelectValueType,
     EbaySalesChannelViewType,
     EbaySalesChannelImportType,
+    EbayCurrencyType,
     SuggestedEbayCategory,
     SuggestedEbayCategoryEntry,
 )
@@ -47,6 +49,7 @@ class EbaySalesChannelMutation:
     update_ebay_internal_property: EbayInternalPropertyType = update(EbayInternalPropertyPartialInput)
     update_ebay_property_select_value: EbayPropertySelectValueType = update(EbayPropertySelectValuePartialInput)
     update_ebay_sales_channel_view: EbaySalesChannelViewType = update(EbaySalesChannelViewPartialInput)
+    update_ebay_currency: EbayCurrencyType = update(EbayCurrencyPartialInput)
 
     create_ebay_import_process: EbaySalesChannelImportType = create(EbaySalesChannelImportInput)
     update_ebay_import_process: EbaySalesChannelImportType = update(EbaySalesChannelImportPartialInput)

--- a/OneSila/sales_channels/integrations/ebay/schema/queries.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/queries.py
@@ -8,6 +8,7 @@ from sales_channels.integrations.ebay.schema.types.types import (
     EbayPropertySelectValueType,
     EbaySalesChannelViewType,
     EbaySalesChannelImportType,
+    EbayCurrencyType,
 )
 
 
@@ -34,3 +35,6 @@ class EbaySalesChannelsQuery:
 
     ebay_import_process: EbaySalesChannelImportType = node()
     ebay_import_processes: DjangoListConnection[EbaySalesChannelImportType] = connection()
+
+    ebay_currency: EbayCurrencyType = node()
+    ebay_currencies: DjangoListConnection[EbayCurrencyType] = connection()

--- a/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
@@ -11,7 +11,9 @@ from sales_channels.integrations.ebay.models import (
     EbayPropertySelectValue,
     EbaySalesChannelImport,
     EbaySalesChannelView,
+    EbayCurrency,
 )
+from currencies.schema.types.filters import CurrencyFilter
 from properties.schema.types.filters import (
     ProductPropertiesRuleFilter,
     ProductPropertiesRuleItemFilter,
@@ -106,3 +108,11 @@ class EbaySalesChannelImportFilter(SearchFilterMixin):
     sales_channel: Optional[SalesChannelFilter]
     status: auto
     type: auto
+
+
+@filter(EbayCurrency)
+class EbayCurrencyFilter(SearchFilterMixin):
+    id: auto
+    sales_channel: Optional[SalesChannelFilter]
+    sales_channel_view: Optional[SalesChannelViewFilter]
+    local_instance: Optional[CurrencyFilter]

--- a/OneSila/sales_channels/integrations/ebay/schema/types/input.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/input.py
@@ -7,6 +7,7 @@ from sales_channels.integrations.ebay.models import (
     EbayPropertySelectValue,
     EbaySalesChannelImport,
     EbaySalesChannelView,
+    EbayCurrency,
 )
 
 
@@ -78,4 +79,9 @@ class EbaySalesChannelViewInput:
 
 @partial(EbaySalesChannelView, fields="__all__")
 class EbaySalesChannelViewPartialInput(NodeInput):
+    pass
+
+
+@partial(EbayCurrency, fields="__all__")
+class EbayCurrencyPartialInput(NodeInput):
     pass

--- a/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
@@ -9,6 +9,7 @@ from sales_channels.integrations.ebay.models import (
     EbayPropertySelectValue,
     EbaySalesChannelImport,
     EbaySalesChannelView,
+    EbayCurrency,
 )
 
 
@@ -49,4 +50,9 @@ class EbaySalesChannelViewOrder:
 
 @order(EbaySalesChannelImport)
 class EbaySalesChannelImportOrder:
+    id: auto
+
+
+@order(EbayCurrency)
+class EbayCurrencyOrder:
     id: auto

--- a/OneSila/sales_channels/integrations/ebay/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/types.py
@@ -19,6 +19,7 @@ from sales_channels.integrations.ebay.models import (
     EbayPropertySelectValue,
     EbaySalesChannelImport,
     EbaySalesChannelView,
+    EbayCurrency,
 )
 from sales_channels.integrations.ebay.schema.types.filters import (
     EbaySalesChannelFilter,
@@ -29,6 +30,7 @@ from sales_channels.integrations.ebay.schema.types.filters import (
     EbayPropertySelectValueFilter,
     EbaySalesChannelImportFilter,
     EbaySalesChannelViewFilter,
+    EbayCurrencyFilter,
 )
 from sales_channels.integrations.ebay.schema.types.ordering import (
     EbaySalesChannelOrder,
@@ -39,6 +41,7 @@ from sales_channels.integrations.ebay.schema.types.ordering import (
     EbayPropertySelectValueOrder,
     EbaySalesChannelImportOrder,
     EbaySalesChannelViewOrder,
+    EbayCurrencyOrder,
 )
 
 
@@ -246,6 +249,28 @@ class EbaySalesChannelViewType(relay.Node, GetQuerysetMultiTenantMixin):
     @field()
     def active(self, info) -> bool:
         return self.sales_channel.active
+
+
+@type(
+    EbayCurrency,
+    filters=EbayCurrencyFilter,
+    order=EbayCurrencyOrder,
+    pagination=True,
+    fields="__all__",
+)
+class EbayCurrencyType(relay.Node, GetQuerysetMultiTenantMixin):
+    sales_channel: Annotated[
+        'EbaySalesChannelType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]
+    sales_channel_view: Optional[Annotated[
+        'EbaySalesChannelViewType',
+        lazy("sales_channels.integrations.ebay.schema.types.types")
+    ]]
+    local_instance: Optional[Annotated[
+        'CurrencyType',
+        lazy("currencies.schema.types.types")
+    ]]
 
 
 @strawberry_type


### PR DESCRIPTION
## Summary
- expose eBay currency GraphQL type with filtering and ordering support
- add partial input, query fields, and update mutation for managing eBay currencies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3cb2cd53c832eb0633b5b7dbbeaf1

## Summary by Sourcery

Expose eBay currency in the GraphQL API by adding the EbayCurrency type with filtering, ordering, and pagination support along with corresponding queries and an update mutation.

New Features:
- Add EbayCurrency GraphQL type with all fields, filters, ordering, and pagination support
- Expose new queries `ebay_currency` and `ebay_currencies` for retrieving eBay currency records
- Add `EbayCurrencyPartialInput` and `update_ebay_currency` mutation for modifying eBay currency entries