### PR TITLE
Limit media image sync to target sales channel

### DIFF
--- a/OneSila/sales_channels/integrations/magento2/receivers.py
+++ b/OneSila/sales_channels/integrations/magento2/receivers.py
@@ -267,6 +267,7 @@ def sales_channels__magento__media_product_through__create(sender, instance, **k
         task_func=create_magento_image_association_db_task,
         multi_tenant_company=instance.multi_tenant_company,
         product=instance.product,
+        sales_channels_filter_kwargs={'id': instance.sales_channel_id} if instance.sales_channel_id else None,
         **task_kwargs)
 
 
@@ -279,6 +280,7 @@ def sales_channels__magento__media_product_through__update(sender, instance, **k
         task_func=update_magento_image_association_db_task,
         multi_tenant_company=instance.multi_tenant_company,
         product=instance.product,
+        sales_channels_filter_kwargs={'id': instance.sales_channel_id} if instance.sales_channel_id else None,
         **task_kwargs)
 
 
@@ -292,7 +294,8 @@ def sales_channels__magento__media_product_through__delete(sender, instance, **k
         multi_tenant_company=instance.multi_tenant_company,
         remote_class=MagentoImageProductAssociation,
         local_instance_id=instance.id,
-        product=instance.product
+        product=instance.product,
+        sales_channels_filter_kwargs={'id': instance.sales_channel_id} if instance.sales_channel_id else None
     )
 
 

--- a/OneSila/sales_channels/integrations/shopify/receivers.py
+++ b/OneSila/sales_channels/integrations/shopify/receivers.py
@@ -306,6 +306,7 @@ def shopify__image_assoc__create(sender, instance, **kwargs):
         multi_tenant_company=instance.multi_tenant_company,
         product=instance.product,
         sales_channel_class=ShopifySalesChannel,
+        sales_channels_filter_kwargs={'id': instance.sales_channel_id} if instance.sales_channel_id else None,
         media_product_through_id=instance.id,
     )
 
@@ -317,6 +318,7 @@ def shopify__image_assoc__update(sender, instance, **kwargs):
         multi_tenant_company=instance.multi_tenant_company,
         product=instance.product,
         sales_channel_class=ShopifySalesChannel,
+        sales_channels_filter_kwargs={'id': instance.sales_channel_id} if instance.sales_channel_id else None,
         media_product_through_id=instance.id,
     )
 
@@ -330,6 +332,7 @@ def shopify__image_assoc__delete(sender, instance, **kwargs):
         local_instance_id=instance.id,
         product=instance.product,
         sales_channel_class=ShopifySalesChannel,
+        sales_channels_filter_kwargs={'id': instance.sales_channel_id} if instance.sales_channel_id else None,
     )
 
 

--- a/OneSila/sales_channels/integrations/woocommerce/receivers.py
+++ b/OneSila/sales_channels/integrations/woocommerce/receivers.py
@@ -275,6 +275,7 @@ def woocommerce__image_assoc__create(sender, instance, **kwargs):
         multi_tenant_company=instance.multi_tenant_company,
         product=instance.product,
         sales_channel_class=WoocommerceSalesChannel,
+        sales_channels_filter_kwargs={'id': instance.sales_channel_id} if instance.sales_channel_id else None,
         media_product_through_id=instance.id,
     )
 
@@ -286,6 +287,7 @@ def woocommerce__image_assoc__update(sender, instance, **kwargs):
         multi_tenant_company=instance.multi_tenant_company,
         product=instance.product,
         sales_channel_class=WoocommerceSalesChannel,
+        sales_channels_filter_kwargs={'id': instance.sales_channel_id} if instance.sales_channel_id else None,
         media_product_through_id=instance.id,
     )
 
@@ -299,6 +301,7 @@ def woocommerce__image_assoc__delete(sender, instance, **kwargs):
         local_instance_id=instance.id,
         product=instance.product,
         sales_channel_class=WoocommerceSalesChannel,
+        sales_channels_filter_kwargs={'id': instance.sales_channel_id} if instance.sales_channel_id else None,
     )
 
 


### PR DESCRIPTION
## Summary
- restrict Shopify, WooCommerce, and Magento MediaProductThrough image sync receivers to only target the associated sales channel when present
- ensure delete flows use the same scoped filtering to avoid unintended cross-channel updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e430a9e6d4832eb12491f94dd6249c

## Summary by Sourcery

Enhancements:
- Add sales_channels_filter_kwargs filter based on instance.sales_channel_id to create, update, and delete handlers for Magento, Shopify, and WooCommerce image associations