### PR TITLE
Add tests for media mirror reuse logic

### DIFF
--- a/OneSila/sales_channels/receivers.py
+++ b/OneSila/sales_channels/receivers.py
@@ -5,7 +5,7 @@ from core.schema.core.subscriptions import refresh_subscription_receiver
 from core.signals import post_create, post_update, mutation_update, post_save
 from eancodes.signals import ean_code_released_for_product
 from inventory.models import Inventory
-from media.models import Media
+from media.models import Media, MediaProductThrough
 from properties.signals import (
     product_properties_rule_configurator_updated,
     property_created,
@@ -562,8 +562,10 @@ def sales_channels__media_product_through__post_create_receiver(sender, instance
     Handles the creation of MediaProductThrough instances.
     Sends a create_remote_image_association signal if the media type is IMAGE.
     """
-    if instance.media.type == Media.IMAGE:
-        create_remote_image_association.send(sender=instance.__class__, instance=instance)
+    if instance.media.type != Media.IMAGE:
+        return
+
+    create_remote_image_association.send(sender=instance.__class__, instance=instance)
 
 
 @receiver(post_update, sender='media.MediaProductThrough')

--- a/OneSila/sales_channels/tests/tests_factories/test_media_product_through.py
+++ b/OneSila/sales_channels/tests/tests_factories/test_media_product_through.py
@@ -1,0 +1,168 @@
+from unittest.mock import Mock, patch
+
+from core.tests import TestCase
+from model_bakery import baker
+
+from media.models import Media, MediaProductThrough
+from products.models import Product
+from integrations.models import IntegrationObjectMixin
+from sales_channels.integrations.shopify.models.products import (
+    ShopifyImageProductAssociation,
+    ShopifyProduct,
+)
+from sales_channels.integrations.shopify.models.sales_channels import (
+    ShopifySalesChannel,
+    ShopifySalesChannelView,
+)
+from sales_channels.integrations.shopify.factories.products.images import (
+    ShopifyMediaProductThroughCreateFactory,
+)
+from sales_channels.models.products import RemoteImage
+from sales_channels.models.sales_channels import SalesChannelViewAssign
+
+
+def _integration_save_without_checks(self, *args, **kwargs):
+    return super(IntegrationObjectMixin, self).save(*args, **kwargs)
+
+
+class RemoteMediaProductThroughCreateFactoryTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sales_channel = baker.make(
+            ShopifySalesChannel,
+            multi_tenant_company=self.multi_tenant_company,
+            hostname="https://store.example.com",
+        )
+        self.product = baker.make(
+            "products.Product",
+            multi_tenant_company=self.multi_tenant_company,
+            type=Product.SIMPLE,
+        )
+        self.media = baker.make(
+            Media,
+            multi_tenant_company=self.multi_tenant_company,
+            type=Media.IMAGE,
+        )
+        self.default_assignment = MediaProductThrough.objects.create(
+            product=self.product,
+            media=self.media,
+            sort_order=5,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.remote_product = baker.make(
+            ShopifyProduct,
+            sales_channel=self.sales_channel,
+            local_instance=self.product,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        self.sales_channel_view = baker.make(
+            ShopifySalesChannelView,
+            sales_channel=self.sales_channel,
+            multi_tenant_company=self.multi_tenant_company,
+            url="https://store.example.com",
+        )
+        self.view_assign = SalesChannelViewAssign.objects.create(
+            product=self.product,
+            sales_channel_view=self.sales_channel_view,
+            sales_channel=self.sales_channel,
+            remote_product=self.remote_product,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+
+    def _make_channel_assignment(self, **kwargs):
+        defaults = {
+            "product": self.product,
+            "media": self.media,
+            "sales_channel": self.sales_channel,
+            "sort_order": 15,
+            "is_main_image": True,
+            "multi_tenant_company": self.multi_tenant_company,
+        }
+        defaults.update(kwargs)
+        return MediaProductThrough.objects.create(**defaults)
+
+    def test_reuses_existing_default_remote_assignment(self):
+        remote_image = baker.make(
+            RemoteImage,
+            sales_channel=self.sales_channel,
+            local_instance=self.media,
+            remote_id="gid://shopify/MediaImage/1",
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        existing_remote_assignment = baker.make(
+            ShopifyImageProductAssociation,
+            sales_channel=self.sales_channel,
+            local_instance=self.default_assignment,
+            remote_product=self.remote_product,
+            remote_image=remote_image,
+            remote_id="gid://shopify/ProductImage/1",
+            successfully_created=False,
+            current_position=3,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        channel_assignment = self._make_channel_assignment()
+        factory = ShopifyMediaProductThroughCreateFactory(
+            self.sales_channel,
+            channel_assignment,
+            remote_product=self.remote_product,
+            api=Mock(),
+        )
+
+        with patch(
+            "sales_channels.factories.products.images.remote_instance_post_create.send"
+        ) as mock_signal, patch.object(
+            IntegrationObjectMixin,
+            "save",
+            _integration_save_without_checks,
+        ):
+            factory.run()
+
+        mock_signal.assert_called_once()
+        remote_instance = ShopifyImageProductAssociation.objects.get(
+            local_instance=channel_assignment,
+            sales_channel=self.sales_channel,
+            remote_product=self.remote_product,
+        )
+        self.assertEqual(factory.remote_instance, remote_instance)
+        self.assertEqual(remote_instance.remote_id, existing_remote_assignment.remote_id)
+        self.assertEqual(remote_instance.remote_image, remote_image)
+        self.assertFalse(remote_instance.successfully_created)
+        self.assertEqual(remote_instance.current_position, channel_assignment.sort_order)
+
+    def test_returns_existing_remote_assignment_for_channel(self):
+        channel_assignment = self._make_channel_assignment(sort_order=22)
+        existing_remote_assignment = baker.make(
+            ShopifyImageProductAssociation,
+            sales_channel=self.sales_channel,
+            local_instance=channel_assignment,
+            remote_product=self.remote_product,
+            remote_id="gid://shopify/ProductImage/2",
+            current_position=9,
+            multi_tenant_company=self.multi_tenant_company,
+        )
+        factory = ShopifyMediaProductThroughCreateFactory(
+            self.sales_channel,
+            channel_assignment,
+            remote_product=self.remote_product,
+            api=Mock(),
+        )
+
+        with patch(
+            "sales_channels.factories.products.images.remote_instance_post_create.send"
+        ) as mock_signal, patch.object(
+            IntegrationObjectMixin,
+            "save",
+            _integration_save_without_checks,
+        ):
+            factory.run()
+
+        mock_signal.assert_not_called()
+        self.assertEqual(factory.remote_instance, existing_remote_assignment)
+        # No new remote assignments created
+        self.assertEqual(
+            ShopifyImageProductAssociation.objects.filter(
+                sales_channel=self.sales_channel,
+                remote_product=self.remote_product,
+            ).count(),
+            1,
+        )


### PR DESCRIPTION
## Summary
- add Shopify-focused factory tests that cover reusing default media assignments for sales channel mirrors
- verify existing channel-specific assignments are returned without creating duplicates

## Testing
- python - <<'PY' ... (custom Django runner invoking sales_channels.tests.tests_factories.test_media_product_through) PY

------
https://chatgpt.com/codex/tasks/task_e_68e53caad3e0832e83e0e94a3c899ed3

## Summary by Sourcery

Add reuse logic for existing remote image assignments in ShopifyMediaProductThroughCreateFactory, refactor media post-create receiver for non-image early return, and add tests for reuse behavior.

Enhancements:
- Implement detection and reuse of default and channel-specific remote image assignments in media product factories to avoid duplicate mirror associations
- Refactor media product post-create receiver to early-return for non-image media types

Tests:
- Add unit tests verifying that the factory reuses an existing default remote assignment and returns existing channel-specific assignments without creating duplicates