### PR TITLE
Filter eBay product imports to offers only

### DIFF
--- a/OneSila/sales_channels/integrations/ebay/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/ebay/factories/mixins.py
@@ -370,7 +370,7 @@ class GetEbayAPIMixin:
             if not isinstance(product, dict):
                 continue
 
-            sku = product.get("sku") or product.get("inventoryItemSku")
+            sku = product.get("sku") or product.get("inventory_item_sku")
             if not sku:
                 continue
 
@@ -386,11 +386,11 @@ class GetEbayAPIMixin:
                 if not isinstance(offer, dict):
                     continue
 
-                marketplace_id = offer.get("marketplace_id") or offer.get("marketplaceId")
+                marketplace_id = offer.get("marketplace_id")
                 if not marketplace_id:
                     continue
 
-                category_id = offer.get("category_id") or offer.get("categoryId")
+                category_id = offer.get("category_id")
                 if not category_id:
                     continue
 


### PR DESCRIPTION
## Summary
- restrict eBay product imports to inventory items that expose a valid SKU in snake_case form
- pair each imported product with concrete offer payloads and skip processing items lacking offers
- align the category aspects helper with the API's snake_case fields for SKU, marketplace, and category identifiers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db01b32140832e898a885850b07848

## Summary by Sourcery

Restrict the eBay product import pipeline to items with valid SKUs and actual offers, update the import process to yield and process product-offer pairs, and standardize field naming to snake_case in category aspects mapping.

New Features:
- Filter eBay product imports to only include inventory items with valid snake_case SKUs and associated offers

Enhancements:
- Pair imported products with offer payloads and skip items without offers
- Update process_product_item signature to accept offer_data alongside product_data
- Align category aspects helper to use snake_case fields for SKU, marketplace_id, and category_id