### PR TITLE
Support subtitle field in AI translation and generation flows

### DIFF
--- a/OneSila/llm/factories/content.py
+++ b/OneSila/llm/factories/content.py
@@ -365,6 +365,56 @@ class ShortDescriptionLLM(DescriptionGenLLM):
         return base_prompt + channel_addition
 
 
+class SubtitleLLM(ContentLLMMixin):
+    """Generate a concise subtitle for a product."""
+
+    @property
+    def system_prompt(self):
+        return (
+            "You create concise product subtitles or taglines. Respond with a single "
+            "sentence under 80 characters in the requested language. Do not use HTML "
+            "or markdown and avoid repeating the product name verbatim."
+        )
+
+    @property
+    def prompt(self):
+        prompt = f"""
+        ##Language Code##
+        {self.language_code}
+
+        ##Product name##
+        {self.product_name}
+
+        ##Product attributes##
+        {self.property_values}
+        """
+
+        if self.short_description:
+            prompt += f"""
+            ##Product Short Description##
+            {self.short_description}
+            """
+
+        if self.brand_prompt:
+            prompt += f"""
+            ##Brand Personality##
+            {self.brand_prompt}
+            """
+
+        prompt += """
+        ##Instructions##
+        Craft a persuasive subtitle or tagline that complements the product name.
+        Keep it conversational, benefit driven, and within 80 characters.
+        Avoid quotation marks, trailing punctuation, or repeating the product name.
+        """
+
+        return prompt
+
+    def parse_response(self):
+        lines = [line.strip().strip('"\'') for line in self.text_response.splitlines() if line.strip()]
+        self.text_response = lines[0] if lines else ""
+
+
 class BulletPointsLLM(ContentLLMMixin):
     """Generate bullet points for a product."""
 

--- a/OneSila/llm/flows/generate_ai_content.py
+++ b/OneSila/llm/flows/generate_ai_content.py
@@ -1,4 +1,4 @@
-from llm.factories.content import DescriptionGenLLM, ShortDescriptionLLM
+from llm.factories.content import DescriptionGenLLM, ShortDescriptionLLM, SubtitleLLM
 from llm.schema.types.input import ContentAiGenerateType
 
 
@@ -7,6 +7,7 @@ class AIGenerateContentFlow:
         factory_map = {
             ContentAiGenerateType.DESCRIPTION: DescriptionGenLLM,
             ContentAiGenerateType.SHORT_DESCRIPTION: ShortDescriptionLLM,
+            ContentAiGenerateType.SUBTITLE: SubtitleLLM,
         }
         factory_class = factory_map.get(content_type, DescriptionGenLLM)
 

--- a/OneSila/llm/flows/translate_ai_content.py
+++ b/OneSila/llm/flows/translate_ai_content.py
@@ -56,6 +56,9 @@ class AITranslateContentFlow:
                 if self.content_type == ContentAiGenerateType.SHORT_DESCRIPTION:
                     self.to_translate = self._get_safe_translation(translation, 'short_description')
 
+                if self.content_type == ContentAiGenerateType.SUBTITLE:
+                    self.to_translate = self._get_safe_translation(translation, 'subtitle')
+
                 if self.content_type == ContentAiGenerateType.NAME:
                     self.to_translate = self._get_safe_translation(translation, 'name')
 
@@ -165,6 +168,7 @@ class BulkAiTranslateContentFlow:
 
                 for content_type in [
                     ContentAiGenerateType.NAME,
+                    ContentAiGenerateType.SUBTITLE,
                     ContentAiGenerateType.SHORT_DESCRIPTION,
                     ContentAiGenerateType.DESCRIPTION
                 ]:

--- a/OneSila/llm/schema/types/input.py
+++ b/OneSila/llm/schema/types/input.py
@@ -22,6 +22,7 @@ from sales_channels.schema.types.input import SalesChannelPartialInput
 class ContentAiGenerateType(Enum):
     DESCRIPTION = "description"
     SHORT_DESCRIPTION = "short_description"
