### PR TITLE
Refine eBay schema import aspect mapping

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/imports/schema_imports.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/imports/schema_imports.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
+from typing import Any
 
 from imports_exports.factories.imports import ImportMixin
 from sales_channels.integrations.ebay.factories.mixins import GetEbayAPIMixin
@@ -29,28 +30,28 @@ class EbaySchemaImportProcessor(ImportMixin, GetEbayAPIMixin):
         self.sales_channel = sales_channel
         self.initial_sales_channel_status = sales_channel.active
         self.api = self.get_api()
-        self.category_map: dict[str, set[str]] | None = None
+        self.category_map: dict[str, dict[str, dict[str, Any]]] | None = None
 
     def prepare_import_process(self):
         # Prevent push operations during the import and mark the channel as importing.
         self.sales_channel.active = False
         self.sales_channel.is_importing = True
-        self.category_map = self.get_all_category_ids()
+        self.category_map = self.get_category_aspects_map()
         self.sales_channel.save(update_fields=["active", "is_importing"])
 
     def get_total_instances(self):
-        total = sum(len(category_ids) for category_ids in self.category_map.values())
+        total = sum(len(categories) for categories in self.category_map.values())
         return max(total, 1)
 
     def import_rules_process(self):
-        total = sum(len(category_ids) for category_ids in self.category_map.values())
+        total = sum(len(categories) for categories in self.category_map.values())
 
         if total == 0:
             logger.info("No eBay categories found for sales channel %s", self.sales_channel)
             return
 
-        for marketplace_remote_id, category_ids in self.category_map.items():
-            view =  EbaySalesChannelView.objects.get(sales_channel=self.sales_channel, remote_id=marketplace_remote_id)
+        for marketplace_remote_id, categories in self.category_map.items():
+            view = EbaySalesChannelView.objects.get(sales_channel=self.sales_channel, remote_id=marketplace_remote_id)
 
             category_tree_id = view.default_category_tree_id
             if not category_tree_id:
@@ -59,16 +60,18 @@ class EbaySchemaImportProcessor(ImportMixin, GetEbayAPIMixin):
                     marketplace_remote_id,
                     self.sales_channel,
                 )
-                self.update_percentage(len(category_ids))
+                self.update_percentage(len(categories))
                 continue
 
-            for category_id in category_ids:
+            for category_id, category_details in categories.items():
+                aspects = category_details.get("aspects") if isinstance(category_details, Mapping) else None
                 factory = EbayProductTypeRuleFactory(
                     sales_channel=self.sales_channel,
                     view=view,
                     category_id=category_id,
                     category_tree_id=category_tree_id,
                     language=self.language,
+                    category_aspects=aspects,
                 )
                 factory.run()
                 self.update_percentage()


### PR DESCRIPTION
## Summary
- derive marketplace/category aspect maps from inventory offers instead of plain category lists
- feed observed aspect values into the product type rule factory and normalise them
- limit select value creation for free-text aspects to the observed values per category

## Testing
- python -m compileall OneSila/sales_channels/integrations/ebay/factories

------
https://chatgpt.com/codex/tasks/task_e_68d503a7794c832e934f3840026f8558

## Summary by Sourcery

Refine eBay schema import to derive and normalize aspect mappings from inventory offers, feed observed aspect values into the product type rule factory, and restrict free-text select value creation to only observed values per category.

New Features:
- Add extraction and normalization of product aspects from inventory offer payloads.

Enhancements:
- Refactor category mapping to return detailed aspect maps with normalized values per marketplace and category.
- Integrate enriched category_aspects into EbayProductTypeRuleFactory and schema import process.
- Limit creation of select/multiselect values for free-text aspects to the observed aspect values.