### PR TITLE
Add sales channel aware media assignments

### DIFF
--- a/OneSila/imports_exports/factories/products.py
+++ b/OneSila/imports_exports/factories/products.py
@@ -393,12 +393,16 @@ class ImportProductInstance(AbstractImportInstance, AddLogTimeentry):
 
         images_instances_ids = []
         images_instances_associations_ids = []
+        product_has_images = self.instance.mediaproductthrough_set.exists()
+
         for image in self.images:
 
             image_import_instance = ImportImageInstance(
                 image,
                 import_process=self.import_process,
-                product=self.instance
+                product=self.instance,
+                sales_channel=self.sales_channel,
+                create_default_assignment=not product_has_images if self.sales_channel is not None else False
             )
             image_import_instance.process()
 

--- a/OneSila/imports_exports/tests/tests_factories/tests_media.py
+++ b/OneSila/imports_exports/tests/tests_factories/tests_media.py
@@ -120,10 +120,10 @@ class ImportImageInstanceProcessTest(TestCase):
         instance.process()
 
         product = Product.objects.get(sku="IMG002")
-        through_exists = MediaProductThrough.objects.filter(
+        through_exists = MediaProductThrough.objects.get_product_images(
             product=product,
-            media=instance.instance
-        ).exists()
+            sales_channel=None,
+        ).filter(media=instance.instance).exists()
 
         self.assertTrue(through_exists)
 
@@ -136,10 +136,10 @@ class ImportImageInstanceProcessTest(TestCase):
         instance.multi_tenant_company = self.import_process.multi_tenant_company
         instance.process()
 
-        through_exists = MediaProductThrough.objects.filter(
+        through_exists = MediaProductThrough.objects.get_product_images(
             product=self.product,
-            media=instance.instance
-        ).exists()
+            sales_channel=None,
+        ).filter(media=instance.instance).exists()
 
         self.assertTrue(through_exists)
 

--- a/OneSila/imports_exports/tests/tests_factories/tests_products.py
+++ b/OneSila/imports_exports/tests/tests_factories/tests_products.py
@@ -420,7 +420,12 @@ class ImportProductInstanceProcessTest(TestCase):
         instance = ImportProductInstance(data, self.import_process)
         instance.process()
 
