### PR TITLE
Add eBay category queries and enforce suggestion name

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/schema/mutations.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/mutations.py
@@ -95,7 +95,7 @@ class EbaySalesChannelMutation:
     @strawberry_django.mutation(handle_django_errors=False, extensions=default_extensions)
     def suggest_ebay_category(
         self,
-        name: str | None,
+        name: str,
         marketplace: SalesChannelViewPartialInput,
         info: Info,
     ) -> SuggestedEbayCategory:
@@ -104,7 +104,9 @@ class EbaySalesChannelMutation:
 
         multi_tenant_company = get_multi_tenant_company(info, fail_silently=False)
 
-        query = (name or "").strip()
+        query = name.strip()
+        if not query:
+            raise ValidationError(_("Category name is required."))
 
         view = SalesChannelView.objects.select_related("sales_channel").get(
             id=marketplace.id.node_id,

--- a/OneSila/sales_channels/integrations/ebay/schema/queries.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/queries.py
@@ -1,5 +1,6 @@
 from core.schema.core.queries import node, connection, DjangoListConnection, type
 from sales_channels.integrations.ebay.schema.types.types import (
+    EbayCategoryType,
     EbaySalesChannelType,
     EbayInternalPropertyType,
     EbayProductTypeType,
@@ -14,6 +15,9 @@ from sales_channels.integrations.ebay.schema.types.types import (
 
 @type(name="Query")
 class EbaySalesChannelsQuery:
+    ebay_category: EbayCategoryType = node()
+    ebay_categories: DjangoListConnection[EbayCategoryType] = connection()
+
     ebay_channel: EbaySalesChannelType = node()
     ebay_channels: DjangoListConnection[EbaySalesChannelType] = connection()
 

--- a/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/filters.py
@@ -3,6 +3,7 @@ from typing import Optional
 from core.schema.core.types.filters import filter, SearchFilterMixin
 from core.schema.core.types.types import auto
 from sales_channels.integrations.ebay.models import (
+    EbayCategory,
     EbaySalesChannel,
     EbayInternalProperty,
     EbayProductType,
@@ -36,6 +37,14 @@ from sales_channels.schema.types.filter_mixins import (
 class EbaySalesChannelFilter(SearchFilterMixin):
     active: auto
     hostname: auto
+
+
+@filter(EbayCategory)
+class EbayCategoryFilter(SearchFilterMixin):
+    id: auto
+    marketplace_default_tree_id: auto
+    remote_id: auto
+    name: auto
 
 
 @filter(EbayProductType)

--- a/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/ordering.py
@@ -1,6 +1,7 @@
 from core.schema.core.types.ordering import order
 from core.schema.core.types.types import auto
 from sales_channels.integrations.ebay.models import (
+    EbayCategory,
     EbaySalesChannel,
     EbayInternalProperty,
     EbayProductType,
@@ -15,6 +16,11 @@ from sales_channels.integrations.ebay.models import (
 
 @order(EbaySalesChannel)
 class EbaySalesChannelOrder:
+    id: auto
+
+
+@order(EbayCategory)
+class EbayCategoryOrder:
     id: auto
 
 

--- a/OneSila/sales_channels/integrations/ebay/schema/types/types.py
+++ b/OneSila/sales_channels/integrations/ebay/schema/types/types.py
@@ -11,6 +11,7 @@ from core.schema.core.types.types import (
 from strawberry.relay import to_base64
 from imports_exports.schema.queries import ImportType
 from sales_channels.integrations.ebay.models import (
+    EbayCategory,
     EbaySalesChannel,
     EbayInternalProperty,
     EbayProductType,
@@ -22,6 +23,7 @@ from sales_channels.integrations.ebay.models import (
     EbayCurrency,
 )
 from sales_channels.integrations.ebay.schema.types.filters import (
+    EbayCategoryFilter,
     EbaySalesChannelFilter,
     EbayInternalPropertyFilter,
     EbayProductTypeFilter,
@@ -33,6 +35,7 @@ from sales_channels.integrations.ebay.schema.types.filters import (
     EbayCurrencyFilter,
 )
 from sales_channels.integrations.ebay.schema.types.ordering import (
+    EbayCategoryOrder,
     EbaySalesChannelOrder,
     EbayInternalPropertyOrder,
     EbayProductTypeOrder,
@@ -48,6 +51,17 @@ from sales_channels.integrations.ebay.schema.types.ordering import (
 @strawberry_type
 class EbayRedirectUrlType:
     redirect_url: str
+
+
+@type(
+    EbayCategory,
+    filters=EbayCategoryFilter,
+    order=EbayCategoryOrder,
+    pagination=True,
+    fields="__all__",
+)
+class EbayCategoryType(relay.Node):
+    pass
 
 
 @type(EbaySalesChannel, filters=EbaySalesChannelFilter, order=EbaySalesChannelOrder, pagination=True, fields="__all__")


### PR DESCRIPTION
## Summary
- add list and node GraphQL queries for eBay categories backed by a new Strawberry type, filter, and ordering
- require a non-empty name for eBay category suggestions and simplify the factory to call the eBay API directly
- update the eBay category suggestion test to validate the new remote-only behaviour

## Testing
- python OneSila/manage.py test sales_channels.integrations.ebay.tests.tests_factories.test_category_node_sync_factory --settings OneSila.settings.agent

------
https://chatgpt.com/codex/tasks/task_e_68d516dd30a0832ea432d3840e713866

## Summary by Sourcery

Introduce full GraphQL support for eBay categories, enforce mandatory suggestion names, and refactor the suggestion factory to use only remote API results

New Features:
- Add GraphQL node and list queries for eBay categories with corresponding filters and ordering
- Enforce non-empty category name in suggestEbayCategory mutation with ValidationError

Enhancements:
- Simplify EbayCategorySuggestionFactory to always fetch remote suggestions and trim query input
- Update suggestion parsing to build full category path

Tests:
- Revise category suggestion factory tests to expect trimmed queries and remote-only suggestions