### PR TITLE
Add admin interface for eBay categories

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/admin.py
+++ b/OneSila/sales_channels/integrations/ebay/admin.py
@@ -1,3 +1,10 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import EbayCategory
+
+
+@admin.register(EbayCategory)
+class EbayCategoryAdmin(admin.ModelAdmin):
+    list_display = ("name", "remote_id", "marketplace_default_tree_id")
+    list_filter = ("marketplace_default_tree_id",)
+    search_fields = ("name", "remote_id")


### PR DESCRIPTION
## Summary
- register the EbayCategory model in the Django admin
- expose key identifying fields in the list view for easier browsing

## Testing
- python manage.py check --settings OneSila.settings.agent

------
https://chatgpt.com/codex/tasks/task_e_68d3d74f0930832e8958afe7cad14f88

## Summary by Sourcery

Add an admin interface for the EbayCategory model to improve browsing and management

New Features:
- Register EbayCategory model in Django admin

Enhancements:
- Expose name, remote_id, and marketplace_default_tree_id in admin list view
- Add list filter by marketplace_default_tree_id
- Enable admin search on name and remote_id