### PR TITLE
Only push starting stock for active products

### DIFF
--- a/OneSila/sales_channels/integrations/amazon/factories/mixins.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/mixins.py
@@ -376,6 +376,9 @@ class GetAmazonAPIMixin:
         local_instance = getattr(self, "local_instance", None)
         is_configurable = False
         if local_instance is not None:
+            if not getattr(local_instance, "active", True):
+                return None
+
             is_configurable_method = getattr(local_instance, "is_configurable", None)
             if callable(is_configurable_method):
                 is_configurable = bool(is_configurable_method())


### PR DESCRIPTION
## Summary
- prevent Amazon starting stock from being pushed when the local product is inactive

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff6275438832e936924fd7555161a

## Summary by Sourcery

Enhancements:
- Prevent pushing starting stock for products marked as inactive by returning early from fulfillment availability attribute builder