+    SUBTITLE = "subtitle"
     NAME = "name"
     BULLET_POINTS = "bullet_points"
 

--- a/OneSila/llm/tests/tests_flows/test_subtitle_ai_support.py
+++ b/OneSila/llm/tests/tests_flows/test_subtitle_ai_support.py
@@ -1,0 +1,82 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from core.tests import TestCase
+from llm.factories.content import SubtitleLLM
+from llm.factories.translations import StringTranslationLLM
+from llm.flows.generate_ai_content import AIGenerateContentFlow
+from llm.flows.translate_ai_content import AITranslateContentFlow, BulkAiTranslateContentFlow
+from llm.schema.types.input import ContentAiGenerateType
+from products.models import ProductTranslation, SimpleProduct
+
+
+def _fake_translate(instance):
+    instance.ai_process = SimpleNamespace(transaction=SimpleNamespace(points=1))
+    return f"translated-{instance.to_translate}"
+
+
+def _fake_generate(instance):
+    instance.ai_process = SimpleNamespace(
+        result="Generated subtitle",
+        transaction=SimpleNamespace(points=3),
+    )
+    return instance.ai_process.result
+
+
+class SubtitleAiFlowsTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.multi_tenant_company.language = "en"
+        self.multi_tenant_company.save()
+        self.product = SimpleProduct.objects.create(multi_tenant_company=self.multi_tenant_company)
+        ProductTranslation.objects.create(
+            product=self.product,
+            language=self.multi_tenant_company.language,
+            name="Rain Coat",
+            subtitle="Stay dry in style",
+            short_description="Waterproof coat for rainy days",
+            description="Long description",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def test_ai_translate_flow_supports_subtitle(self):
+        with patch.object(StringTranslationLLM, "translate", new=_fake_translate):
+            flow = AITranslateContentFlow(
+                multi_tenant_company=self.multi_tenant_company,
+                to_translate=None,
+                from_language_code=self.multi_tenant_company.language,
+                to_language_code="nl",
+                product=self.product,
+                content_type=ContentAiGenerateType.SUBTITLE,
+            )
+
+            result = flow.flow()
+
+        self.assertEqual(result, "translated-Stay dry in style")
+        self.assertEqual(flow.used_points, 1)
+
+    def test_bulk_translation_updates_subtitle(self):
+        with patch.object(StringTranslationLLM, "translate", new=_fake_translate):
+            flow = BulkAiTranslateContentFlow(
+                multi_tenant_company=self.multi_tenant_company,
+                from_language_code=self.multi_tenant_company.language,
+                to_language_codes=["nl"],
+                products=SimpleProduct.objects.filter(id=self.product.id),
+            )
+            flow.translate_products()
+
+        translation = ProductTranslation.objects.get(product=self.product, language="nl")
+        self.assertEqual(translation.subtitle, "translated-Stay dry in style")
+        self.assertEqual(flow.total_points, 4)
+
+    def test_ai_generate_flow_uses_subtitle_factory(self):
+        with patch.object(SubtitleLLM, "generate_response", new=_fake_generate):
+            flow = AIGenerateContentFlow(
+                product=self.product,
+                language="nl",
+                content_type=ContentAiGenerateType.SUBTITLE,
+            )
+            content = flow.flow()
+
+        self.assertEqual(content, "Generated subtitle")
+        self.assertEqual(flow.used_points, 3)


### PR DESCRIPTION
## Summary
- add the subtitle field to the AI content enum and update translate/generate flows to populate it
- introduce a SubtitleLLM factory dedicated to generating concise subtitle copy
- verify subtitle handling with new flow-level tests that exercise translation, bulk translation, and generation paths

## Testing
- python manage.py test llm.tests.tests_flows.test_subtitle_ai_support --settings OneSila.settings.agent

------
https://chatgpt.com/codex/tasks/task_e_68dda68453a0832e8c010ede74ad67ff