-        self.assertTrue(MediaProductThrough.objects.filter(product=instance.instance).exists())
+        self.assertTrue(
+            MediaProductThrough.objects.get_product_images(
+                product=instance.instance,
+                sales_channel=None,
+            ).exists()
+        )
 
     def test_create_product_with_prices(self):
         data = {
@@ -776,7 +781,12 @@ class ImportProductInstanceProcessTest(TestCase):
         instance.process()
 
         self.assertTrue(ProductTranslation.objects.filter(product=instance.instance).exists())
-        self.assertTrue(MediaProductThrough.objects.filter(product=instance.instance).exists())
+        self.assertTrue(
+            MediaProductThrough.objects.get_product_images(
+                product=instance.instance,
+                sales_channel=None,
+            ).exists()
+        )
         self.assertTrue(SalesPrice.objects.filter(product=instance.instance).count() >= 2)
         self.assertTrue(ConfigurableVariation.objects.filter(parent=instance.instance).exists())
         self.assertTrue(ProductPropertiesRuleItem.objects.filter(rule=instance.rule).count() >= 2)
@@ -893,7 +903,10 @@ class ImportProductInstanceCreateOnlyTest(TestCase):
         instance1.process()
         product = instance1.instance
         self.assertEqual(product.name, "Original Product")
-        initial_images = MediaProductThrough.objects.filter(product=product).count()
+        initial_images = MediaProductThrough.objects.get_product_images(
+            product=product,
+            sales_channel=None,
+        ).count()
 
         second_data = {
             "name": "Updated Product",
@@ -908,7 +921,10 @@ class ImportProductInstanceCreateOnlyTest(TestCase):
         product.refresh_from_db()
         self.assertEqual(product.name, "Original Product")
         self.assertEqual(
-            MediaProductThrough.objects.filter(product=product).count(),
+            MediaProductThrough.objects.get_product_images(
+                product=product,
+                sales_channel=None,
+            ).count(),
             initial_images,
         )
 
@@ -926,7 +942,10 @@ class ImportProductInstanceCreateOnlyTest(TestCase):
         instance1.process()
         product = instance1.instance
         self.assertEqual(product.name, "Original Product")
-        initial_images = MediaProductThrough.objects.filter(product=product).count()
+        initial_images = MediaProductThrough.objects.get_product_images(
+            product=product,
+            sales_channel=None,
+        ).count()
 
         second_data = {
             "name": "Updated Product",
@@ -946,7 +965,10 @@ class ImportProductInstanceCreateOnlyTest(TestCase):
         product.refresh_from_db()
         self.assertEqual(product.name, "Updated Product")
         self.assertEqual(
-            MediaProductThrough.objects.filter(product=product).count(),
+            MediaProductThrough.objects.get_product_images(
+                product=product,
+                sales_channel=None,
+            ).count(),
             initial_images + 1,
         )
 

--- a/OneSila/llm/factories/mixins.py
+++ b/OneSila/llm/factories/mixins.py
@@ -233,9 +233,15 @@ class ContentLLMMixin(AskGPTMixin, CalculateCostMixin, CreateTransactionMixin):
             self.images = []
             return
 
-        self.images = [i.media.image_web_url for i in MediaProductThrough.objects.filter(
-            media__type=Media.IMAGE,
-            product=self.product)]
+        images_queryset = MediaProductThrough.objects.get_product_images(
+            product=self.product,
+            sales_channel=None,
+        )
+
+        self.images = [
+            item.media.image_web_url
+            for item in images_queryset.filter(media__type=Media.IMAGE)
+        ]
 
     def _set_documents(self):
 
@@ -243,9 +249,15 @@ class ContentLLMMixin(AskGPTMixin, CalculateCostMixin, CreateTransactionMixin):
             self.documents = []
             return
 
-        self.documents = [i.media.file_url() for i in MediaProductThrough.objects.filter(
-            media__type=Media.FILE,
-            product=self.product)]
+        documents_queryset = MediaProductThrough.objects.get_product_images(
+            product=self.product,
+            sales_channel=None,
+        )
+
+        self.documents = [
+            item.media.file_url()
+            for item in documents_queryset.filter(media__type=Media.FILE)
+        ]
 
     def _set_is_configurable(self):
         self.is_configurable = self.product.is_configurable()

--- a/OneSila/media/managers.py
+++ b/OneSila/media/managers.py
@@ -10,6 +10,29 @@ class MediaQuerySet(MultiTenantQuerySet):
     pass
 
 
+class MediaProductThroughQuerySet(MultiTenantQuerySet):
+    def get_product_images(self, *, product, sales_channel=None):
+        base_queryset = self.filter(product=product)
+
+        if sales_channel is None:
+            return base_queryset.filter(sales_channel__isnull=True)
+
+        sales_channel_queryset = base_queryset.filter(sales_channel=sales_channel)
+
+        if sales_channel_queryset.exists():
+            return sales_channel_queryset
+
+        return base_queryset.filter(sales_channel__isnull=True)
+
+
+class MediaProductThroughManager(MultiTenantManager):
+    def get_queryset(self):
+        return MediaProductThroughQuerySet(self.model, using=self._db)
+
+    def get_product_images(self, *, product, sales_channel=None):
+        return self.get_queryset().get_product_images(product=product, sales_channel=sales_channel)
+
+
 class MediaManager(MultiTenantManager):
     def get_queryset(self):
         return MediaQuerySet(self.model, using=self._db)

--- a/OneSila/products/managers.py
+++ b/OneSila/products/managers.py
@@ -116,9 +116,10 @@ class ProductQuerySet(MultiTenantQuerySet):
                     product=new_product,
                     sort_order=img.sort_order,
                     is_main_image=img.is_main_image,
+                    sales_channel=img.sales_channel,
                     multi_tenant_company=multi_tenant_company,
                 )
-                for img in MediaProductThrough.objects.filter(product=product)
+                for img in product.mediaproductthrough_set.all()
             ])
 
             # Properties
@@ -306,6 +307,7 @@ class AliasProductQuerySet(QuerySetProxyModelMixin, ProductQuerySet):
                     product=alias_product,
                     sort_order=img.sort_order,
                     is_main_image=img.is_main_image,
+                    sales_channel=img.sales_channel,
                     multi_tenant_company=parent.multi_tenant_company
                 ) for img in parent_images
             ])

--- a/OneSila/products_inspector/factories/inspector_block.py
+++ b/OneSila/products_inspector/factories/inspector_block.py
@@ -167,7 +167,11 @@ class HasImagesInspectorBlockFactory(InspectorBlockFactory):
         super().__init__(block, success_signal=inspector_has_images_success, failure_signal=inspector_has_images_failed, save_inspector=save_inspector)
 
     def _check(self):
