### PR TITLE
Add optional title support for image URL imports

### DIFF
--- a/OneSila/imports_exports/factories/media.py
+++ b/OneSila/imports_exports/factories/media.py
@@ -16,6 +16,8 @@ class ImportImageInstance(AbstractImportInstance):
       - image_url: HTTPS URL of the image (used if image_content is not provided).
       - image_content: Binary or base64 image content (takes priority over image_url).
       - type: Image type; defaults to Image.PACK_SHOT if not provided.
+      - title: Optional image title.
+      - description: Optional image description.
       - product_data: Optional data for importing an associated product.
       - is_main_image: Optional boolean flag indicating if this is the main image (default: False).
       - sort_order: Optional integer for ordering (default: 10).
@@ -30,6 +32,8 @@ class ImportImageInstance(AbstractImportInstance):
         self.set_field_if_exists('image_url')
         self.set_field_if_exists('image_content')
         self.set_field_if_exists('type', default_value=Image.PACK_SHOT)
+        self.set_field_if_exists('title')
+        self.set_field_if_exists('description')
         self.set_field_if_exists('product_data')
 
         # relevant only if we have either product or product_data provided
@@ -94,6 +98,12 @@ class ImportImageInstance(AbstractImportInstance):
             'multi_tenant_company': self.multi_tenant_company,
             'image_type': self.type,
         }
+
+        if hasattr(self, 'title'):
+            self.kwargs['title'] = self.title
+
+        if hasattr(self, 'description'):
+            self.kwargs['description'] = self.description
 
         try:
             if hasattr(self, 'image_content'):

--- a/OneSila/media/schema/mutations/mutation_type.py
+++ b/OneSila/media/schema/mutations/mutation_type.py
@@ -55,7 +55,11 @@ class MediaMutation:
         images = []
         for image_url in urls:
             importer = ImportImageInstance(
-                {'image_url': image_url.url, 'type': image_url.type},
+                {
+                    'image_url': image_url.url,
+                    'type': image_url.type,
+                    'title': image_url.title,
+                },
                 import_process=import_process,
             )
             importer.process()

--- a/OneSila/media/schema/types/input.py
+++ b/OneSila/media/schema/types/input.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from core.schema.core.types.input import NodeInput, input, partial, strawberry_input
 from media.models import Media, Image, Video, MediaProductThrough, File
 
@@ -56,3 +58,4 @@ class MediaProductThroughPartialInput(NodeInput):
 class ImageUrlInput:
     url: str
     type: str
+    title: Optional[str] = None

--- a/README.md
+++ b/README.md
@@ -104,6 +104,23 @@ will yield:
 }
 ```
 
+### Importing images via GraphQL
+
+Images can be uploaded in bulk by calling the `uploadImagesFromUrls` mutation. Each entry accepts the image URL, type, and an optional title:
+
+```graphql
+mutation uploadImagesFromUrls {
+  uploadImagesFromUrls(
+    urls: [
+      { url: "https://example.com/product.jpg", type: "PACK", title: "Front shot" }
+    ]
+  ) {
+    id
+    title
+  }
+}
+```
+
 ## Running tests
 
 Runings tests, including coverage:


### PR DESCRIPTION
## Summary
- allow the `ImageUrlInput` GraphQL input to include an optional title and pass it to the importer
- persist media titles and descriptions when importing images from URLs
- document the new `uploadImagesFromUrls` input in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dda470afb8832eb0b5713c79055449