### PR TITLE
Add search-enabled manager for eBay categories

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/managers.py
+++ b/OneSila/sales_channels/integrations/ebay/managers.py
@@ -1,5 +1,8 @@
 from core.managers import MultiTenantManager, MultiTenantQuerySet
+from core.managers.search import SearchManagerMixin, SearchQuerySetMixin
 from django.db.models import BooleanField, Case, Value, When
+from django.db.models import Manager as DjangoManager
+from django.db.models import QuerySet as DjangoQuerySet
 from polymorphic.managers import PolymorphicManager, PolymorphicQuerySet
 
 from sales_channels.managers import _MappingManagerMixin, _MappingQuerySetMixin
@@ -48,3 +51,12 @@ class EbayPropertySelectValueManager(_MappingManagerMixin, MultiTenantManager):
 
 class EbayProductTypeManager(_MappingManagerMixin, MultiTenantManager):
     queryset_class = EbayProductTypeQuerySet
+
+
+class EbayCategoryQuerySet(SearchQuerySetMixin, DjangoQuerySet):
+    pass
+
+
+class EbayCategoryManager(SearchManagerMixin, DjangoManager):
+    def get_queryset(self):
+        return EbayCategoryQuerySet(self.model, using=self._db)

--- a/OneSila/sales_channels/integrations/ebay/models/categories.py
+++ b/OneSila/sales_channels/integrations/ebay/models/categories.py
@@ -1,4 +1,5 @@
 from core import models
+from sales_channels.integrations.ebay.managers import EbayCategoryManager
 
 
 class EbayCategory(models.SharedModel):
@@ -6,9 +7,12 @@ class EbayCategory(models.SharedModel):
     remote_id = models.CharField(max_length=50)
     name = models.CharField(max_length=512)
 
+    objects = EbayCategoryManager()
+
     class Meta:
         unique_together = ("marketplace_default_tree_id", "remote_id")
         ordering = ("marketplace_default_tree_id", "name")
+        search_terms = ['remote_id', 'name']
 
     def __str__(self) -> str:
         return f"{self.name} ({self.remote_id})"


### PR DESCRIPTION
## Summary
- add an eBay-specific search-aware queryset and manager for categories
- assign the new manager to the `EbayCategory` model so `.search()` is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d525d250c0832eae2544f49d21edc0