-        images_count = MediaProductThrough.objects.filter_multi_tenant(self.multi_tenant_company).filter(product=self.product).count()
+        images_count = (
+            MediaProductThrough.objects.filter_multi_tenant(self.multi_tenant_company)
+            .get_product_images(product=self.product, sales_channel=None)
+            .count()
+        )
 
         if self.product.is_configurable():
             if images_count == 0:

--- a/OneSila/sales_channels/factories/products/products.py
+++ b/OneSila/sales_channels/factories/products/products.py
@@ -641,10 +641,14 @@ class RemoteProductSyncFactory(IntegrationInstanceOperationMixin, EanCodeValueMi
         self.finalize_content_translations()
 
     def get_medias(self):
-        return MediaProductThrough.objects.filter(
-            product=self.local_instance,
-            media__type=Media.IMAGE
-        ).order_by('-is_main_image', 'sort_order')
+        return (
+            MediaProductThrough.objects.get_product_images(
+                product=self.local_instance,
+                sales_channel=self.sales_channel,
+            )
+            .filter(media__type=Media.IMAGE)
+            .order_by('-is_main_image', 'sort_order')
+        )
 
     def assign_images(self):
         """

--- a/OneSila/sales_channels/integrations/amazon/factories/products/images.py
+++ b/OneSila/sales_channels/integrations/amazon/factories/products/images.py
@@ -39,9 +39,11 @@ class AmazonMediaProductThroughBase(GetAmazonAPIMixin):
     def _get_images(self):
         product = self.remote_product.local_instance
         throughs = (
-            MediaProductThrough.objects.filter(
-                product=product, media__type=Media.IMAGE
+            MediaProductThrough.objects.get_product_images(
+                product=product,
+                sales_channel=self.sales_channel,
             )
+            .filter(media__type=Media.IMAGE)
             .order_by("sort_order")
         )
 

--- a/OneSila/sales_channels/integrations/shopify/factories/products/products.py
+++ b/OneSila/sales_channels/integrations/shopify/factories/products/products.py
@@ -329,10 +329,14 @@ class ShopifyProductSyncFactory(GetShopifyApiMixin, RemoteProductSyncFactory):
         return remote_property.id
 
     def get_medias(self):
-        return MediaProductThrough.objects.filter(
-            product=self.local_instance,
-            media__type__in=[Media.IMAGE, Media.VIDEO]
-        ).order_by('-is_main_image', 'sort_order')
+        return (
+            MediaProductThrough.objects.get_product_images(
+                product=self.local_instance,
+                sales_channel=self.sales_channel,
+            )
+            .filter(media__type__in=[Media.IMAGE, Media.VIDEO])
+            .order_by('-is_main_image', 'sort_order')
+        )
 
     def create_image_assignment(self, media_through):
         """

--- a/OneSila/sales_channels/integrations/woocommerce/tests/tests_factories/tests_media.py
+++ b/OneSila/sales_channels/integrations/woocommerce/tests/tests_factories/tests_media.py
@@ -22,7 +22,10 @@ class WooCommerceMediaProductThroughFactoryTestCase(CreateTestProductMixin, Crea
             name="Test Product",
             assign_to_sales_channel=True)
         image = self.create_and_attach_image(self.product, fname='yellow.png')
-        local_image_count = MediaProductThrough.objects.filter(product=self.product).count()
+        local_image_count = MediaProductThrough.objects.get_product_images(
+            product=self.product,
+            sales_channel=self.sales_channel,
+        ).count()
         logger.debug(f"Product has {local_image_count} images pre-woocommerce product create")
 
         remote_instance = WoocommerceProduct.objects.get(local_instance=self.product)
@@ -34,5 +37,8 @@ class WooCommerceMediaProductThroughFactoryTestCase(CreateTestProductMixin, Crea
 
         remote_product = self.api.get_product(remote_instance.remote_id)
         remote_image_count = len(remote_product['images'])
-        local_image_count = MediaProductThrough.objects.filter(product=self.product).count()
+        local_image_count = MediaProductThrough.objects.get_product_images(
+            product=self.product,
+            sales_channel=self.sales_channel,
+        ).count()
         self.assertEqual(remote_image_count, local_image_count)


### PR DESCRIPTION
## Summary
- add a `sales_channel` relation and channel-aware uniqueness to `MediaProductThrough`, exposing a helper for retrieving images with fallback to defaults
- update image import flows and remote sales channel factories to create per-channel media assignments while preserving default associations
- adjust downstream helpers and tests to rely on the new manager API when counting or fetching product imagery

## Testing
- python OneSila/manage.py test imports_exports.tests.tests_factories.tests_media.ImportImageInstanceProcessTest --settings OneSila.settings.agent *(interrupted due to long-running migration setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e32ba314832ea313e9515ff8fcc4