### PR TITLE
Add eBay marketplace account deletion webhook endpoint

### DIFF
--- a/OneSila/OneSila/settings/base.py
+++ b/OneSila/OneSila/settings/base.py
@@ -393,6 +393,12 @@ SHOPIFY_API_VERSION = "2025-04"
 SHOPIFY_TEST_REDIRECT_URI = os.getenv('SHOPIFY_TEST_REDIRECT_URI')
 SHOPIFY_API_KEY = os.getenv('SHOPIFY_API_KEY')
 SHOPIFY_API_SECRET = os.getenv('SHOPIFY_API_SECRET')
+
+#
+# eBay integration settings (sales_channels.integrations.ebay)
+#
+
+EBAY_ACCOUNT_DELETION_VERIFICATION_TOKEN = os.getenv('EBAY_ACCOUNT_DELETION_VERIFICATION_TOKEN', '')
 #
 # OpenAI settings. (llm)
 #

--- a/OneSila/OneSila/settings/local_template.py
+++ b/OneSila/OneSila/settings/local_template.py
@@ -119,5 +119,6 @@ EBAY_CLIENT_SECRET = None
 EBAY_DEV_ID = None
 EBAY_APPLICATION_SCOPES = ["https://api.ebay.com/oauth/api_scope"]
 EBAY_RU_NAME = 'Name'
+EBAY_ACCOUNT_DELETION_VERIFICATION_TOKEN = "replace-with-onesila-ebay-verification-token-123456"
 
 TEST_WEBHOOK_SECRET = "test-secret"

