### PR TITLE
Refine starting stock handling across integrations

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/admin.py
+++ b/OneSila/sales_channels/integrations/amazon/admin.py
@@ -51,7 +51,7 @@ class AmazonSalesChannelAdmin(PolymorphicChildModelAdmin):
             'fields': ('hostname', 'active', 'verify_ssl', 'region', 'refresh_token', 'first_import_complete', 'is_importing', 'multi_tenant_company')
         }),
         ('Amazon Settings', {
-            'fields': ('use_configurable_name', 'sync_contents', 'sync_ean_codes', 'sync_prices', 'import_orders', 'requests_per_minute', 'max_retries')
+            'fields': ('use_configurable_name', 'sync_contents', 'sync_ean_codes', 'sync_prices', 'import_orders', 'starting_stock', 'requests_per_minute', 'max_retries')
         }),
     )
 

--- a/OneSila/sales_channels/integrations/magento2/admin.py
+++ b/OneSila/sales_channels/integrations/magento2/admin.py
@@ -24,7 +24,7 @@ class MagentoSalesChannelAdmin(PolymorphicChildModelAdmin):
             'fields': ('hostname', 'active', 'verify_ssl', 'authentication_method', 'host_api_username', 'host_api_key', 'first_import_complete', 'is_importing', 'multi_tenant_company')
         }),
         ('Magento Settings', {
-            'fields': ('attribute_set_skeleton_id', 'use_configurable_name', 'sync_contents', 'sync_ean_codes', 'sync_prices', 'import_orders', 'requests_per_minute', 'max_retries')
+            'fields': ('attribute_set_skeleton_id', 'use_configurable_name', 'sync_contents', 'sync_ean_codes', 'sync_prices', 'import_orders', 'starting_stock', 'requests_per_minute', 'max_retries')
         }),
     )
 

--- a/OneSila/sales_channels/integrations/magento2/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/magento2/factories/products/products.py
@@ -124,13 +124,17 @@ class MagentoProductSyncFactory(GetMagentoAPIMixin, RemoteProductSyncFactory):
         )
 
     def set_stock(self):
-        return  # @TODO: Come back after we decide with inventory
+        if not getattr(self, "is_create", False):
+            return
 
         if self.remote_type == self.REMOTE_TYPE_CONFIGURABLE:
-            self.stock = None
-        else:
-            self.stock = self.local_instance.inventory.salable()
+            return
 
+        starting_stock = getattr(self.sales_channel, "starting_stock", None)
+        if starting_stock is None:
+            return
+
+        self.stock = starting_stock
         self.add_field_in_payload('stock', self.stock)
 
     def set_price(self):

--- a/OneSila/sales_channels/integrations/shopify/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/shopify/factories/products/products.py
@@ -462,6 +462,16 @@ class ShopifyProductCreateFactory(ShopifyProductSyncFactory, RemoteProductCreate
             self._assign_image_remote_ids()
             self._publish_product()
 
+    def _apply_starting_stock(self):
+        if not getattr(self, "is_create", False):
+            return
+
+        starting_stock = getattr(self.sales_channel, "starting_stock", None)
+        if starting_stock is None:
+            return
+
+        self.variant_payload['inventoryQuantity'] = starting_stock
+
     def _publish_product(self):
         publication_ids = ShopifySalesChannelView.objects.filter(sales_channel=self.sales_channel).values_list('publication_id', flat=True).distinct()
 
@@ -570,6 +580,7 @@ class ShopifyProductCreateFactory(ShopifyProductSyncFactory, RemoteProductCreate
 
     def customize_payload(self):
         super().customize_payload()
+        self._apply_starting_stock()
         super().assign_images()
 
         if self.local_instance.type == Product.CONFIGURABLE:

--- a/OneSila/sales_channels/integrations/woocommerce/admin.py
+++ b/OneSila/sales_channels/integrations/woocommerce/admin.py
@@ -21,7 +21,7 @@ class WoocommerceSalesChannelAdmin(PolymorphicChildModelAdmin):
         }),
         ('Synchronization Settings', {
             'fields': ('use_configurable_name', 'sync_contents', 'sync_ean_codes',
-                      'sync_prices', 'import_orders', 'first_import_complete',
+                      'sync_prices', 'import_orders', 'starting_stock', 'first_import_complete',
                       'is_importing', 'requests_per_minute', 'max_retries')
         }),
     )

--- a/OneSila/sales_channels/models/sales_channels.py
+++ b/OneSila/sales_channels/models/sales_channels.py
@@ -25,6 +25,11 @@ class SalesChannel(Integration, models.Model):
     first_import_complete = models.BooleanField(default=False, help_text="Set to True once the first import has been completed.")
     is_importing = models.BooleanField(default=False, help_text=_("True while an import process is running."))
     mark_for_delete = models.BooleanField(default=False, help_text="Set to True when shop is scheduled for deletion (e.g. from shopify/shop_redact).")
+    starting_stock = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        help_text="Initial stock quantity to send when creating remote products.",
+    )
 
     is_external_install = models.BooleanField(
         default=False,


### PR DESCRIPTION
## Summary
- add a starting_stock field on sales channels for initial remote inventory
- include the optional starting stock value during Amazon, Magento, Shopify, and WooCommerce product creates, ensuring Amazon sends it via attributes and Shopify only applies it on create
- expose the starting stock control in the relevant admin configurations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de4a7fff60832e9e49b96befc3a301

## Summary by Sourcery

Add starting_stock field to sales channels and propagate it during remote product creation across Amazon, Magento2, Shopify, and WooCommerce integrations.

New Features:
- Introduce starting_stock field on sales channels to configure initial remote inventory
- Expose starting_stock setting in Amazon, Magento2, and WooCommerce admin configurations

Enhancements:
- Include starting_stock on Amazon product create via fulfillment_availability attribute for non-configurable products
- Set Magento2 product stock to starting_stock on create for simple products
- Apply starting_stock to Shopify variant inventoryQuantity on product create
- Enable manage_stock and set stock_quantity from starting_stock in WooCommerce product create, and apply backorder setting