### PR TITLE
Add factory to propagate eBay product type mappings

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/__init__.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/__init__.py
@@ -4,6 +4,7 @@ from .languages import EbayRemoteLanguagePullFactory
 from .views import EbaySalesChannelViewPullFactory
 from .categories import EbayCategorySuggestionFactory
 from .full_schema import EbayProductTypeRuleFactory
+from .product_type_mapping import EbayProductTypeRemoteMappingFactory
 
 __all__ = [
     'GetEbayRedirectUrlFactory',
@@ -13,4 +14,5 @@ __all__ = [
     'EbaySalesChannelViewPullFactory',
     'EbayProductTypeRuleFactory',
     'EbayCategorySuggestionFactory',
+    'EbayProductTypeRemoteMappingFactory',
 ]

--- a/OneSila/sales_channels/integrations/ebay/factories/sales_channels/product_type_mapping.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/sales_channels/product_type_mapping.py
@@ -1,0 +1,107 @@
+"""Utilities for mirroring eBay product type mappings across marketplaces."""
+
+from typing import Iterable
+
+from sales_channels.integrations.ebay.models import EbayCategory, EbayProductType
+
+
+class EbayProductTypeRemoteMappingFactory:
+    """Propagate a mapped eBay product type across sibling marketplaces."""
+
+    def __init__(self, *, product_type: EbayProductType) -> None:
+        self.product_type = product_type
+        self.remote_id: str = ""
+        self.source_tree_id: str = ""
+        self.target_tree_ids: set[str] = set()
+        self._related_product_types: list[EbayProductType] = []
+        self._should_run = True
+
+    def run(self) -> None:
+        """Assign the product type's remote id to matching marketplaces."""
+
+        self._initialize_context()
+        self._load_target_tree_ids()
+        self._load_related_product_types()
+        self._apply_remote_id_to_related_product_types()
+
+    def _initialize_context(self) -> None:
+        self._should_run = True
+        self.remote_id = ""
+        self.source_tree_id = ""
+        self.target_tree_ids = set()
+        self._related_product_types = []
+
+        product_type = self.product_type
+
+        self.remote_id = (product_type.remote_id or "").strip()
+        if not self.remote_id:
+            self._should_run = False
+            return
+
+        if not product_type.local_instance_id:
+            self._should_run = False
+            return
+
+        marketplace = product_type.marketplace
+        if marketplace is None:
+            self._should_run = False
+            return
+
+        self.source_tree_id = (
+            getattr(marketplace, "default_category_tree_id", None) or ""
+        ).strip()
+        if not self.source_tree_id:
+            self._should_run = False
+
+    def _load_target_tree_ids(self) -> None:
+        if not self._should_run:
+            return
+
+        self.target_tree_ids = self._collect_target_tree_ids(
+            remote_id=self.remote_id,
+            source_tree_id=self.source_tree_id,
+        )
+
+        if not self.target_tree_ids:
+            self._should_run = False
+
+    def _load_related_product_types(self) -> None:
+        if not self._should_run:
+            return
+
+        product_type = self.product_type
+        queryset = EbayProductType.objects.filter(
+            sales_channel=product_type.sales_channel,
+            multi_tenant_company=product_type.multi_tenant_company,
+            local_instance=product_type.local_instance,
+            marketplace__default_category_tree_id__in=self.target_tree_ids,
+        ).exclude(pk=product_type.pk)
+
+        self._related_product_types = list(queryset.iterator())
+
+    def _apply_remote_id_to_related_product_types(self) -> None:
+        if not self._should_run or not self._related_product_types:
+            return
+
+        updates: list[EbayProductType] = []
+        for candidate in self._related_product_types:
+            current_remote_id = (candidate.remote_id or "").strip()
+            if current_remote_id and current_remote_id != self.remote_id:
+                continue
+            if current_remote_id == self.remote_id:
+                continue
+            candidate.remote_id = self.remote_id
+            updates.append(candidate)
+
+        for candidate in updates:
+            candidate.save(update_fields=["remote_id"])
+
+    def _collect_target_tree_ids(self, *, remote_id: str, source_tree_id: str) -> set[str]:
+        """Return marketplace tree ids that share the given remote category id."""
+
+        tree_ids: Iterable[str | None] = (
+            EbayCategory.objects.filter(remote_id=remote_id)
+            .exclude(marketplace_default_tree_id=source_tree_id)
+            .values_list("marketplace_default_tree_id", flat=True)
+        )
+        return {tree_id for tree_id in tree_ids if tree_id}

--- a/OneSila/sales_channels/integrations/ebay/tests/tests_factories/test_product_type_remote_mapping_factory.py
+++ b/OneSila/sales_channels/integrations/ebay/tests/tests_factories/test_product_type_remote_mapping_factory.py
@@ -1,0 +1,160 @@
+"""Tests for the EbayProductTypeRemoteMappingFactory."""
+
+from __future__ import annotations
+
+from unittest.mock import PropertyMock, patch
+
+from properties.models import (
+    ProductPropertiesRule,
+    Property,
+    PropertySelectValue,
+    PropertySelectValueTranslation,
+)
+from sales_channels.integrations.ebay.factories.sales_channels import (
+    EbayProductTypeRemoteMappingFactory,
+)
+from sales_channels.integrations.ebay.models import EbayProductType, EbaySalesChannelView
+
+from .mixins import TestCaseEbayMixin
+
+
+class TestEbayProductTypeRemoteMappingFactory(TestCaseEbayMixin):
+    """Validate mirroring of eBay product type mappings across marketplaces."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.product_type_property = Property.objects.filter(
+            multi_tenant_company=self.multi_tenant_company,
+            is_product_type=True,
+        ).first()
+        if self.product_type_property is None:
+            self.product_type_property = Property.objects.create(
+                multi_tenant_company=self.multi_tenant_company,
+                type=Property.TYPES.SELECT,
+                is_product_type=True,
+            )
+        self.product_type_value, _ = PropertySelectValue.objects.get_or_create(
+            multi_tenant_company=self.multi_tenant_company,
+            property=self.product_type_property,
+        )
+        PropertySelectValueTranslation.objects.get_or_create(
+            multi_tenant_company=self.multi_tenant_company,
+            propertyselectvalue=self.product_type_value,
+            language=self.multi_tenant_company.language,
+            defaults={"value": "1990s"},
+        )
+        self.rule, _ = ProductPropertiesRule.objects.get_or_create(
+            multi_tenant_company=self.multi_tenant_company,
+            product_type=self.product_type_value,
+        )
+
+        self.view_gb = EbaySalesChannelView.objects.create(
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="EBAY_GB",
+            default_category_tree_id="3",
+            is_default=True,
+        )
+        self.view_us = EbaySalesChannelView.objects.create(
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="EBAY_US",
+            default_category_tree_id="205",
+            is_default=False,
+        )
+
+        self.product_type_gb = EbayProductType.objects.create(
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+            marketplace=self.view_gb,
+            local_instance=self.rule,
+            imported=False,
+        )
+        self.product_type_us = EbayProductType.objects.create(
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+            marketplace=self.view_us,
+            local_instance=self.rule,
+            imported=False,
+        )
+
+    def test_run_assigns_remote_id_to_matching_marketplaces(self) -> None:
+        """Direct factory execution mirrors the remote id to sibling marketplaces."""
+
+        self.product_type_gb.remote_id = "72548"
+        factory = EbayProductTypeRemoteMappingFactory(product_type=self.product_type_gb)
+        with patch.object(
+            EbayProductType,
+            "has_errors",
+            new_callable=PropertyMock,
+            return_value=False,
+        ):
+            with patch.object(
+                EbayProductTypeRemoteMappingFactory,
+                "_collect_target_tree_ids",
+                return_value={"205"},
+            ):
+                factory.run()
+
+        self.product_type_us.refresh_from_db()
+        self.assertEqual(self.product_type_us.remote_id, "72548")
+
+    def test_collect_target_tree_ids_uses_category_matches(self) -> None:
+        """Category lookups exclude the source tree and normalise identifiers."""
+
+        factory = EbayProductTypeRemoteMappingFactory(product_type=self.product_type_gb)
+        with patch(
+            "sales_channels.integrations.ebay.factories.sales_channels.product_type_mapping.EbayCategory.objects.filter",
+        ) as mock_filter:
+            mock_queryset = mock_filter.return_value
+            mock_exclude = mock_queryset.exclude.return_value
+            mock_exclude.values_list.return_value = ["205", None]
+
+            result = factory._collect_target_tree_ids(remote_id="72548", source_tree_id="3")
+
+        self.assertEqual(result, {"205"})
+        mock_filter.assert_called_once_with(remote_id="72548")
+        mock_queryset.exclude.assert_called_once_with(marketplace_default_tree_id="3")
+        mock_exclude.values_list.assert_called_once_with("marketplace_default_tree_id", flat=True)
+
+    def test_run_does_not_override_existing_remote_id(self) -> None:
+        """Existing mappings on other marketplaces remain untouched."""
+
+        EbayProductType.objects.filter(pk=self.product_type_us.pk).update(remote_id="99999")
+
+        self.product_type_gb.remote_id = "72548"
+        with patch.object(
+            EbayProductType,
+            "has_errors",
+            new_callable=PropertyMock,
+            return_value=False,
+        ):
+            with patch.object(
+                EbayProductTypeRemoteMappingFactory,
+                "_collect_target_tree_ids",
+                return_value={"205"},
+            ):
+                EbayProductTypeRemoteMappingFactory(product_type=self.product_type_gb).run()
+
+        self.product_type_us.refresh_from_db()
+        self.assertEqual(self.product_type_us.remote_id, "99999")
+
+    def test_signal_propagates_remote_id_on_update(self) -> None:
+        """Saving a remote id triggers propagation through the registered receiver."""
+
+        self.product_type_gb.remote_id = "72548"
+        with patch.object(
+            EbayProductType,
+            "has_errors",
+            new_callable=PropertyMock,
+            return_value=False,
+        ):
+            with patch.object(
+                EbayProductTypeRemoteMappingFactory,
+                "_collect_target_tree_ids",
+                return_value={"205"},
+            ):
+                self.product_type_gb.save(update_fields=["remote_id"])
+
+        self.product_type_us.refresh_from_db()
+        self.assertEqual(self.product_type_us.remote_id, "72548")


### PR DESCRIPTION
## Summary
- add an EbayProductTypeRemoteMappingFactory that mirrors remote IDs to sibling marketplaces
- hook the factory into Ebay product type updates and expose it via the sales channel factories package
- cover the propagation logic with targeted tests that patch external dependencies for sqlite compatibility
- refine the factory run orchestration to delegate to helper steps and drop unused future imports

## Testing
- python OneSila/manage.py test sales_channels.integrations.ebay.tests.tests_factories.test_product_type_remote_mapping_factory --settings OneSila.settings.agent

------
https://chatgpt.com/codex/tasks/task_e_68d3e5446a30832e91a8aa73f003e696