--- a/OneSila/OneSila/urls.py
+++ b/OneSila/OneSila/urls.py
@@ -40,6 +40,7 @@ urlpatterns = [
     path('sales_channels/', include('sales_channels.urls')),
     path('direct/integrations/shopify/', include('sales_channels.integrations.shopify.urls')),
     path('direct/integrations/amazon/', include('sales_channels.integrations.amazon.urls')),
+    path('direct/integrations/ebay/', include('sales_channels.integrations.ebay.urls')),
     path('integrations/', include('integrations.urls')),
     path('webhooks/test-receiver/', test_receiver),
     path('graphql/',

--- a/OneSila/sales_channels/integrations/ebay/tests/tests_views.py
+++ b/OneSila/sales_channels/integrations/ebay/tests/tests_views.py
@@ -1,0 +1,76 @@
+import hashlib
+import hmac
+import json
+
+from django.test import Client, override_settings
+
+from core.tests import TestCase
+from sales_channels.integrations.ebay.models.sales_channels import EbaySalesChannel
+
+
+class EbayMarketplaceAccountDeletionViewTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.client = Client()
+        self.url = "/direct/integrations/ebay/account-deletion/"
+
+    @override_settings(EBAY_ACCOUNT_DELETION_VERIFICATION_TOKEN="A" * 40)
+    def test_challenge_response_returns_expected_signature(self):
+        challenge_code = "challenge-code"
+        endpoint = "https://example.com/direct/integrations/ebay/account-deletion/"
+
+        response = self.client.get(
+            self.url,
+            data={
+                "challenge_code": challenge_code,
+                "endpoint": endpoint,
+                "verification_token": "A" * 40,
+            },
+        )
+
+        expected_signature = hmac.new(
+            key=("A" * 40).encode("utf-8"),
+            msg=f"{challenge_code}{endpoint}".encode("utf-8"),
+            digestmod=hashlib.sha256,
+        ).hexdigest()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"challengeResponse": expected_signature})
+
+    @override_settings(EBAY_ACCOUNT_DELETION_VERIFICATION_TOKEN="B" * 32)
+    def test_notification_marks_sales_channel_for_deletion(self):
+        channel = EbaySalesChannel.objects.create(
+            hostname="ebay-store",
+            multi_tenant_company=self.multi_tenant_company,
+            remote_id="seller-123",
+        )
+
+        payload = {
+            "notification": {
+                "data": {
+                    "sellerId": "seller-123",
+                }
+            }
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_X_EBAY_VERIFICATION_TOKEN="B" * 32,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        channel.refresh_from_db()
+        self.assertTrue(channel.mark_for_delete)
+
+    @override_settings(EBAY_ACCOUNT_DELETION_VERIFICATION_TOKEN="C" * 32)
+    def test_notification_with_invalid_token_is_rejected(self):
+        response = self.client.post(
+            self.url,
+            data=json.dumps({}),
+            content_type="application/json",
+            HTTP_X_EBAY_VERIFICATION_TOKEN="invalid-token",
+        )
+
+        self.assertEqual(response.status_code, 403)

--- a/OneSila/sales_channels/integrations/ebay/urls.py
+++ b/OneSila/sales_channels/integrations/ebay/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from . import views
+
+app_name = "ebay"
+
+urlpatterns = [
+    path(
+        "account-deletion/",
+        views.ebay_marketplace_account_deletion,
+        name="marketplace_account_deletion",
+    ),
+]

--- a/OneSila/sales_channels/integrations/ebay/views.py
+++ b/OneSila/sales_channels/integrations/ebay/views.py
@@ -1,4 +1,146 @@
-from core.views import EmptyTemplateView
+import hashlib
+import hmac
+import json
+import logging
+from typing import Any
 
-# class SomeModelView(EmptyTemplateView):
-#    pass
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponse, JsonResponse
+from django.utils.crypto import constant_time_compare
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+
+from sales_channels.integrations.ebay.models.sales_channels import EbaySalesChannel
+
+logger = logging.getLogger(__name__)
+
+
+def _get_verification_token() -> str:
+    token = getattr(settings, "EBAY_ACCOUNT_DELETION_VERIFICATION_TOKEN", "")
+    if not token:
+        raise ImproperlyConfigured("Missing EBAY_ACCOUNT_DELETION_VERIFICATION_TOKEN setting")
+    if not 32 <= len(token) <= 80:
+        raise ImproperlyConfigured("EBAY_ACCOUNT_DELETION_VERIFICATION_TOKEN must be between 32 and 80 characters")
+    return token
+
+
+def _compute_challenge_response(*, challenge_code: str, verification_token: str, endpoint: str) -> str:
+    message = f"{challenge_code}{endpoint}".encode("utf-8")
+    key = verification_token.encode("utf-8")
+    return hmac.new(key=key, msg=message, digestmod=hashlib.sha256).hexdigest()
+
+
+def _extract_account_identifier(*, payload: Any) -> str | None:
+    candidate_keys = {
+        "sellerid",
+        "userid",
+        "username",
+        "remoteid",
+        "remote_id",
+        "accountid",
+        "account_id",
+        "ebayaccountid",
+        "ebayuserid",
+    }
+    stack: list[Any] = [payload]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            for key, value in current.items():
+                if isinstance(value, (dict, list)):
+                    stack.append(value)
+                elif isinstance(value, str) and key.lower() in candidate_keys:
+                    return value
+        elif isinstance(current, list):
+            stack.extend(item for item in current if isinstance(item, (dict, list)))
+    return None
+
+
+def _extract_request_token(*, request) -> str | None:
+    header_value = request.headers.get("X-EBAY-VERIFICATION-TOKEN")
+    if header_value:
+        return header_value
+
+    return (
+        request.GET.get("verification_token")
+        or request.GET.get("verificationToken")
+    )
+
+
+def _handle_challenge(*, request, verification_token: str) -> HttpResponse:
+    challenge_code = request.GET.get("challenge_code") or request.GET.get("challengeCode")
+    if not challenge_code:
+        logger.warning("eBay account deletion challenge missing challenge code")
+        return HttpResponse(status=400)
+
+    endpoint = request.GET.get("endpoint") or request.build_absolute_uri()
+    provided_token = _extract_request_token(request=request)
+    if provided_token and not constant_time_compare(provided_token, verification_token):
+        logger.warning("eBay account deletion challenge token mismatch")
+        return HttpResponse(status=403)
+
+    response = _compute_challenge_response(
+        challenge_code=challenge_code,
+        verification_token=verification_token,
+        endpoint=endpoint,
+    )
+    return JsonResponse({"challengeResponse": response})
+
+
+def _handle_notification(*, request, verification_token: str) -> HttpResponse:
+    provided_token = _extract_request_token(request=request)
+    if not provided_token:
+        logger.warning("eBay account deletion notification missing verification token")
+        return HttpResponse(status=403)
+    if not constant_time_compare(provided_token, verification_token):
+        logger.warning("eBay account deletion notification token mismatch")
+        return HttpResponse(status=403)
+
+    try:
+        raw_body = request.body.decode("utf-8")
+    except UnicodeDecodeError:
+        logger.warning("eBay account deletion payload is not valid UTF-8")
+        return HttpResponse(status=400)
+
+    body = raw_body.strip()
+    if not body:
+        payload: dict[str, Any] = {}
+    else:
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            logger.warning("eBay account deletion payload is not valid JSON")
+            return HttpResponse(status=400)
+
+    identifier = _extract_account_identifier(payload=payload)
+    if not identifier:
+        logger.warning("eBay account deletion payload missing account identifier")
+        return HttpResponse(status=200)
+
+    channel = EbaySalesChannel.objects.filter(remote_id=identifier).first()
+    if not channel:
+        logger.warning("No eBay SalesChannel found for remote_id=%s", identifier)
+        return HttpResponse(status=200)
+
+    if not channel.mark_for_delete:
+        channel.mark_for_delete = True
+        channel.save(update_fields=["mark_for_delete"])
+        logger.info("Marked eBay SalesChannel %s for deletion", channel.pk)
+
+    return HttpResponse(status=200)
+
+
+@csrf_exempt
+@require_http_methods(["GET", "POST"])
+def ebay_marketplace_account_deletion(request):
+    try:
+        verification_token = _get_verification_token()
+    except ImproperlyConfigured as exc:
+        logger.error("eBay account deletion endpoint misconfigured: %s", exc)
+        return HttpResponse(status=500)
+
+    if request.method == "GET":
+        return _handle_challenge(request=request, verification_token=verification_token)
+
+    return _handle_notification(request=request, verification_token=verification_token)


### PR DESCRIPTION
## Summary
- add configuration for the eBay account deletion verification token and expose the integration URLs publicly
- implement the marketplace account deletion endpoint that validates challenges and marks the eBay sales channel for deletion
- cover the endpoint with unit tests for challenge responses, channel deletion, and invalid token handling

## Testing
- python OneSila/manage.py test sales_channels.integrations.ebay.tests.tests_views --settings OneSila.settings.agent

------
https://chatgpt.com/codex/tasks/task_e_68da72baa920832e9bd85e0ee4d249b1

## Summary by Sourcery

Add a new eBay marketplace account deletion webhook endpoint with GET challenge verification and POST notification handling to mark sales channels for deletion.

New Features:
- Implement a CSRF-exempt endpoint for eBay account deletion with HMAC-based challenge-response and notification processing
- Add EBAY_ACCOUNT_DELETION_VERIFICATION_TOKEN setting for webhook verification token configuration
- Expose the account deletion endpoint at /direct/integrations/ebay/account-deletion/ via URL routing

Tests:
- Cover challenge-response flow with expected signature verification
- Verify that valid notifications mark the corresponding eBay sales channel for deletion
- Ensure notifications with invalid tokens are rejected with a 403 status