### PR TITLE
Fail fast on missing eBay locale mapping

### DIFF
--- a/OneSila/products/models.py
+++ b/OneSila/products/models.py
@@ -655,6 +655,7 @@ class ProductTranslation(TranslationFieldsMixin, models.Model):
     sales_channel = models.ForeignKey('sales_channels.SalesChannel', null=True, blank=True, on_delete=models.CASCADE, related_name='product_translations')
 
     name = models.CharField(max_length=512)
+    subtitle = models.CharField(max_length=512, null=True, blank=True)
     short_description = models.TextField(blank=True, null=True)
     description = models.TextField(blank=True, null=True)
     url_key = models.CharField(max_length=512, null=True, blank=True)


### PR DESCRIPTION
## Summary
- require eBay inventory items to resolve to a mapped locale language before creating translations

## Testing
- python -m compileall OneSila/sales_channels/integrations/ebay/factories/imports/products_imports.py

------
https://chatgpt.com/codex/tasks/task_e_68db0ed24f84832eb867217c5f2d6bd5

## Summary by Sourcery

Implement translation extraction and validation for eBay product imports, enforcing mapped locales and adding subtitle support.

New Features:
- Extract and normalize title, subtitle, description, and listing_description in _parse_translations for eBay products.
- Raise errors when an eBay inventory item is missing a locale or its locale isn’t mapped to a local language.

Enhancements:
- Add subtitle field to ProductTranslation model.